### PR TITLE
Allow callbacks to override event metadata

### DIFF
--- a/docs/decentralised-runtime.md
+++ b/docs/decentralised-runtime.md
@@ -45,6 +45,37 @@ Case records are persisted and updated in the `ccd.case_data` table, including l
 
 Snapshots are recorded in the `ccd.case_event` table upon conclusion of each case event.
 
+### Event metadata
+
+Decentralised services can set the event history summary and description from server-side event handling. This is useful
+when the metadata should be derived from the selected case data rather than typed manually in XUI.
+
+For an emulated AboutToSubmit callback:
+
+```java
+return AboutToStartOrSubmitResponse.<CaseData, State>builder()
+    .data(caseData)
+    .eventMetadata(EventMetadata.builder()
+        .summary("Selected documents added")
+        .description("Documents: application.pdf, evidence.pdf")
+        .build())
+    .build();
+```
+
+For a decentralised submit handler:
+
+```java
+return SubmitResponse.<State>builder()
+    .eventMetadata(EventMetadata.builder()
+        .summary("Selected documents added")
+        .description("Documents: application.pdf, evidence.pdf")
+        .build())
+    .build();
+```
+
+`EventMetadata` is consumed by the decentralised runtime when it writes `ccd.case_event`. It is SDK-internal metadata and
+is not included in the callback response JSON returned to CCD.
+
 ### Optimistic locking of legacy JSON blobs
 
 The SDK implements optimistic locking on the legacy JSON blob in `ccd.case_data` via the `version` column.

--- a/sdk/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/api/EventMetadata.java
+++ b/sdk/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/api/EventMetadata.java
@@ -1,0 +1,17 @@
+package uk.gov.hmcts.ccd.sdk.api;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class EventMetadata {
+
+  private String summary;
+
+  private String description;
+}

--- a/sdk/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/api/callback/AboutToStartOrSubmitResponse.java
+++ b/sdk/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/api/callback/AboutToStartOrSubmitResponse.java
@@ -1,10 +1,12 @@
 package uk.gov.hmcts.ccd.sdk.api.callback;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 import java.util.Map;
 import lombok.Builder;
 import lombok.Data;
+import uk.gov.hmcts.ccd.sdk.api.EventMetadata;
 
 @Builder
 @Data
@@ -25,5 +27,8 @@ public class AboutToStartOrSubmitResponse<T, S> {
 
   @JsonProperty("security_classification")
   private String securityClassification;
+
+  @JsonIgnore
+  private EventMetadata eventMetadata;
 
 }

--- a/sdk/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/api/callback/SubmitResponse.java
+++ b/sdk/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/api/callback/SubmitResponse.java
@@ -1,8 +1,10 @@
 package uk.gov.hmcts.ccd.sdk.api.callback;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.util.List;
 import lombok.Builder;
 import lombok.Data;
+import uk.gov.hmcts.ccd.sdk.api.EventMetadata;
 import uk.gov.hmcts.reform.ccd.client.model.Classification;
 
 /**
@@ -29,4 +31,7 @@ public class SubmitResponse<State> {
   private State state;
 
   private Classification caseSecurityClassification;
+
+  @JsonIgnore
+  private EventMetadata eventMetadata;
 }

--- a/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/impl/CaseSubmissionHandler.java
+++ b/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/impl/CaseSubmissionHandler.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import java.util.Optional;
 import java.util.function.Supplier;
 import uk.gov.hmcts.ccd.decentralised.dto.DecentralisedCaseEvent;
+import uk.gov.hmcts.ccd.sdk.api.EventMetadata;
 import uk.gov.hmcts.ccd.sdk.api.callback.SubmitResponse;
 
 /**
@@ -36,6 +37,10 @@ interface CaseSubmissionHandler {
        * Optional post-submit canonical case level security classification to be persisted.
        */
       Optional<uk.gov.hmcts.reform.ccd.client.model.Classification> securityClassification,
+      /*
+       * Optional replacement values for the case event audit metadata.
+       */
+      Optional<EventMetadata> eventMetadata,
       /*
        * Deferred response builder executed post-transaction by {@link CaseSubmissionService}.
        */

