### PR TITLE
chore: prune unused sdk dependencies

### DIFF
--- a/sdk/ccd-config-generator/build.gradle
+++ b/sdk/ccd-config-generator/build.gradle
@@ -35,14 +35,12 @@ dependencies {
     // Types from this library are used in the config generator's API
     api group: 'de.cronn', name: 'reflection-util', version: '2.18.0'
     implementation group: 'org.objenesis', name: 'objenesis', version: '3.4'
-    implementation group: 'cglib', name: 'cglib', version: '3.3.0'
     implementation group: 'net.jodah', name: 'typetools', version: '0.6.3'
     implementation 'org.reflections:reflections:0.10.2'
     api 'com.google.guava:guava:33.4.8-jre'
 
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.20.0'
 }
-
 
 
 

--- a/sdk/ccd-gradle-plugin/build.gradle
+++ b/sdk/ccd-gradle-plugin/build.gradle
@@ -23,11 +23,8 @@ dependencies {
     // Ensure we run the plugin's tests when the libraries are modified.
     testImplementation project(':ccd-config-generator')
 
-
     testImplementation 'junit:junit:4.13.2'
     testImplementation group: 'commons-io', name: 'commons-io', version: '2.20.0'
-    testImplementation group: 'org.hamcrest', name: 'hamcrest-all', version: '1.3'
-    testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.27.4'
 }
 
 java {


### PR DESCRIPTION
## Summary
- drop unused cglib dependency from sdk/ccd-config-generator
- remove unused Hamcrest and AssertJ test deps from sdk/ccd-gradle-plugin

## Testing
- ./gradlew :sdk:ccd-config-generator:check
- ./gradlew :sdk:ccd-gradle-plugin:check
