### PR TITLE
Centralize SDK Spring Boot BOM

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -1,5 +1,9 @@
+import org.springframework.boot.gradle.plugin.SpringBootPlugin
+
 plugins {
     id("io.freefair.lombok") version "9.2.0" apply(false)
+    id("org.springframework.boot") version "3.2.12" apply(false)
+    id("io.spring.dependency-management") version "1.1.7" apply(false)
 }
 
 def sdkCheck = tasks.register('check');
@@ -8,6 +12,17 @@ subprojects {
     apply plugin: 'java'
     apply plugin: 'checkstyle'
     apply plugin: 'io.freefair.lombok'
+    apply plugin: 'io.spring.dependency-management'
+
+    dependencyManagement {
+        imports {
+            mavenBom(SpringBootPlugin.BOM_COORDINATES)
+        }
+    }
+
+    if (project.name == 'decentralised-runtime') {
+        apply plugin: 'org.springframework.boot'
+    }
 
     version = System.getenv('RELEASE_VERSION')?.replace('refs/tags/', '') ?: 'DEV-SNAPSHOT'
 

--- a/sdk/ccd-config-generator/build.gradle
+++ b/sdk/ccd-config-generator/build.gradle
@@ -5,15 +5,13 @@ repositories {
     mavenCentral()
 }
 
-def springBootVersion = '2.7.18'
-
 dependencies {
     // Use JUnit test framework for unit tests
     testImplementation 'junit:junit:4.13.2'
     annotationProcessor group: 'org.projectlombok', name: 'lombok', version: '1.18.42'
     compileOnly group: 'org.projectlombok', name: 'lombok', version: '1.18.42'
-    implementation "org.springframework.boot:spring-boot-autoconfigure:${springBootVersion}"
-    implementation "org.springframework.boot:spring-boot-starter-web:${springBootVersion}"
+    implementation "org.springframework.boot:spring-boot-autoconfigure"
+    implementation "org.springframework.boot:spring-boot-starter-web"
     api(group: 'com.github.hmcts', name: 'core-case-data-store-client', version: '5.2.0') {
         // The config generator needs only the types defined in the CCD client library,
         // not all the runtime spring dependencies used by the CCD client.
@@ -28,7 +26,7 @@ dependencies {
     testImplementation group: 'org.hamcrest', name: 'hamcrest-all', version: '1.3'
     testImplementation group: 'commons-io', name: 'commons-io', version: '2.21.0'
     testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.27.6'
-    testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: springBootVersion
+    testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test'
 
 
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.20.0'

--- a/sdk/ccd-gradle-plugin/test-projects/java-library/build.gradle
+++ b/sdk/ccd-gradle-plugin/test-projects/java-library/build.gradle
@@ -26,7 +26,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.springframework.boot:spring-boot-autoconfigure:2.7.18'
+    implementation 'org.springframework.boot:spring-boot-autoconfigure:3.2.12'
 
     // Use JUnit test framework
     testImplementation 'junit:junit:4.13.2'

--- a/sdk/ccd-servicebus-support/build.gradle
+++ b/sdk/ccd-servicebus-support/build.gradle
@@ -1,10 +1,5 @@
-plugins {
-    id 'io.spring.dependency-management' version '1.1.7'
-}
-
 dependencyManagement {
     imports {
-        mavenBom 'org.springframework.boot:spring-boot-dependencies:3.5.9'
         mavenBom 'com.azure.spring:spring-cloud-azure-dependencies:6.1.0'
     }
 }

--- a/sdk/cftlib-dev-only/build.gradle
+++ b/sdk/cftlib-dev-only/build.gradle
@@ -10,7 +10,6 @@ repositories {
 }
 
 dependencies {
-    implementation platform("org.springframework.boot:spring-boot-dependencies:3.5.9")
     implementation 'org.springframework.boot:spring-boot-starter-jdbc'
     implementation 'org.elasticsearch.client:elasticsearch-rest-high-level-client:7.17.29'
     implementation 'com.fasterxml.jackson.core:jackson-databind'

--- a/sdk/decentralised-runtime/build.gradle
+++ b/sdk/decentralised-runtime/build.gradle
@@ -1,7 +1,3 @@
-plugins {
-    id 'org.springframework.boot' version '3.5.9'
-}
-
 repositories {
     maven {
         url = 'https://pkgs.dev.azure.com/hmcts/Artifacts/_packaging/hmcts-lib/maven/v1'
@@ -9,7 +5,6 @@ repositories {
 }
 
 dependencies {
-    implementation platform("org.springframework.boot:spring-boot-dependencies:3.5.9")
     implementation project(':ccd-config-generator')
     // A filtered set of useful CCD POJOs including DTOs and other utilities.
     implementation ('com.github.hmcts.rse-cft-lib:ccd-lib:0.19.1953') {


### PR DESCRIPTION
Centralizes Spring Boot dependency management at the SDK root, uses Boot 3.2.12 as the baseline, and removes per-module version drift.