### PR TITLE
[NFDIV-4775] Support configuration of Searchable

### DIFF
--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/api/CCD.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/api/CCD.java
@@ -45,4 +45,5 @@ public @interface CCD {
 
   boolean ignore() default false;
 
+  boolean searchable() default true;
 }

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/CaseFieldGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/CaseFieldGenerator.java
@@ -100,6 +100,9 @@ class CaseFieldGenerator<T, S, R extends HasRole> implements ConfigGenerator<T, 
         if (cf.showSummaryContent()) {
           fieldInfo.put("ShowSummaryContentOption", "Y");
         }
+        if (!cf.searchable()) {
+          fieldInfo.put("Searchable", "N");
+        }
         if (!Strings.isNullOrEmpty(cf.showCondition())) {
           fieldInfo.put("FieldShowCondition", cf.showCondition());
         }

--- a/ccd-config-generator/src/test/java/uk/gov/hmcts/reform/fpl/model/CaseData.java
+++ b/ccd-config-generator/src/test/java/uk/gov/hmcts/reform/fpl/model/CaseData.java
@@ -295,6 +295,7 @@ public class CaseData {
   private final Others others;
   private final DynamicList nextHearingDateList;
 
+  @CCD(searchable = true)
   private final List<Element<Representative>> representatives;
 
   // EPO Order
@@ -363,8 +364,10 @@ public class CaseData {
   }
 
   private final String caseNote;
+
   @CCD(searchable = false)
   private final List<Element<CaseNote>> caseNotes;
+
   private final OrganisationPolicy<UserRole> organisationPolicy;
 
   @JsonUnwrapped()

--- a/ccd-config-generator/src/test/java/uk/gov/hmcts/reform/fpl/model/CaseData.java
+++ b/ccd-config-generator/src/test/java/uk/gov/hmcts/reform/fpl/model/CaseData.java
@@ -363,6 +363,7 @@ public class CaseData {
   }
 
   private final String caseNote;
+  @CCD(searchable = false)
   private final List<Element<CaseNote>> caseNotes;
   private final OrganisationPolicy<UserRole> organisationPolicy;
 

--- a/ccd-config-generator/src/test/java/uk/gov/hmcts/reform/fpl/model/emergencyprotectionorder/EPOPhrase.java
+++ b/ccd-config-generator/src/test/java/uk/gov/hmcts/reform/fpl/model/emergencyprotectionorder/EPOPhrase.java
@@ -4,10 +4,13 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import uk.gov.hmcts.ccd.sdk.api.CCD;
 
 @Data
 @Builder
 @AllArgsConstructor(onConstructor_ = {@JsonCreator})
 public class EPOPhrase {
+
+    @CCD(searchable = false)
     private String includePhrase;
 }

--- a/ccd-config-generator/src/test/resources/CARE_SUPERVISION_EPO/CaseField.json
+++ b/ccd-config-generator/src/test/resources/CARE_SUPERVISION_EPO/CaseField.json
@@ -842,6 +842,7 @@
     "FieldTypeParameter": "CaseNote",
     "CaseTypeID": "CARE_SUPERVISION_EPO",
     "LiveFrom": "01/01/2017",
+    "Searchable": "N",
     "Label": " ",
     "SecurityClassification": "Public"
   },

--- a/ccd-config-generator/src/test/resources/CARE_SUPERVISION_EPO/ComplexTypes/EPOPhrase.json
+++ b/ccd-config-generator/src/test/resources/CARE_SUPERVISION_EPO/ComplexTypes/EPOPhrase.json
@@ -3,6 +3,7 @@
     "ID": "EPOPhrase",
     "FieldType": "Text",
     "LiveFrom": "01/01/2017",
+    "Searchable": "N",
     "SecurityClassification": "Public",
     "ListElementCode": "includePhrase"
   }


### PR DESCRIPTION
### Change description ###
CCD allows configuration of a Searchable column to specify whether a case field will be indexed by Elastic Search:
https://tools.hmcts.net/confluence/pages/viewpage.action?spaceKey=RCCD&title=Configuring+Searchable+column

Case fields are searchable (indexed) by default. This PR adds support for configuration of searchable in the CCD annotation of a case field. Where searchable has been specified as false in the annotation, "Searchable": "N" will be set in the CCD config to indicate the field should not be indexed.

### Jira Ticket ###
https://tools.hmcts.net/jira/browse/NFDIV-4775