### PR TITLE
Fix missing event page labels (#554)

### DIFF
--- a/ccd-config-generator/build.gradle
+++ b/ccd-config-generator/build.gradle
@@ -31,7 +31,6 @@ dependencies {
     testImplementation 'org.skyscreamer:jsonassert:1.5.3'
     testImplementation 'com.google.guava:guava:33.4.8-jre'
     testImplementation group: 'org.hamcrest', name: 'hamcrest-all', version: '1.3'
-    testImplementation group: 'commons-lang', name: 'commons-lang', version: '2.6'
     testImplementation group: 'commons-io', name: 'commons-io', version: '2.19.0'
     testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.27.3'
     testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: springBootVersion

--- a/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/CaseEventToFieldsGenerator.java
+++ b/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/CaseEventToFieldsGenerator.java
@@ -82,7 +82,7 @@ class CaseEventToFieldsGenerator<T, S, R extends HasRole> implements ConfigGener
           }
 
           if (collection.getPageLabels().containsKey(field.getPage())) {
-            info.put("PageLabel", collection.getPageLabels().remove(field.getPage()));
+            info.put("PageLabel", collection.getPageLabels().get(field.getPage()));
           }
 
           if (null != field.getDisplayContextParameter()) {

--- a/ccd-config-generator/src/test/java/uk/gov/hmcts/ccd/sdk/E2EConfigGenerationTests.java
+++ b/ccd-config-generator/src/test/java/uk/gov/hmcts/ccd/sdk/E2EConfigGenerationTests.java
@@ -26,7 +26,7 @@ import java.util.stream.Collectors;
 import lombok.SneakyThrows;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.filefilter.TrueFileFilter;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;

--- a/ccd-config-generator/src/test/resources/CARE_SUPERVISION_EPO/CaseEventToFields/attachScannedDocs.json
+++ b/ccd-config-generator/src/test/resources/CARE_SUPERVISION_EPO/CaseEventToFields/attachScannedDocs.json
@@ -9,6 +9,7 @@
     "PageDisplayOrder": 1,
     "PageFieldDisplayOrder": 1,
     "PageID": "attachScannedDocs",
+    "PageLabel" : "Correspondence",
     "ShowSummaryChangeOption": "Y"
   },
   {
@@ -21,6 +22,7 @@
     "PageDisplayOrder": 1,
     "PageFieldDisplayOrder": 2,
     "PageID": "attachScannedDocs",
+    "PageLabel" : "Correspondence",
     "ShowSummaryChangeOption": "Y"
   },
   {
@@ -36,6 +38,7 @@
     "PageDisplayOrder": 1,
     "PageFieldDisplayOrder": 3,
     "PageID": "attachScannedDocs",
+    "PageLabel" : "Correspondence",
     "ShowSummaryChangeOption": "Y"
   },
   {
@@ -49,6 +52,7 @@
     "PageDisplayOrder": 1,
     "PageFieldDisplayOrder": 4,
     "PageID": "attachScannedDocs",
+    "PageLabel" : "Correspondence",
     "ShowSummaryChangeOption": "Y"
   }
 ]

--- a/ccd-config-generator/src/test/resources/CARE_SUPERVISION_EPO/CaseEventToFields/handleEvidence.json
+++ b/ccd-config-generator/src/test/resources/CARE_SUPERVISION_EPO/CaseEventToFields/handleEvidence.json
@@ -9,6 +9,7 @@
     "PageDisplayOrder" : 1,
     "PageFieldDisplayOrder" : 1,
     "PageID" : "handleEvidence",
+    "PageLabel" : "Correspondence",
     "ShowSummaryChangeOption" : "Y"
   }
 ]


### PR DESCRIPTION
### Change description ###

Assign the page label to all fields in an event page because the fields are sorted when written to the JSON but CCD uses the page label in the _first_ field of the serialised case definition, (not necessarily the order of the fields in the Java config).

This also means that if the config is generated a second time, (as done by the e2e tests), then the page labels will still be present.

This PR also removes commons-lang which has an unresolved CVE and switches the single use of it, (in the e2e tests), to use commons-lang3

See #554 for more details of the issue.