### PR TITLE
Remove deprecated usage of JavaPluginConvention

### DIFF
--- a/test-projects/e2e/build.gradle
+++ b/test-projects/e2e/build.gradle
@@ -57,7 +57,7 @@ dependencies {
   implementation 'com.github.hmcts.java-logging:logging:6.1.9'
   implementation 'com.github.hmcts:service-auth-provider-java-client:5.3.3'
 
-  implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.14'
+  implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.15'
 
   implementation 'com.github.ben-manes.caffeine:caffeine:3.2.3'
   implementation 'com.google.guava:guava:33.5.0-jre'


### PR DESCRIPTION
### Change description ###

- This is failing for gradle 9 upgrades 

