### PR TITLE
Remove IdamService.User wrapper

### DIFF
--- a/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/impl/AuditEventService.java
+++ b/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/impl/AuditEventService.java
@@ -23,6 +23,7 @@ import uk.gov.hmcts.ccd.data.persistence.dto.DecentralisedCaseEvent;
 import uk.gov.hmcts.ccd.domain.model.std.AuditEvent;
 import uk.gov.hmcts.ccd.sdk.ResolvedConfigRegistry;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+import uk.gov.hmcts.reform.idam.client.models.UserInfo;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -66,7 +67,7 @@ class AuditEventService {
   @SneakyThrows
   public long saveAuditRecord(
       DecentralisedCaseEvent event,
-      IdamService.User user,
+      UserInfo user,
       uk.gov.hmcts.ccd.domain.model.definition.CaseDetails currentView,
       UUID idempotencyKey
   ) {
@@ -120,13 +121,13 @@ class AuditEventService {
     var params = new MapSqlParameterSource()
         .addValue("data", defaultMapper.writeValueAsString(currentView.getData()))
         .addValue("event_id", eventDetails.getEventId())
-        .addValue("user_id", user.getUserDetails().getUid())
+        .addValue("user_id", user.getUid())
         .addValue("case_data_id", event.getInternalCaseId())
         .addValue("case_type_id", eventDetails.getCaseType())
         .addValue("case_type_version", 1)
         .addValue("state_id", currentView.getState())
-        .addValue("user_first_name", user.getUserDetails().getGivenName())
-        .addValue("user_last_name", user.getUserDetails().getFamilyName())
+        .addValue("user_first_name", user.getGivenName())
+        .addValue("user_last_name", user.getFamilyName())
         .addValue("event_name", eventDetails.getEventName())
         .addValue("state_name", stateName)
         .addValue("summary", eventDetails.getSummary())
@@ -144,7 +145,7 @@ class AuditEventService {
       );
       this.publisher.get().publishEvent(
           currentView.getReference(),
-          user.getUserDetails().getUid(),
+          user.getUid(),
           eventDetails.getEventId(),
           oldState,
           toCaseDetails(event.getCaseDetails()),

--- a/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/impl/CaseSubmissionService.java
+++ b/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/impl/CaseSubmissionService.java
@@ -15,6 +15,7 @@ import uk.gov.hmcts.ccd.data.persistence.dto.DecentralisedSubmitEventResponse;
 import uk.gov.hmcts.ccd.domain.model.callbacks.AfterSubmitCallbackResponse;
 import uk.gov.hmcts.ccd.sdk.ResolvedConfigRegistry;
 import uk.gov.hmcts.ccd.sdk.api.callback.SubmitResponse;
+import uk.gov.hmcts.reform.idam.client.models.UserInfo;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -64,7 +65,7 @@ public class CaseSubmissionService {
    * Encapsulates all database operations that must run within a single transaction.
    */
   private TransactionResult executeSubmissionInTransaction(DecentralisedCaseEvent event,
-                                                           IdamService.User user,
+                                                           UserInfo user,
                                                            CaseSubmissionHandler handler,
                                                            UUID idempotencyKey) {
     // Idempotency Check inside the transaction to ensure atomicity

--- a/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/impl/IdamService.java
+++ b/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/impl/IdamService.java
@@ -2,8 +2,6 @@ package uk.gov.hmcts.ccd.sdk.impl;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.idam.client.IdamClient;
@@ -17,7 +15,7 @@ class IdamService {
   private static final String BEARER_PREFIX = "Bearer" + " ";
 
   private final IdamClient idamClient;
-  private final Cache<String, User> userCache;
+  private final Cache<String, UserInfo> userCache;
 
   IdamService(
       IdamClient idamClient,
@@ -30,10 +28,10 @@ class IdamService {
         .build();
   }
 
-  public User retrieveUser(String authorisation) {
+  public UserInfo retrieveUser(String authorisation) {
     return userCache.get(
         getBearerToken(authorisation),
-        token -> new User(token, idamClient.getUserInfo(token))
+        idamClient::getUserInfo
     );
   }
 
@@ -44,10 +42,4 @@ class IdamService {
     return token.startsWith(BEARER_PREFIX) ? token : BEARER_PREFIX.concat(token);
   }
 
-  @Getter
-  @AllArgsConstructor
-  public static class User {
-    private String authToken;
-    private UserInfo userDetails;
-  }
 }

--- a/sdk/decentralised-runtime/src/test/java/uk/gov/hmcts/ccd/sdk/IdamServiceTest.java
+++ b/sdk/decentralised-runtime/src/test/java/uk/gov/hmcts/ccd/sdk/IdamServiceTest.java
@@ -19,7 +19,7 @@ class IdamServiceTest {
     var secondCall = idamService.retrieveUser("token");
 
     assertThat(firstCall).isSameAs(secondCall);
-    assertThat(firstCall.getUserDetails()).isEqualTo(userInfo);
+    assertThat(firstCall).isEqualTo(userInfo);
     assertThat(idamClient.callCount).isEqualTo(1);
     assertThat(idamClient.lastToken).isEqualTo("Bearer token");
   }


### PR DESCRIPTION
Replace the inner User wrapper with the UserInfo returned by idam-client so we only cache the user details. Update the callers and the unit test to work with the new return type.