### PR TITLE
Ignore unknown "value" attribute from ccd for PreviousOrganisation type

### DIFF
--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/type/PreviousOrganisation.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/type/PreviousOrganisation.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.ccd.sdk.type;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -17,6 +18,7 @@ import uk.gov.hmcts.ccd.sdk.api.ComplexType;
 @Builder
 @Data
 @ComplexType(name = "PreviousOrganisation", generate = false)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class PreviousOrganisation {
 
   @JsonProperty("FromTimeStamp")


### PR DESCRIPTION
### Change description ###


Add ignore unknown props annotation to PreviousOrganisations to circumvent Jackson Deserialization issue when getting case data back from aac after notice of change
