### PR TITLE
Ensure cascading deletes purge nfdiv case relations

### DIFF
--- a/sdk/decentralised-runtime/src/main/resources/dataruntime-db/migration/V0009__cascade_case_data_dependencies.sql
+++ b/sdk/decentralised-runtime/src/main/resources/dataruntime-db/migration/V0009__cascade_case_data_dependencies.sql
@@ -1,0 +1,8 @@
+-- Ensure CCD case data deletions cascade to dependent records in decentralised runtimes.
+
+alter table if exists ccd.case_event
+    drop constraint if exists case_event_case_data_id_fkey;
+
+alter table if exists ccd.case_event
+    add constraint case_event_case_data_id_fkey
+        foreign key (case_data_id) references ccd.case_data(id) on delete cascade;

--- a/test-projects/e2e/src/cftlibTest/java/uk/gov/hmcts/divorce/cftlib/TestWithCCD.java
+++ b/test-projects/e2e/src/cftlibTest/java/uk/gov/hmcts/divorce/cftlib/TestWithCCD.java
@@ -1258,4 +1258,15 @@ public class TestWithCCD extends CftlibTest {
         }
     }
 
+    @SneakyThrows
+    @Order(200)
+    @Test
+    void cascadingDeleteRemovesAllCaseData() {
+        db.getJdbcTemplate().execute("DELETE FROM ccd.case_data");
+
+        Integer caseDataCount = db.getJdbcTemplate()
+            .queryForObject("SELECT COUNT(*) FROM ccd.case_data", Integer.class);
+        assertThat("Case data table should be empty after delete", caseDataCount, equalTo(0));
+    }
+
 }

--- a/test-projects/e2e/src/main/resources/db/migration/V0002__case_notes_cascade.sql
+++ b/test-projects/e2e/src/main/resources/db/migration/V0002__case_notes_cascade.sql
@@ -1,0 +1,6 @@
+alter table case_notes
+    drop constraint if exists case_notes_reference_fkey;
+
+alter table case_notes
+    add constraint case_notes_reference_fkey
+        foreign key (reference) references ccd.case_data(reference) on delete cascade;


### PR DESCRIPTION
## Summary
- add a regression test that deletes from ccd.case_data in the nfdiv cftlib suite
- rebuild nfdiv foreign keys so deleting case data cascades to related records

## Testing
- ./gradlew -i e2e:cftlibTest
