### PR TITLE
[ADOP-2567] Added TTL Type

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ subprojects {
     apply plugin: 'java'
     apply plugin: 'jacoco'
 
-    version System.getenv('RELEASE_VERSION')?.replace('refs/tags/', '') ?: 'DEV-SNAPSHOT'
+    version System.getenv('RELEASE_VERSION')?.replace('refs/tags/', '') ?: '5.5.13-alpha'
 
     compileJava   {
         sourceCompatibility = 17

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ subprojects {
     apply plugin: 'java'
     apply plugin: 'jacoco'
 
-    version System.getenv('RELEASE_VERSION')?.replace('refs/tags/', '') ?: '5.5.13-alpha'
+    version System.getenv('RELEASE_VERSION')?.replace('refs/tags/', '') ?: 'DEV-SNAPSHOT'
 
     compileJava   {
         sourceCompatibility = 17

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/type/FieldType.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/type/FieldType.java
@@ -26,5 +26,6 @@ public enum FieldType {
   FlagType,
   FlagDetail,
   ComponentLauncher,
-  SearchCriteria
+  SearchCriteria,
+  TTL
 }

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/type/TTL.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/type/TTL.java
@@ -1,0 +1,39 @@
+package uk.gov.hmcts.ccd.sdk.type;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.LocalDate;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import uk.gov.hmcts.ccd.sdk.api.ComplexType;
+
+@NoArgsConstructor
+@Builder
+@Data
+@ComplexType(name = "TTL")
+public class TTL {
+
+  @JsonProperty("SystemTTL")
+  @JsonFormat(pattern = "yyyy-MM-dd")
+  private LocalDate systemTTL;
+
+  @JsonProperty("Suspended")
+  private YesOrNo suspended;
+
+  @JsonProperty("OverrideTTL")
+  @JsonFormat(pattern = "yyyy-MM-dd")
+  private LocalDate overrideTTL;
+
+  @JsonCreator
+  public TTL(
+      @JsonProperty("SystemTTL") LocalDate systemTTL,
+      @JsonProperty("Suspended") YesOrNo suspended,
+      @JsonProperty("OverrideTTL") LocalDate overrideTTL
+  ) {
+    this.systemTTL = systemTTL;
+    this.suspended = suspended;
+    this.overrideTTL = overrideTTL;
+  }
+}

--- a/ccd-config-generator/src/test/java/uk/gov/hmcts/reform/fpl/model/CaseData.java
+++ b/ccd-config-generator/src/test/java/uk/gov/hmcts/reform/fpl/model/CaseData.java
@@ -18,6 +18,7 @@ import uk.gov.hmcts.ccd.sdk.type.DynamicMultiSelectList;
 import uk.gov.hmcts.ccd.sdk.type.ListValue;
 import uk.gov.hmcts.ccd.sdk.type.OrganisationPolicy;
 import uk.gov.hmcts.ccd.sdk.type.ScannedDocument;
+import uk.gov.hmcts.ccd.sdk.type.TTL;
 import uk.gov.hmcts.ccd.sdk.type.YesOrNo;
 import uk.gov.hmcts.reform.fpl.RetiredFields;
 import uk.gov.hmcts.reform.fpl.access.BulkScan;
@@ -409,4 +410,6 @@ public class CaseData {
           access = {NoticeOfChangeAccess.class}
   )
   private ChangeOrganisationRequest<CaseRoleID> changeOrganisationRequestField;
+
+  private TTL timeToLive;
 }

--- a/ccd-config-generator/src/test/java/uk/gov/hmcts/reform/fpl/model/CaseData.java
+++ b/ccd-config-generator/src/test/java/uk/gov/hmcts/reform/fpl/model/CaseData.java
@@ -15,6 +15,7 @@ import uk.gov.hmcts.ccd.sdk.api.CCD;
 import uk.gov.hmcts.ccd.sdk.type.ChangeOrganisationRequest;
 import uk.gov.hmcts.ccd.sdk.type.DynamicList;
 import uk.gov.hmcts.ccd.sdk.type.DynamicMultiSelectList;
+import uk.gov.hmcts.ccd.sdk.type.FieldType;
 import uk.gov.hmcts.ccd.sdk.type.ListValue;
 import uk.gov.hmcts.ccd.sdk.type.OrganisationPolicy;
 import uk.gov.hmcts.ccd.sdk.type.ScannedDocument;
@@ -411,5 +412,10 @@ public class CaseData {
   )
   private ChangeOrganisationRequest<CaseRoleID> changeOrganisationRequestField;
 
+  @JsonProperty("TTL")
+  @CCD(
+    typeOverride = TTL,
+    label = "Set up TTL"
+  )
   private TTL timeToLive;
 }

--- a/ccd-config-generator/src/test/resources/CARE_SUPERVISION_EPO/CaseField.json
+++ b/ccd-config-generator/src/test/resources/CARE_SUPERVISION_EPO/CaseField.json
@@ -971,8 +971,8 @@
   {
     "CaseTypeID" : "CARE_SUPERVISION_EPO",
     "FieldType" : "TTL",
-    "ID" : "timeToLive",
-    "Label" : " ",
+    "ID" : "TTL",
+    "Label" : "Set up TTL",
     "LiveFrom" : "01/01/2017"
   }
 ]

--- a/ccd-config-generator/src/test/resources/CARE_SUPERVISION_EPO/CaseField.json
+++ b/ccd-config-generator/src/test/resources/CARE_SUPERVISION_EPO/CaseField.json
@@ -967,5 +967,12 @@
     "ID" : "SearchCriteria",
     "Label" : " ",
     "LiveFrom" : "01/01/2017"
+  },
+  {
+    "CaseTypeID" : "CARE_SUPERVISION_EPO",
+    "FieldType" : "TTL",
+    "ID" : "timeToLive",
+    "Label" : " ",
+    "LiveFrom" : "01/01/2017"
   }
 ]


### PR DESCRIPTION
### Change description ###
This change adds the new [TTL](https://tools.hmcts.net/confluence/display/RCCD/CCD+Supported+Field+Types#CCDSupportedFieldTypes-ccdTypeTTL) Complex Type for Java for use in [Retain & Dispose](https://tools.hmcts.net/confluence/pages/viewpage.action?pageId=1525469246#TechnicalSetupGuide:Retain&DisposeOnboardingConfiguration-Stepb:DefineTTLIncrementforsignificantevents).

Default behaviour: Leave the sub-fields blank as this means the case won't be deleted by Retain & Dispose.

Added to FPL CaseData to test.


