### PR TITLE
Disable Renovate updates for ccd-lib

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,5 +3,13 @@
   "extends": [
     "local>hmcts/.github:renovate-config",
     "local>hmcts/.github//renovate/automerge-all"
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": [
+        "com.github.hmcts.rse-cft-lib:ccd-lib"
+      ],
+      "enabled": false
+    }
   ]
 }


### PR DESCRIPTION
Stop Renovate from updating com.github.hmcts.rse-cft-lib:ccd-lib because decentralised runtime depends on this version.