### PR TITLE
[NFDIV-3945] Allow CaseRoleID list format to be passed in as a generic

### DIFF
--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/type/ChangeOrganisationRequest.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/type/ChangeOrganisationRequest.java
@@ -67,4 +67,3 @@ public class ChangeOrganisationRequest<R> {
     this.createdBy = createdBy;
   }
 }
-

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/type/ChangeOrganisationRequest.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/type/ChangeOrganisationRequest.java
@@ -41,6 +41,9 @@ public class ChangeOrganisationRequest<R> {
   @JsonProperty("ApprovalRejectionTimestamp")
   private LocalDateTime approvalRejectionTimestamp;
 
+  @JsonProperty("CreatedBy")
+  private String createdBy;
+
   @JsonCreator
   public ChangeOrganisationRequest(
       @JsonProperty("OrganisationToAdd") Organisation organisationToAdd,
@@ -50,7 +53,8 @@ public class ChangeOrganisationRequest<R> {
       @JsonProperty("NotesReason") String notesReason,
       @JsonProperty("ApprovalStatus") ChangeOrganisationApprovalStatus approvalStatus,
       @JsonProperty("RequestTimestamp") LocalDateTime requestTimestamp,
-      @JsonProperty("ApprovalRejectionTimestamp") LocalDateTime approvalRejectionTimestamp
+      @JsonProperty("ApprovalRejectionTimestamp") LocalDateTime approvalRejectionTimestamp,
+      @JsonProperty("CreatedBy") String createdBy
   ) {
     this.organisationToAdd = organisationToAdd;
     this.organisationToRemove = organisationToRemove;
@@ -60,5 +64,7 @@ public class ChangeOrganisationRequest<R> {
     this.approvalStatus = approvalStatus;
     this.requestTimestamp = requestTimestamp;
     this.approvalRejectionTimestamp = approvalRejectionTimestamp;
+    this.createdBy = createdBy;
   }
 }
+

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/type/ChangeOrganisationRequest.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/type/ChangeOrganisationRequest.java
@@ -15,7 +15,7 @@ import uk.gov.hmcts.ccd.sdk.api.ComplexType;
 @Data
 @ComplexType(name = "ChangeOrganisationRequest", generate = false)
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class ChangeOrganisationRequest {
+public class ChangeOrganisationRequest<R> {
 
   @JsonProperty("OrganisationToAdd")
   private Organisation organisationToAdd;
@@ -24,7 +24,7 @@ public class ChangeOrganisationRequest {
   private Organisation organisationToRemove;
 
   @JsonProperty("CaseRoleId")
-  private DynamicList caseRoleId;
+  private R caseRoleId;
 
   @JsonProperty("Reason")
   private String reason;
@@ -45,7 +45,7 @@ public class ChangeOrganisationRequest {
   public ChangeOrganisationRequest(
       @JsonProperty("OrganisationToAdd") Organisation organisationToAdd,
       @JsonProperty("OrganisationToRemove") Organisation organisationToRemove,
-      @JsonProperty("CaseRoleId") DynamicList caseRoleId,
+      @JsonProperty("CaseRoleId") R caseRoleId,
       @JsonProperty("Reason") String reason,
       @JsonProperty("NotesReason") String notesReason,
       @JsonProperty("ApprovalStatus") ChangeOrganisationApprovalStatus approvalStatus,

--- a/ccd-config-generator/src/test/java/uk/gov/hmcts/reform/fpl/model/CaseData.java
+++ b/ccd-config-generator/src/test/java/uk/gov/hmcts/reform/fpl/model/CaseData.java
@@ -367,7 +367,7 @@ public class CaseData {
   private final RetiredFields retiredFields;
 
   @CCD(access = {NoticeOfChangeAccess.class})
-  private final ChangeOrganisationRequest changeOrganisationRequest;
+  private final ChangeOrganisationRequest<DynamicList> changeOrganisationRequest;
 
   @CCD(
     label = "Scanned documents",


### PR DESCRIPTION
### Change description ###
Allow the CaseRoleID list format to be passed in as a generic. The DynamicList implementation we use in config generator is not suitable for all services, due to the use of UUID rather than String in DynamicListElement.


