### PR TITLE
Add reusable Service Bus support and e2e coverage

### DIFF
--- a/sdk/ccd-gradle-plugin/build.gradle
+++ b/sdk/ccd-gradle-plugin/build.gradle
@@ -72,7 +72,8 @@ task functionalTest(type: Test) {
 
 functionalTest.dependsOn(
     project(':ccd-config-generator').tasks.named('publishToMavenLocal'),
-    project(':decentralised-runtime').tasks.named('publishToMavenLocal')
+    project(':decentralised-runtime').tasks.named('publishToMavenLocal'),
+    project(':ccd-servicebus-support').tasks.named('publishToMavenLocal')
 )
 
 functionalTest.inputs.dir file('test-projects')

--- a/sdk/ccd-gradle-plugin/src/main/groovy/uk/gov/hmcts/ccd/sdk/CcdSdkPlugin.java
+++ b/sdk/ccd-gradle-plugin/src/main/groovy/uk/gov/hmcts/ccd/sdk/CcdSdkPlugin.java
@@ -83,6 +83,11 @@ public class CcdSdkPlugin implements Plugin<Project> {
           }
         });
       }
+
+      if (config.caseEventServiceBus) {
+        project.getDependencies().add("implementation", "com.github.hmcts:ccd-servicebus-support:"
+            + getVersion());
+      }
     });
   }
 
