### PR TITLE
Remove unused tab order property

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,8 +303,13 @@ Tabs follow a similar API to events:
 
 Adding in multiple user roles will create multiple versions of the tab visible to each user role. If a user has both roles they will see the tab twice.
 
-The tab ID `"CaseHistory"` can be used to identify and configure the special History tab. If an app does not specify a tab with this ID
-then a default History tab will be automatically configured as the first tab.
+The tab ID `"CaseHistory"` can be used to identify and configure the special History tab and its order. If an app does
+not specify a tab with this ID then a default History tab will be automatically configured as the first tab.
+
+```java
+  builder.tab("CaseHistory", "History")
+    .field("caseHistory");
+```
 
 ## Permissions
 

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ There are five methods on the `ConfigBuilder` that allow the configuration of wo
     .caseReferenceField();
 ```
 
-There are some convience methods for `caseReferenceField`, `stateField`, `createdDateField` and `lastModifiedDate`.
+There are some convenience methods for `caseReferenceField`, `stateField`, `createdDateField` and `lastModifiedDate`.
 
 On the work basket and search results fields a sort order can be specified using the `SortOrder` class:
 
@@ -302,6 +302,9 @@ Tabs follow a similar API to events:
 ```
 
 Adding in multiple user roles will create multiple versions of the tab visible to each user role. If a user has both roles they will see the tab twice.
+
+The tab ID `"CaseHistory"` can be used to identify and configure the special History tab. If an app does not specify a tab with this ID
+then a default History tab will be automatically configured as the first tab.
 
 ## Permissions
 

--- a/README.md
+++ b/README.md
@@ -303,13 +303,15 @@ Tabs follow a similar API to events:
 
 Adding in multiple user roles will create multiple versions of the tab visible to each user role. If a user has both roles they will see the tab twice.
 
-The tab ID `"CaseHistory"` can be used to identify and configure the special History tab and its order. If an app does
-not specify a tab with this ID then a default History tab will be automatically configured as the first tab.
+The tab ID `"CaseHistory"` can be used to configure the special History tab and its order. Use the field
+ID `"caseHistory"` for the history field itself:
 
 ```java
   builder.tab("CaseHistory", "History")
     .field("caseHistory");
 ```
+
+If an app does not specify a tab with that ID then a default History tab will be automatically configured as the first tab.
 
 ## Permissions
 

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/api/Tab.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/api/Tab.java
@@ -18,7 +18,6 @@ public class Tab<T, R extends HasRole> {
   private String tabID;
   private String labelText;
   private String showCondition;
-  private int displayOrder;
   private List<TabField> fields;
   private Set<R> forRoles;
 


### PR DESCRIPTION
### Change description ###

Remove the unused tab order property because the tabs are arranged in the order that they are configured in the config builder.

Also adding a note to the README about the special history tab ID



