### PR TITLE
chore(e2e): replace gson with jackson

### DIFF
--- a/test-projects/e2e/build.gradle
+++ b/test-projects/e2e/build.gradle
@@ -93,7 +93,6 @@ dependencies {
     exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
   }
 
-  testImplementation 'com.google.code.gson:gson:2.11.0'
   testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
 
   cftlibTestImplementation "org.junit.platform:junit-platform-console-standalone:${versions.junitPlatform}"


### PR DESCRIPTION
## Summary
- replace the TestWithCCD gson calls with the existing ObjectMapper
- remove the redundant gson test dependency

## Testing
- ./gradlew :e2e:cftlibTestClasses
