### PR TITLE
Declare ccd client as an API level dependency

### DIFF
--- a/ccd-config-generator/build.gradle
+++ b/ccd-config-generator/build.gradle
@@ -19,7 +19,7 @@ dependencies {
     compileOnly group: 'org.projectlombok', name: 'lombok', version: '1.18.24'
     implementation "org.springframework.boot:spring-boot-autoconfigure:${springBootVersion}"
     implementation "org.springframework.boot:spring-boot-starter-web:${springBootVersion}"
-    implementation(group: 'com.github.hmcts', name: 'core-case-data-store-client', version: '4.9.1') {
+    api(group: 'com.github.hmcts', name: 'core-case-data-store-client', version: '4.9.1') {
         // The config generator needs only the types defined in the CCD client library,
         // not all the runtime spring dependencies used by the CCD client.
         transitive = false

--- a/ccd-gradle-plugin/test-projects/java-library/src/main/java/uk/gov/hmcts/test/library/CCDConfig.java
+++ b/ccd-gradle-plugin/test-projects/java-library/src/main/java/uk/gov/hmcts/test/library/CCDConfig.java
@@ -1,12 +1,35 @@
 package uk.gov.hmcts.test.library;
 
+import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
 import uk.gov.hmcts.ccd.sdk.api.ConfigBuilder;
 import org.springframework.stereotype.Component;
+import uk.gov.hmcts.ccd.sdk.api.callback.AboutToStartOrSubmitResponse;
+
+import static uk.gov.hmcts.ccd.sdk.api.Permission.CRU;
 
 @Component
 public class CCDConfig implements uk.gov.hmcts.ccd.sdk.api.CCDConfig<CaseData, State, Role> {
   @Override
   public void configure(ConfigBuilder<CaseData, State, Role> builder) {
     builder.caseType("test", "test", "test");
+      builder
+            .event("submit-case")
+        .forAllStates()
+      .name("Submit case")
+      .description("Submit case")
+      .aboutToSubmitCallback(this::aboutToSubmit)
+      .submittedCallback(this::submitted)
+      .fields()
+      .mandatory(CaseData::getDocuments)
+      .done();
+
+  }
+
+  private uk.gov.hmcts.reform.ccd.client.model.SubmittedCallbackResponse submitted(CaseDetails<CaseData, State> caseDataStateCaseDetails, CaseDetails<CaseData, State> caseDataStateCaseDetails1) {
+    return null;
+  }
+
+  private AboutToStartOrSubmitResponse<CaseData, State> aboutToSubmit(CaseDetails<CaseData, State> caseDataStateCaseDetails, CaseDetails<CaseData, State> caseDataStateCaseDetails1) {
+    return null;
   }
 }

--- a/ccd-gradle-plugin/test-projects/java-library/src/main/java/uk/gov/hmcts/test/library/CaseData.java
+++ b/ccd-gradle-plugin/test-projects/java-library/src/main/java/uk/gov/hmcts/test/library/CaseData.java
@@ -1,4 +1,8 @@
 package uk.gov.hmcts.test.library;
 
 public class CaseData {
+  private String documents;
+  public String getDocuments() {
+    return documents;
+  }
 }


### PR DESCRIPTION
We use the ccd client types in our APIs so it must be an API level dependency so consumers can access those types.