--- a/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/impl/CaseSubmissionService.java
+++ b/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/impl/CaseSubmissionService.java
@@ -17,6 +17,7 @@ import uk.gov.hmcts.ccd.decentralised.dto.DecentralisedCaseEvent;
 import uk.gov.hmcts.ccd.decentralised.dto.DecentralisedSubmitEventResponse;
 import uk.gov.hmcts.ccd.domain.model.callbacks.AfterSubmitCallbackResponse;
 import uk.gov.hmcts.ccd.sdk.ResolvedConfigRegistry;
+import uk.gov.hmcts.ccd.sdk.api.EventMetadata;
 import uk.gov.hmcts.ccd.sdk.api.callback.SubmitResponse;
 
 @Service
@@ -123,6 +124,12 @@ public class CaseSubmissionService {
     handlerResult.securityClassification()
         .map(classification -> SecurityClassification.valueOf(classification.name()))
         .ifPresent(event.getCaseDetails()::setSecurityClassification);
+    handlerResult.eventMetadata().ifPresent(metadata -> applyEventMetadata(event, metadata));
+  }
+
+  private void applyEventMetadata(DecentralisedCaseEvent event, EventMetadata eventMetadata) {
+    event.getEventDetails().setSummary(eventMetadata.getSummary());
+    event.getEventDetails().setDescription(eventMetadata.getDescription());
   }
 
   private void upsertCase(DecentralisedCaseEvent event, Optional<JsonNode> dataUpdate) {

--- a/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/impl/CaseSubmissionService.java
+++ b/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/impl/CaseSubmissionService.java
@@ -128,8 +128,11 @@ public class CaseSubmissionService {
   }
 
   private void applyEventMetadata(DecentralisedCaseEvent event, EventMetadata eventMetadata) {
-    event.getEventDetails().setSummary(eventMetadata.getSummary());
-    event.getEventDetails().setDescription(eventMetadata.getDescription());
+    var eventDetails = event.getEventDetails();
+    eventDetails.setSummary(Optional.ofNullable(eventMetadata.getSummary()).orElse(eventDetails.getSummary()));
+    eventDetails.setDescription(
+        Optional.ofNullable(eventMetadata.getDescription()).orElse(eventDetails.getDescription())
+    );
   }
 
   private void upsertCase(DecentralisedCaseEvent event, Optional<JsonNode> dataUpdate) {

--- a/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/impl/DecentralisedSubmissionHandler.java
+++ b/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/impl/DecentralisedSubmissionHandler.java
@@ -37,7 +37,12 @@ class DecentralisedSubmissionHandler implements CaseSubmissionHandler {
     var state = Optional.ofNullable(outcome.getState()).map(Object::toString);
     var securityClassification = Optional.ofNullable(outcome.getCaseSecurityClassification());
 
-    return new CaseSubmissionHandlerResult(Optional.empty(), state, securityClassification, () -> outcome);
+    return new CaseSubmissionHandlerResult(
+        Optional.empty(),
+        state,
+        securityClassification,
+        Optional.ofNullable(outcome.getEventMetadata()),
+        () -> outcome);
   }
 
   private SubmitResponse<?> prepareSubmitHandler(DecentralisedCaseEvent event) {

--- a/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/impl/LegacyCallbackSubmissionHandler.java
+++ b/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/impl/LegacyCallbackSubmissionHandler.java
@@ -13,6 +13,7 @@ import uk.gov.hmcts.ccd.decentralised.dto.DecentralisedCaseEvent;
 import uk.gov.hmcts.ccd.decentralised.dto.DecentralisedSubmitEventResponse;
 import uk.gov.hmcts.ccd.sdk.ResolvedConfigRegistry;
 import uk.gov.hmcts.ccd.sdk.api.Event;
+import uk.gov.hmcts.ccd.sdk.api.EventMetadata;
 import uk.gov.hmcts.ccd.sdk.api.Webhook;
 import uk.gov.hmcts.ccd.sdk.api.callback.AboutToStartOrSubmitResponse;
 import uk.gov.hmcts.ccd.sdk.api.callback.SubmitResponse;
@@ -73,6 +74,7 @@ class LegacyCallbackSubmissionHandler implements CaseSubmissionHandler {
         Optional.ofNullable(dataSnapshot),
         state,
         securityClassification,
+        Optional.ofNullable(outcome.eventMetadata()),
         () -> {
           var builder = SubmitResponse.builder()
               .errors(errors)
@@ -98,10 +100,12 @@ class LegacyCallbackSubmissionHandler implements CaseSubmissionHandler {
     Event<?, ?, ?> eventConfig = registry.getRequiredEvent(caseType, eventId);
 
     var response = new DecentralisedSubmitEventResponse();
+    EventMetadata eventMetadata = null;
 
     if (eventConfig.getAboutToSubmitCallback() != null) {
       CallbackRequest request = buildCallbackRequest(event);
       AboutToStartOrSubmitResponse callbackResponse = executor.aboutToSubmit(request);
+      eventMetadata = callbackResponse.getEventMetadata();
 
       Map<String, JsonNode> normalisedData = callbackResponse.getData() == null
           ? Map.of()
@@ -122,7 +126,7 @@ class LegacyCallbackSubmissionHandler implements CaseSubmissionHandler {
     }
 
     boolean hasSubmitted = eventConfig.getSubmittedCallback() != null;
-    return new LegacySubmitOutcome(response, hasSubmitted);
+    return new LegacySubmitOutcome(response, eventMetadata, hasSubmitted);
   }
 
   private Optional<SubmittedCallbackResponse> runSubmittedCallback(DecentralisedCaseEvent event) {
@@ -170,6 +174,7 @@ class LegacyCallbackSubmissionHandler implements CaseSubmissionHandler {
   }
 
   private record LegacySubmitOutcome(DecentralisedSubmitEventResponse response,
+                                     EventMetadata eventMetadata,
                                      boolean runSubmittedCallback) {}
 
   @SneakyThrows

--- a/test-projects/e2e/src/cftlibTest/java/uk/gov/hmcts/divorce/cftlib/TestWithCCD.java
+++ b/test-projects/e2e/src/cftlibTest/java/uk/gov/hmcts/divorce/cftlib/TestWithCCD.java
@@ -89,9 +89,11 @@ import uk.gov.hmcts.divorce.simplecase.SimpleCaseConfiguration;
 import uk.gov.hmcts.divorce.simplecase.model.SimpleCaseData;
 import uk.gov.hmcts.divorce.simplecase.model.SimpleCaseState;
 import uk.gov.hmcts.divorce.sow014.nfd.CaseworkerMaintainCaseLink;
+import uk.gov.hmcts.divorce.sow014.nfd.CaseworkerOverrideEventMetadata;
 import uk.gov.hmcts.divorce.sow014.nfd.CaseworkerPopulateSearchCriteria;
 import uk.gov.hmcts.divorce.sow014.nfd.DecentralisedCaseworkerAddNote;
 import uk.gov.hmcts.divorce.sow014.nfd.DecentralisedCaseworkerAddNoteFailure;
+import uk.gov.hmcts.divorce.sow014.nfd.DecentralisedOverrideEventMetadata;
 import uk.gov.hmcts.divorce.sow014.nfd.FailingSubmittedCallback;
 import uk.gov.hmcts.divorce.sow014.nfd.CaseworkerRoundTripData;
 import uk.gov.hmcts.divorce.sow014.nfd.ApiFirstTaskCancelEvent;
@@ -1967,6 +1969,24 @@ public class TestWithCCD extends CftlibTest {
         return e;
     }
 
+    private void assertLatestEventMetadata(String eventId, String expectedSummary, String expectedDescription) {
+        var latestMetadata = db.queryForMap(
+            """
+                SELECT ce.summary, ce.description
+                  FROM ccd.case_event ce
+                  JOIN ccd.case_data cd ON cd.id = ce.case_data_id
+                 WHERE cd.reference = :ref
+                   AND ce.event_id = :eventId
+              ORDER BY ce.id DESC
+                 LIMIT 1
+                """,
+            Map.of("ref", caseRef, "eventId", eventId)
+        );
+
+        assertThat(latestMetadata.get("summary"), equalTo(expectedSummary));
+        assertThat(latestMetadata.get("description"), equalTo(expectedDescription));
+    }
+
     private HttpPost prepareEventRequest(String user, String eventId, Map<String, ?> data) {
         return prepareEventRequestForCase(caseRef, user, eventId, data);
     }
@@ -2162,6 +2182,70 @@ public class TestWithCCD extends CftlibTest {
         String lastNoteSql = "SELECT note FROM case_notes WHERE reference = :ref ORDER BY id DESC LIMIT 1";
         String latestNote = db.queryForObject(lastNoteSql, Map.of("ref", caseRef), String.class);
         assertThat(latestNote, equalTo(noteText));
+    }
+
+    @Order(19)
+    @Test
+    public void decentralisedSubmitHandlerCanOverrideEventMetadata() throws Exception {
+        var start = ccdApi.startEvent(
+            getAuthorisation("TEST_CASE_WORKER_USER@mailinator.com"),
+            getServiceAuth(),
+            String.valueOf(caseRef),
+            DecentralisedOverrideEventMetadata.EVENT_ID
+        );
+
+        var request = prepareEventRequestWithToken(
+            "TEST_CASE_WORKER_USER@mailinator.com",
+            DecentralisedOverrideEventMetadata.EVENT_ID,
+            Map.of("note", "metadata override"),
+            start.getToken(),
+            caseRef
+        );
+
+        var response = HttpClientBuilder.create().build().execute(request);
+        try {
+            assertThat(response.getStatusLine().getStatusCode(), equalTo(201));
+        } finally {
+            response.close();
+        }
+
+        assertLatestEventMetadata(
+            DecentralisedOverrideEventMetadata.EVENT_ID,
+            DecentralisedOverrideEventMetadata.METADATA_OVERRIDE_PREFIX + " summary",
+            DecentralisedOverrideEventMetadata.METADATA_OVERRIDE_PREFIX + " description"
+        );
+    }
+
+    @Order(19)
+    @Test
+    public void aboutToSubmitCallbackCanOverrideEventMetadata() throws Exception {
+        var start = ccdApi.startEvent(
+            getAuthorisation("TEST_CASE_WORKER_USER@mailinator.com"),
+            getServiceAuth(),
+            String.valueOf(caseRef),
+            CaseworkerOverrideEventMetadata.EVENT_ID
+        );
+
+        var request = prepareEventRequestWithToken(
+            "TEST_CASE_WORKER_USER@mailinator.com",
+            CaseworkerOverrideEventMetadata.EVENT_ID,
+            Map.of("note", "metadata override"),
+            start.getToken(),
+            caseRef
+        );
+
+        var response = HttpClientBuilder.create().build().execute(request);
+        try {
+            assertThat(response.getStatusLine().getStatusCode(), equalTo(201));
+        } finally {
+            response.close();
+        }
+
+        assertLatestEventMetadata(
+            CaseworkerOverrideEventMetadata.EVENT_ID,
+            CaseworkerOverrideEventMetadata.METADATA_OVERRIDE_PREFIX + " summary",
+            CaseworkerOverrideEventMetadata.METADATA_OVERRIDE_PREFIX + " description"
+        );
     }
 
     @Order(20)

--- a/test-projects/e2e/src/main/java/uk/gov/hmcts/divorce/sow014/nfd/CaseworkerOverrideEventMetadata.java
+++ b/test-projects/e2e/src/main/java/uk/gov/hmcts/divorce/sow014/nfd/CaseworkerOverrideEventMetadata.java
@@ -1,0 +1,57 @@
+package uk.gov.hmcts.divorce.sow014.nfd;
+
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CASE_WORKER;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.JUDGE;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SOLICITOR;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
+import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
+import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE_DELETE;
+
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.ccd.sdk.api.CCDConfig;
+import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
+import uk.gov.hmcts.ccd.sdk.api.ConfigBuilder;
+import uk.gov.hmcts.ccd.sdk.api.EventMetadata;
+import uk.gov.hmcts.ccd.sdk.api.callback.AboutToStartOrSubmitResponse;
+import uk.gov.hmcts.divorce.common.ccd.PageBuilder;
+import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
+import uk.gov.hmcts.divorce.divorcecase.model.State;
+import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
+
+@Component
+public class CaseworkerOverrideEventMetadata implements CCDConfig<CaseData, State, UserRole> {
+
+    public static final String EVENT_ID = "cw-override-event-metadata";
+    public static final String METADATA_OVERRIDE_PREFIX = "about-to-submit override";
+
+    @Override
+    public void configure(final ConfigBuilder<CaseData, State, UserRole> configBuilder) {
+        new PageBuilder(configBuilder
+            .event(EVENT_ID)
+            .forAllStates()
+            .name("Override event metadata")
+            .description("Override event metadata")
+            .aboutToSubmitCallback(this::aboutToSubmit)
+            .showEventNotes()
+            .grant(CREATE_READ_UPDATE, CASE_WORKER, SOLICITOR, JUDGE)
+            .grant(CREATE_READ_UPDATE_DELETE, SUPER_USER)
+            .grantHistoryOnly(LEGAL_ADVISOR, JUDGE))
+            .page("overrideEventMetadata")
+            .pageLabel("Override event metadata")
+            .optional(CaseData::getNote);
+    }
+
+    private AboutToStartOrSubmitResponse<CaseData, State> aboutToSubmit(
+        final CaseDetails<CaseData, State> details,
+        final CaseDetails<CaseData, State> beforeDetails
+    ) {
+        return AboutToStartOrSubmitResponse.<CaseData, State>builder()
+            .data(details.getData())
+            .eventMetadata(EventMetadata.builder()
+                .summary(METADATA_OVERRIDE_PREFIX + " summary")
+                .description(METADATA_OVERRIDE_PREFIX + " description")
+                .build())
+            .build();
+    }
+}

--- a/test-projects/e2e/src/main/java/uk/gov/hmcts/divorce/sow014/nfd/DecentralisedOverrideEventMetadata.java
+++ b/test-projects/e2e/src/main/java/uk/gov/hmcts/divorce/sow014/nfd/DecentralisedOverrideEventMetadata.java
@@ -1,0 +1,57 @@
+package uk.gov.hmcts.divorce.sow014.nfd;
+
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CASE_WORKER;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.JUDGE;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
+import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
+import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE_DELETE;
+
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.ccd.sdk.api.CCDConfig;
+import uk.gov.hmcts.ccd.sdk.api.DecentralisedConfigBuilder;
+import uk.gov.hmcts.ccd.sdk.api.Event.EventBuilder;
+import uk.gov.hmcts.ccd.sdk.api.EventMetadata;
+import uk.gov.hmcts.ccd.sdk.api.EventPayload;
+import uk.gov.hmcts.ccd.sdk.api.callback.SubmitResponse;
+import uk.gov.hmcts.divorce.common.ccd.PageBuilder;
+import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
+import uk.gov.hmcts.divorce.divorcecase.model.State;
+import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
+
+@Component
+public class DecentralisedOverrideEventMetadata implements CCDConfig<CaseData, State, UserRole> {
+
+    public static final String EVENT_ID = "cw-dec-override-event-metadata";
+    public static final String METADATA_OVERRIDE_PREFIX = "submit handler override";
+
+    @Override
+    public void configureDecentralised(final DecentralisedConfigBuilder<CaseData, State, UserRole> configBuilder) {
+        EventBuilder<CaseData, UserRole, State> eventBuilder = configBuilder
+            .decentralisedEvent(EVENT_ID, this::submit, this::start)
+            .forAllStates()
+            .name("Override metadata dec")
+            .showEventNotes()
+            .grant(CREATE_READ_UPDATE, CASE_WORKER, JUDGE)
+            .grant(CREATE_READ_UPDATE_DELETE, SUPER_USER)
+            .grantHistoryOnly(LEGAL_ADVISOR, JUDGE);
+
+        new PageBuilder(eventBuilder)
+            .page("overrideEventMetadataDecentralised")
+            .pageLabel("Override metadata dec")
+            .optional(CaseData::getNote);
+    }
+
+    private CaseData start(EventPayload<CaseData, State> payload) {
+        return payload.caseData();
+    }
+
+    private SubmitResponse<State> submit(EventPayload<CaseData, State> payload) {
+        return SubmitResponse.<State>builder()
+            .eventMetadata(EventMetadata.builder()
+                .summary(METADATA_OVERRIDE_PREFIX + " summary")
+                .description(METADATA_OVERRIDE_PREFIX + " description")
+                .build())
+            .build();
+    }
+}


### PR DESCRIPTION
Allow decentralised services to set event summary and description during the submission process.

Services sometimes need to derive event summaries and comments from selected case data during submission, rather than relying on manually entered XUI event notes.

