### PR TITLE
prevent duplicate service bus publishes

### DIFF
--- a/sdk/ccd-servicebus-support/src/main/java/uk/gov/hmcts/ccd/sdk/servicebus/CcdCaseEventPublisher.java
+++ b/sdk/ccd-servicebus-support/src/main/java/uk/gov/hmcts/ccd/sdk/servicebus/CcdCaseEventPublisher.java
@@ -15,6 +15,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.jms.core.JmsTemplate;
 import org.springframework.jms.core.MessagePostProcessor;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @Slf4j
@@ -29,6 +30,7 @@ public class CcdCaseEventPublisher {
   @Value("${ccd.servicebus.destination:}")
   private String destination;
 
+  @Transactional
   public void publishPendingCaseEvents() {
     if (destination == null || destination.isBlank()) {
       log.warn("No CCD Service Bus destination configured; skipping publish run");

--- a/sdk/ccd-servicebus-support/src/main/java/uk/gov/hmcts/ccd/sdk/servicebus/CcdMessageQueueRepository.java
+++ b/sdk/ccd-servicebus-support/src/main/java/uk/gov/hmcts/ccd/sdk/servicebus/CcdMessageQueueRepository.java
@@ -26,6 +26,7 @@ public class CcdMessageQueueRepository {
          AND message_type = ?
        ORDER BY time_stamp
        LIMIT ?
+       FOR UPDATE SKIP LOCKED
       """;
 
   private static final String UPDATE_PUBLISHED = """


### PR DESCRIPTION
### Change description ###

Add row locking to the message_queue_candidates select and keep the publish loop transactional so only one publisher can send a given row.