### PR TITLE
Remove referer dependency from decentralised runtime

### DIFF
--- a/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/CaseController.java
+++ b/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/CaseController.java
@@ -1,8 +1,6 @@
 package uk.gov.hmcts.ccd.sdk;
 
-import java.net.URI;
 import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
@@ -21,7 +19,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
-import org.springframework.web.util.UriComponentsBuilder;
 import uk.gov.hmcts.ccd.data.persistence.dto.DecentralisedAuditEvent;
 import uk.gov.hmcts.ccd.data.persistence.dto.DecentralisedCaseDetails;
 import uk.gov.hmcts.ccd.data.persistence.dto.DecentralisedCaseEvent;
@@ -74,9 +71,6 @@ public class CaseController {
 
     log.info("Creating event '{}' for case reference: {}",
         event.getEventDetails().getEventId(), event.getCaseDetails().getReference());
-    var referer = Objects.requireNonNullElse(headers.getFirst(HttpHeaders.REFERER), "");
-    URI uri = UriComponentsBuilder.fromUriString(referer).build().toUri();
-    var params = UriComponentsBuilder.fromUri(uri).build().getQueryParams();
 
     var user = idam.retrieveUser(headers.getFirst("Authorization"));
     AtomicReference<ConfigGeneratorCallbackDispatcher.SubmitDispatchOutcome> dispatchOutcome =
@@ -89,7 +83,7 @@ public class CaseController {
           return false;
         }
 
-        var outcome = dispatcher.prepareSubmit(event, params);
+        var outcome = dispatcher.prepareSubmit(event);
         dispatchOutcome.set(outcome);
 
         var submitResponse = outcome.response();

--- a/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/ConfigGeneratorCallbackDispatcher.java
+++ b/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/ConfigGeneratorCallbackDispatcher.java
@@ -9,7 +9,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.util.MultiValueMap;
+import org.springframework.util.LinkedMultiValueMap;
 import uk.gov.hmcts.ccd.data.casedetails.SecurityClassification;
 import uk.gov.hmcts.ccd.data.persistence.dto.DecentralisedCaseEvent;
 import uk.gov.hmcts.ccd.data.persistence.dto.DecentralisedSubmitEventResponse;
@@ -33,8 +33,7 @@ class ConfigGeneratorCallbackDispatcher {
   private final ObjectMapper mapper;
 
   @SneakyThrows
-  public SubmitDispatchOutcome prepareSubmit(DecentralisedCaseEvent event,
-                                             MultiValueMap<String, String> urlParams) {
+  public SubmitDispatchOutcome prepareSubmit(DecentralisedCaseEvent event) {
     String caseType = event.getEventDetails().getCaseType();
     String eventId = event.getEventDetails().getEventId();
     Event<?, ?, ?> eventConfig = registry.getRequiredEvent(caseType, eventId);
@@ -51,6 +50,8 @@ class ConfigGeneratorCallbackDispatcher {
       );
       long caseRef = event.getCaseDetails().getReference();
 
+      // TODO: revisit when CCD resumes sending query params; referer header is absent at the moment.
+      var urlParams = new LinkedMultiValueMap<String, String>();
       SubmitResponse submitResponse = eventConfig.getSubmitHandler()
           .submit(new uk.gov.hmcts.ccd.sdk.api.EventPayload(caseRef, domainCaseData, urlParams));
 


### PR DESCRIPTION
## Summary
- drop referer header parsing in decentralised runtime
- instantiate empty query param map inline with TODO about CCD header

## Testing
- ./gradlew check
- ./gradlew -i e2e:cftlibTest
