### PR TITLE
Default migration target DSN to postgres

### DIFF
--- a/scripts/migrate-ccd-data.sh
+++ b/scripts/migrate-ccd-data.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # Configuration (can be overridden via environment variables)
 SRC_DSN="${SRC_DSN:-postgresql://postgres:postgres@localhost:6432/datastore}"
-DST_DSN="${DST_DSN:-postgresql://postgres:postgres@localhost:6432/sptribs}"
+DST_DSN="${DST_DSN:-postgresql://postgres:postgres@localhost:6432/postgres}"
 CASE_TYPE="${CASE_TYPE:-CriminalInjuriesCompensation}"
 DO_APPLY=false
 


### PR DESCRIPTION
Default the migration target DSN to the postgres database to align with the cleanup script defaults.