@@ -98,6 +103,7 @@ public class CcdSdkPlugin implements Plugin<Project> {
     private String rootPackage = "uk.gov.hmcts";
     private String caseType = "";
     private boolean decentralised = false;
+    private boolean caseEventServiceBus = false;
 
     public CCDConfig() {
     }

--- a/sdk/ccd-servicebus-support/build.gradle
+++ b/sdk/ccd-servicebus-support/build.gradle
@@ -1,0 +1,21 @@
+plugins {
+    id 'io.spring.dependency-management' version '1.1.7'
+}
+
+dependencyManagement {
+    imports {
+        mavenBom 'org.springframework.boot:spring-boot-dependencies:3.4.3'
+    }
+}
+
+dependencies {
+    api 'org.springframework:spring-jms'
+    api 'org.springframework:spring-jdbc'
+    api 'org.springframework:spring-context'
+    api 'org.springframework:spring-web'
+
+    compileOnly 'org.springframework.boot:spring-boot-autoconfigure'
+
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
+    implementation 'org.apache.qpid:qpid-jms-client:2.5.0'
+}

--- a/sdk/ccd-servicebus-support/src/main/java/uk/gov/hmcts/ccd/sdk/servicebus/CcdCaseEventPublisher.java
+++ b/sdk/ccd-servicebus-support/src/main/java/uk/gov/hmcts/ccd/sdk/servicebus/CcdCaseEventPublisher.java
@@ -1,0 +1,129 @@
+package uk.gov.hmcts.ccd.sdk.servicebus;
+
+import static uk.gov.hmcts.ccd.sdk.servicebus.CcdMessageQueueRepository.MessageQueueCandidate;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import jakarta.jms.JMSException;
+import jakarta.jms.Message;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.jms.core.JmsTemplate;
+import org.springframework.jms.core.MessagePostProcessor;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@ConditionalOnProperty(name = "spring.jms.servicebus.enabled", havingValue = "true")
+public class CcdCaseEventPublisher {
+
+  private final CcdMessageQueueRepository repository;
+  private final JmsTemplate jmsTemplate;
+  private final String destination;
+  private final CcdServiceBusProperties properties;
+
+  public CcdCaseEventPublisher(CcdMessageQueueRepository repository,
+                               JmsTemplate jmsTemplate,
+                               @Value("${azure.servicebus.ccd-case-events.topic-name:}") String azureDestination,
+                               CcdServiceBusProperties properties) {
+    this.repository = repository;
+    this.jmsTemplate = jmsTemplate;
+    this.properties = properties;
+    this.destination = Optional.ofNullable(properties.getDestination())
+        .filter(value -> !value.isBlank())
+        .orElse(azureDestination);
+  }
+
+  public void publishPendingCaseEvents() {
+    if (destination == null || destination.isBlank()) {
+      log.debug("No Service Bus destination configured; skipping publish");
+      return;
+    }
+
+    int totalPublished = 0;
+
+    while (true) {
+      List<MessageQueueCandidate> candidates =
+          repository.findUnpublishedMessages(properties.getMessageType(), properties.getBatchSize());
+      if (candidates.isEmpty()) {
+        break;
+      }
+
+      List<Long> publishedIds = new ArrayList<>(candidates.size());
+      for (MessageQueueCandidate candidate : candidates) {
+        if (sendToServiceBus(candidate)) {
+          publishedIds.add(candidate.id());
+        }
+      }
+
+      if (!publishedIds.isEmpty()) {
+        repository.markPublished(publishedIds, LocalDateTime.now());
+        totalPublished += publishedIds.size();
+      }
+
+      if (candidates.size() < properties.getBatchSize()) {
+        break;
+      }
+    }
+
+    if (properties.getPublishedRetentionDays() > 0) {
+      LocalDateTime cutoff = LocalDateTime.now().minusDays(properties.getPublishedRetentionDays());
+      int removed = repository.deletePublishedBefore(properties.getMessageType(), cutoff);
+      if (removed > 0) {
+        log.debug("Removed {} published message_queue_candidates records older than {}", removed, cutoff);
+      }
+    }
+
+    if (totalPublished > 0) {
+      log.info("Published {} CCD case event message(s) to {}", totalPublished, destination);
+    } else {
+      log.debug("No CCD case event messages published in this run");
+    }
+  }
+
+  private boolean sendToServiceBus(MessageQueueCandidate candidate) {
+    try {
+      jmsTemplate.convertAndSend(destination, candidate.payload(), applyProperties(candidate.payload()));
+      return true;
+    } catch (Exception ex) {
+      log.error("Failed to publish message_queue_candidates id {} reference {}", candidate.id(),
+          candidate.reference(), ex);
+      return false;
+    }
+  }
+
+  private MessagePostProcessor applyProperties(JsonNode payload) {
+    return message -> {
+      for (MessageProperty property : MessageProperty.values()) {
+        applyProperty(message, payload, property);
+      }
+      return message;
+    };
+  }
+
+  private void applyProperty(Message message, JsonNode payload, MessageProperty property) throws JMSException {
+    if (payload.hasNonNull(property.jsonKey)) {
+      message.setStringProperty(property.jmsKey, payload.get(property.jsonKey).asText());
+    }
+  }
+
+  private enum MessageProperty {
+    JURISDICTION("JurisdictionId", "jurisdiction_id"),
+    CASE_TYPE("CaseTypeId", "case_type_id"),
+    CASE_ID("CaseId", "case_id"),
+    SESSION("CaseId", "JMSXGroupID"),
+    EVENT("EventId", "event_id");
+
+    private final String jsonKey;
+    private final String jmsKey;
+
+    MessageProperty(String jsonKey, String jmsKey) {
+      this.jsonKey = jsonKey;
+      this.jmsKey = jmsKey;
+    }
+  }
+}

--- a/sdk/ccd-servicebus-support/src/main/java/uk/gov/hmcts/ccd/sdk/servicebus/CcdCaseEventScheduler.java
+++ b/sdk/ccd-servicebus-support/src/main/java/uk/gov/hmcts/ccd/sdk/servicebus/CcdCaseEventScheduler.java
@@ -1,0 +1,25 @@
+package uk.gov.hmcts.ccd.sdk.servicebus;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@ConditionalOnProperty(
+    name = {"spring.jms.servicebus.enabled", "ccd.servicebus.scheduler-enabled"},
+    havingValue = "true"
+)
+@RequiredArgsConstructor
+public class CcdCaseEventScheduler {
+
+  private final CcdCaseEventPublisher ccdCaseEventPublisher;
+
+  @Scheduled(cron = "${ccd.servicebus.schedule:*/30 * * * * *}")
+  public void publishPendingMessages() {
+    log.debug("Scheduled CCD case event publishing task invoked");
+    ccdCaseEventPublisher.publishPendingCaseEvents();
+  }
+}

--- a/sdk/ccd-servicebus-support/src/main/java/uk/gov/hmcts/ccd/sdk/servicebus/CcdMessageConverter.java
+++ b/sdk/ccd-servicebus-support/src/main/java/uk/gov/hmcts/ccd/sdk/servicebus/CcdMessageConverter.java
@@ -1,0 +1,30 @@
+package uk.gov.hmcts.ccd.sdk.servicebus;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+import com.fasterxml.jackson.databind.ObjectWriter;
+import jakarta.jms.BytesMessage;
+import jakarta.jms.JMSException;
+import jakarta.jms.Session;
+import java.io.IOException;
+import org.apache.qpid.jms.message.JmsBytesMessage;
+import org.apache.qpid.jms.provider.amqp.message.AmqpJmsMessageFacade;
+import org.apache.qpid.proton.amqp.Symbol;
+import org.springframework.jms.support.converter.MappingJackson2MessageConverter;
+
+/**
+ * JMS MessageConverter that supports publishing JSON content types in Azure Service Bus.
+ */
+public class CcdMessageConverter extends MappingJackson2MessageConverter {
+
+  @Override
+  protected BytesMessage mapToBytesMessage(Object object, Session session, ObjectWriter objectWriter)
+      throws JMSException, IOException {
+    BytesMessage message = super.mapToBytesMessage(object, session, objectWriter);
+    if (message instanceof JmsBytesMessage qpidMessage) {
+      AmqpJmsMessageFacade facade = (AmqpJmsMessageFacade) qpidMessage.getFacade();
+      facade.setContentType(Symbol.valueOf(APPLICATION_JSON_VALUE));
+    }
+    return message;
+  }
+}

--- a/sdk/ccd-servicebus-support/src/main/java/uk/gov/hmcts/ccd/sdk/servicebus/CcdMessageQueueRepository.java
+++ b/sdk/ccd-servicebus-support/src/main/java/uk/gov/hmcts/ccd/sdk/servicebus/CcdMessageQueueRepository.java
@@ -1,0 +1,98 @@
+package uk.gov.hmcts.ccd.sdk.servicebus;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataRetrievalFailureException;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class CcdMessageQueueRepository {
+
+  private static final String SELECT_UNPUBLISHED = """
+      SELECT id, reference, message_type, time_stamp, message_information
+        FROM ccd.message_queue_candidates
+       WHERE published IS NULL
+         AND message_type = ?
+       ORDER BY time_stamp
+       LIMIT ?
+      """;
+
+  private static final String UPDATE_PUBLISHED = """
+      UPDATE ccd.message_queue_candidates
+         SET published = ?
+       WHERE id = ?
+      """;
+
+  private static final String DELETE_PUBLISHED = """
+      DELETE FROM ccd.message_queue_candidates
+       WHERE message_type = ?
+         AND published < ?
+      """;
+
+  private final JdbcTemplate jdbcTemplate;
+  private final ObjectMapper objectMapper;
+
+  public List<MessageQueueCandidate> findUnpublishedMessages(String messageType, int limit) {
+    return jdbcTemplate.query(SELECT_UNPUBLISHED, rowMapper(), messageType, limit);
+  }
+
+  public void markPublished(List<Long> ids, LocalDateTime publishedAt) {
+    if (ids == null || ids.isEmpty()) {
+      return;
+    }
+
+    jdbcTemplate.batchUpdate(UPDATE_PUBLISHED, new BatchPreparedStatementSetter() {
+      @Override
+      public void setValues(PreparedStatement ps, int i) throws SQLException {
+        ps.setObject(1, publishedAt);
+        ps.setLong(2, ids.get(i));
+      }
+
+      @Override
+      public int getBatchSize() {
+        return ids.size();
+      }
+    });
+  }
+
+  public int deletePublishedBefore(String messageType, LocalDateTime cutoff) {
+    return jdbcTemplate.update(DELETE_PUBLISHED, messageType, cutoff);
+  }
+
+  private RowMapper<MessageQueueCandidate> rowMapper() {
+    return (ResultSet rs, int rowNum) -> new MessageQueueCandidate(
+        rs.getLong("id"),
+        rs.getLong("reference"),
+        rs.getString("message_type"),
+        rs.getTimestamp("time_stamp").toLocalDateTime(),
+        toJsonNode(rs.getString("message_information"))
+    );
+  }
+
+  private JsonNode toJsonNode(String rawJson) {
+    try {
+      return objectMapper.readTree(rawJson);
+    } catch (JsonProcessingException e) {
+      throw new DataRetrievalFailureException("Unable to parse message_information JSON", e);
+    }
+  }
+
+  public record MessageQueueCandidate(
+      long id,
+      long reference,
+      String messageType,
+      LocalDateTime timestamp,
+      JsonNode payload
+  ) { }
+}

--- a/sdk/ccd-servicebus-support/src/main/java/uk/gov/hmcts/ccd/sdk/servicebus/CcdServiceBusJmsConfiguration.java
+++ b/sdk/ccd-servicebus-support/src/main/java/uk/gov/hmcts/ccd/sdk/servicebus/CcdServiceBusJmsConfiguration.java
@@ -1,0 +1,44 @@
+package uk.gov.hmcts.ccd.sdk.servicebus;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.jms.ConnectionFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.jms.connection.CachingConnectionFactory;
+import org.springframework.jms.core.JmsTemplate;
+import org.springframework.jms.support.converter.MappingJackson2MessageConverter;
+import org.springframework.jms.support.converter.MessageConverter;
+import org.springframework.jms.support.converter.MessageType;
+
+@Configuration
+@EnableConfigurationProperties(CcdServiceBusProperties.class)
+@ConditionalOnProperty(name = "spring.jms.servicebus.enabled", havingValue = "true")
+public class CcdServiceBusJmsConfiguration {
+
+  @Bean
+  @Primary
+  public JmsTemplate jmsTemplate(ConnectionFactory jmsConnectionFactory, MessageConverter messageConverter) {
+    JmsTemplate jmsTemplate = new JmsTemplate();
+    jmsTemplate.setMessageConverter(messageConverter);
+    CachingConnectionFactory cachingConnectionFactory = new CachingConnectionFactory(jmsConnectionFactory);
+    cachingConnectionFactory.setCacheProducers(false);
+    jmsTemplate.setConnectionFactory(cachingConnectionFactory);
+    return jmsTemplate;
+  }
+
+  @Bean
+  public MessageConverter ccdServiceBusMessageConverter(ObjectMapper objectMapper) {
+    MappingJackson2MessageConverter converter = new CcdMessageConverter();
+    ObjectMapper mapper = objectMapper.copy();
+    mapper.enable(JsonParser.Feature.STRICT_DUPLICATE_DETECTION);
+    converter.setObjectMapper(mapper);
+    converter.setTargetType(MessageType.BYTES);
+    converter.setTypeIdPropertyName("_type");
+    return converter;
+  }
+
+}

--- a/sdk/ccd-servicebus-support/src/main/java/uk/gov/hmcts/ccd/sdk/servicebus/CcdServiceBusProperties.java
+++ b/sdk/ccd-servicebus-support/src/main/java/uk/gov/hmcts/ccd/sdk/servicebus/CcdServiceBusProperties.java
@@ -1,0 +1,27 @@
+package uk.gov.hmcts.ccd.sdk.servicebus;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@ConfigurationProperties(prefix = "ccd.servicebus")
+public class CcdServiceBusProperties {
+
+  @Setter
+  private boolean schedulerEnabled = false;
+
+  private final String messageType = "CASE_EVENT";
+
+  @Setter
+  private int batchSize = 1000;
+
+  @Setter
+  private int publishedRetentionDays = 90;
+
+  @Setter
+  private String schedule = "*/30 * * * * *";
+
+  @Setter
+  private String destination;
+}

--- a/sdk/settings.gradle
+++ b/sdk/settings.gradle
@@ -1,1 +1,1 @@
-include 'ccd-gradle-plugin', 'ccd-config-generator', 'decentralised-runtime'
+include 'ccd-gradle-plugin', 'ccd-config-generator', 'decentralised-runtime', 'ccd-servicebus-support'

--- a/test-projects/e2e/build.gradle
+++ b/test-projects/e2e/build.gradle
@@ -14,6 +14,7 @@ version = '0.0.1'
 ccd {
   configDir = file('build/definitions')
   decentralised = true
+  caseEventServiceBus = true
 }
 
 java {
@@ -96,6 +97,7 @@ dependencies {
   testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
 
   cftlibTestImplementation "org.junit.platform:junit-platform-console-standalone:${versions.junitPlatform}"
+  cftlibTestImplementation 'jakarta.jms:jakarta.jms-api:3.1.0'
 }
 
 springBoot {


### PR DESCRIPTION
## Summary
- add shared CCD Service Bus support library and plugin wiring flag
- adopt the library in sptribs and e2e sample projects
- add cftlib test using mocked JmsTemplate to verify publishing flow

## Testing
- ./gradlew :sdk:ccd-servicebus-support:check
- ./gradlew :sptribs:check
- ./gradlew :e2e:cftlibTest