### PR TITLE
Exclude Azure Service Bus auto-config from cftlib test

### DIFF
--- a/test-projects/e2e/src/cftlibTest/java/uk/gov/hmcts/divorce/cftlib/TestWithCCD.java
+++ b/test-projects/e2e/src/cftlibTest/java/uk/gov/hmcts/divorce/cftlib/TestWithCCD.java
@@ -93,7 +93,8 @@ import uk.gov.hmcts.rse.ccd.lib.test.CftlibTest;
     "spring.jms.servicebus.enabled=true",
     "ccd.servicebus.destination=ccd-case-events-test",
     "ccd.servicebus.scheduler-enabled=true",
-    "ccd.servicebus.schedule=*/1 * * * * *"
+    "ccd.servicebus.schedule=*/1 * * * * *",
+    "spring.autoconfigure.exclude=com.azure.spring.cloud.autoconfigure.implementation.jms.ServiceBusJmsAutoConfiguration"
 })
 @Slf4j
 public class TestWithCCD extends CftlibTest {


### PR DESCRIPTION
## Summary
- exclude ServiceBusJmsAutoConfiguration for the cftlib TestWithCCD suite so Azure's starter does not demand a connection string

## Testing
- ./gradlew e2e:cftlibTest
