### PR TITLE
[NFDIV-3945] Add CreatedBy field to ChangeOrganisationRequest

### DIFF
--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/type/ChangeOrganisationRequest.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/type/ChangeOrganisationRequest.java
@@ -42,6 +42,9 @@ public class ChangeOrganisationRequest<R extends HasRole> {
   @JsonProperty("ApprovalRejectionTimestamp")
   private LocalDateTime approvalRejectionTimestamp;
 
+  @JsonProperty("CreatedBy")
+  private String createdBy;
+
   @JsonCreator
   public ChangeOrganisationRequest(
       @JsonProperty("OrganisationToAdd") Organisation organisationToAdd,
@@ -51,7 +54,8 @@ public class ChangeOrganisationRequest<R extends HasRole> {
       @JsonProperty("NotesReason") String notesReason,
       @JsonProperty("ApprovalStatus") ChangeOrganisationApprovalStatus approvalStatus,
       @JsonProperty("RequestTimestamp") LocalDateTime requestTimestamp,
-      @JsonProperty("ApprovalRejectionTimestamp") LocalDateTime approvalRejectionTimestamp
+      @JsonProperty("ApprovalRejectionTimestamp") LocalDateTime approvalRejectionTimestamp,
+      @JsonProperty("CreatedBy") String createdBy
   ) {
     this.organisationToAdd = organisationToAdd;
     this.organisationToRemove = organisationToRemove;
@@ -61,5 +65,6 @@ public class ChangeOrganisationRequest<R extends HasRole> {
     this.approvalStatus = approvalStatus;
     this.requestTimestamp = requestTimestamp;
     this.approvalRejectionTimestamp = approvalRejectionTimestamp;
+    this.createdBy = createdBy;
   }
 }


### PR DESCRIPTION
### Change description ###
Adding a missing subfield to the definition (see [aac example of ChangeOrganisationRequest](https://github.com/hmcts/aac-manage-case-assignment/blob/9993c9a4712df5fa5523d189c31294b91b13e85c/src/main/java/uk/gov/hmcts/reform/managecase/domain/ChangeOrganisationRequest.java#L44)).


