### PR TITLE
HDPI-1429: Provide case state when fetching case data from decentralised service

### DIFF
--- a/data-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/CaseRepository.java
+++ b/data-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/CaseRepository.java
@@ -1,5 +1,5 @@
 package uk.gov.hmcts.ccd.sdk;
 
 public interface CaseRepository<CaseType> {
-  CaseType getCase(long caseRef, CaseType data);
+  CaseType getCase(long caseRef, String state, CaseType data);
 }

--- a/data-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/DecentralisedCaseRepository.java
+++ b/data-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/DecentralisedCaseRepository.java
@@ -2,10 +2,10 @@ package uk.gov.hmcts.ccd.sdk;
 
 
 public abstract class DecentralisedCaseRepository<CaseType> implements CaseRepository<CaseType> {
-  public final CaseType getCase(long caseRef, CaseType data) {
-    return getCase(caseRef);
+  public final CaseType getCase(long caseRef, String state, CaseType data) {
+    return getCase(caseRef, state);
   }
 
-  public abstract CaseType getCase(long caseRef);
+  public abstract CaseType getCase(long caseRef, String state);
 }
 


### PR DESCRIPTION
### Change description ###

Provide case state when fetching case data from decentralised service so that the service can optimise or control the case data that is returned. For example, some rendered Markdown content may be different/absent based on the state.

A specific use case for PCS is in checking for un-submitted case data in a separate "draft" table. There is no need to do that once the case has reached a certain state.

Also removing an unused `ObjectMapper` reference


