### PR TITLE
[NFDIV-4461] Allow same search field to be used by different roles

### DIFF
--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/SearchFieldAndResultGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/SearchFieldAndResultGenerator.java
@@ -43,8 +43,9 @@ class SearchFieldAndResultGenerator<T, S, R extends HasRole> implements ConfigGe
         result.add(map);
       }
     }
+
     Path output = Paths.get(root.getPath(), fileName + ".json");
-    JsonUtils.mergeInto(output, result, new AddMissing(), "CaseFieldID");
+    JsonUtils.mergeInto(output, result, new AddMissing(), "CaseFieldID", "UserRole");
   }
 
   protected static Map<String, Object> buildField(String caseType, String fieldId, String label, int displayOrder,

--- a/ccd-config-generator/src/test/java/uk/gov/hmcts/reform/fpl/CCDConfig.java
+++ b/ccd-config-generator/src/test/java/uk/gov/hmcts/reform/fpl/CCDConfig.java
@@ -221,6 +221,7 @@ public class CCDConfig implements uk.gov.hmcts.ccd.sdk.api.CCDConfig<CaseData, S
         .field(CaseData::getCaseName, "Case name")
         .field(CaseData::getFamilyManCaseNumber, "FamilyMan case number")
         .field(CaseData::getHearingDetails, "Hearing Details", LOCAL_AUTHORITY)
+        .field(CaseData::getHearingDetails, "Hearing Details", HMCTS_ADMIN)
         .field("hearingPreferencesWelsh", "Is in Welsh")
         .caseReferenceField()
         .field(CaseData::getDateSubmitted, "Date submitted", "", "#DATETIMEDISPLAY(d  MMMM yyyy)")

--- a/ccd-config-generator/src/test/java/uk/gov/hmcts/reform/fpl/CCDConfig.java
+++ b/ccd-config-generator/src/test/java/uk/gov/hmcts/reform/fpl/CCDConfig.java
@@ -191,6 +191,7 @@ public class CCDConfig implements uk.gov.hmcts.ccd.sdk.api.CCDConfig<CaseData, S
         .field(CaseData::getCaseName, "Case name")
         .field(CaseData::getFamilyManCaseNumber, "FamilyMan case number")
         .field(CaseData::getDateOfIssue, "Date of Issue", HMCTS_ADMIN)
+        .field(CaseData::getDateOfIssue, "Date of Issue", LOCAL_AUTHORITY)
         .field("hearingPreferencesWelsh", "Is in Welsh")
         .caseReferenceField()
         .field("allocatedJudge", "Allocated Judge", "judgeTitle", "hearingPreferencesWelsh=\"no\"")

--- a/ccd-config-generator/src/test/resources/CARE_SUPERVISION_EPO/AuthorisationCaseField/caseworker-publiclaw-courtadmin.json
+++ b/ccd-config-generator/src/test/resources/CARE_SUPERVISION_EPO/AuthorisationCaseField/caseworker-publiclaw-courtadmin.json
@@ -32,6 +32,13 @@
     "CaseTypeID": "CARE_SUPERVISION_EPO",
     "UserRole": "caseworker-publiclaw-courtadmin",
     "LiveFrom": "01/01/2017",
+    "CaseFieldID": "hearingDetails"
+  },
+  {
+    "CRUD": "R",
+    "CaseTypeID": "CARE_SUPERVISION_EPO",
+    "UserRole": "caseworker-publiclaw-courtadmin",
+    "LiveFrom": "01/01/2017",
     "CaseFieldID": "orders"
   },
   {

--- a/ccd-config-generator/src/test/resources/CARE_SUPERVISION_EPO/AuthorisationCaseField/caseworker-publiclaw-solicitor.json
+++ b/ccd-config-generator/src/test/resources/CARE_SUPERVISION_EPO/AuthorisationCaseField/caseworker-publiclaw-solicitor.json
@@ -77,6 +77,13 @@
     "CaseFieldID": "allocatedJudgeLabel"
   },
   {
+    "CRUD" : "R",
+    "CaseTypeID" : "CARE_SUPERVISION_EPO",
+    "UserRole" : "caseworker-publiclaw-solicitor",
+    "LiveFrom" : "01/01/2017",
+    "CaseFieldID" : "dateOfIssue"
+  },
+  {
     "CRUD": "CR",
     "CaseTypeID": "CARE_SUPERVISION_EPO",
     "UserRole": "caseworker-publiclaw-solicitor",

--- a/ccd-config-generator/src/test/resources/CARE_SUPERVISION_EPO/SearchInputFields.json
+++ b/ccd-config-generator/src/test/resources/CARE_SUPERVISION_EPO/SearchInputFields.json
@@ -28,6 +28,13 @@
     "Label" : "Date of Issue"
   },
   {
+    "LiveFrom" : "01/01/2017",
+    "CaseTypeID" : "CARE_SUPERVISION_EPO",
+    "CaseFieldID" : "dateOfIssue",
+    "UserRole" : "caseworker-publiclaw-solicitor",
+    "Label" : "Date of Issue"
+  },
+  {
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "CARE_SUPERVISION_EPO",
     "CaseFieldID": "hearingPreferencesWelsh",

--- a/ccd-config-generator/src/test/resources/CARE_SUPERVISION_EPO/WorkBasketInputFields.json
+++ b/ccd-config-generator/src/test/resources/CARE_SUPERVISION_EPO/WorkBasketInputFields.json
@@ -21,6 +21,13 @@
     "Label" : "Hearing Details"
   },
   {
+    "LiveFrom" : "01/01/2017",
+    "CaseTypeID" : "CARE_SUPERVISION_EPO",
+    "CaseFieldID" : "hearingDetails",
+    "UserRole" : "caseworker-publiclaw-courtadmin",
+    "Label" : "Hearing Details"
+  },
+  {
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "CARE_SUPERVISION_EPO",
     "CaseFieldID": "familyManCaseNumber",


### PR DESCRIPTION
### Change description ###
https://tools.hmcts.net/jira/browse/NFDIV-2726

Search fields are merged based on CaseFieldID, meaning it's not possible to use the same search field for multiple roles (see example [CCD config in confluence](https://tools.hmcts.net/confluence/display/RCCD/Per-role+CaseTabs%2C+Workbasket+and+Search)). In this PR, we start merging search fields based on CaseFieldID and UserRole, meaning the same search field can be defined multiple times provided the role is unique.


