### PR TITLE
Refactor runtime callback dispatch

### DIFF
--- a/sdk/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/api/Event.java
+++ b/sdk/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/api/Event.java
@@ -11,10 +11,14 @@ import java.util.stream.Collectors;
 import lombok.Builder;
 import lombok.Data;
 import uk.gov.hmcts.ccd.sdk.api.callback.AboutToStart;
+import uk.gov.hmcts.ccd.sdk.api.callback.AboutToStartOrSubmitResponse;
 import uk.gov.hmcts.ccd.sdk.api.callback.AboutToSubmit;
 import uk.gov.hmcts.ccd.sdk.api.callback.Start;
 import uk.gov.hmcts.ccd.sdk.api.callback.Submit;
 import uk.gov.hmcts.ccd.sdk.api.callback.Submitted;
+import uk.gov.hmcts.ccd.sdk.runtime.RuntimeCallback;
+import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
+import uk.gov.hmcts.reform.ccd.client.model.SubmittedCallbackResponse;
 
 @Builder
 @Data
@@ -36,9 +40,9 @@ public class Event<T, R extends HasRole, S> {
   private boolean showEventNotes;
   private boolean publishToCamunda;
   private Integer ttlIncrement;
-  private AboutToStart<T, S> aboutToStartCallback;
-  private AboutToSubmit<T, S> aboutToSubmitCallback;
-  private Submitted<T, S> submittedCallback;
+  private RuntimeCallback<AboutToStartOrSubmitResponse> runtimeAboutToStartCallback;
+  private RuntimeCallback<AboutToStartOrSubmitResponse> runtimeAboutToSubmitCallback;
+  private RuntimeCallback<SubmittedCallbackResponse> runtimeSubmittedCallback;
   private Submit<T, S> submitHandler;
   private Start<T, S> startHandler;
   private FieldCollection fields;
@@ -70,7 +74,6 @@ public class Event<T, R extends HasRole, S> {
   public static class EventBuilder<T, R extends HasRole, S> {
 
     private FieldCollection.FieldCollectionBuilder<T, S, EventBuilder<T, R, S>> fieldsBuilder;
-
     public static <T, R extends HasRole, S> EventBuilder<T, R, S> builder(
         String id, Class dataClass, PropertyUtils propertyUtils,
         Set<S> preStates, Set<S> postStates) {
@@ -182,23 +185,79 @@ public class Event<T, R extends HasRole, S> {
       return this;
     }
 
+    public EventBuilder<T, R, S> aboutToStartCallback(AboutToStart<T, S> aboutToStartCallback) {
+      if (this.startHandler == null) {
+        this.runtimeAboutToStartCallback = aboutToStartCallback == null
+            ? null
+            : (request, context) -> aboutToStartCallback.handle(caseDetails(request, context));
+      }
+      return this;
+    }
+
     public EventBuilder<T, R, S> submittedCallback(Submitted<T, S> submittedCallback) {
-      // TODO: split out decentralised event building to remove these fields for decentralised events.
       if (this.submitHandler != null) {
         throw new IllegalStateException("Cannot set both submitHandler and submittedCallback");
       }
-      this.submittedCallback = submittedCallback;
+      this.runtimeSubmittedCallback = submittedCallback == null
+          ? null
+          : (request, context) -> submittedCallback.handle(
+              caseDetails(request, context),
+              caseDetailsBefore(request, context)
+          );
       return this;
     }
 
 
     public EventBuilder<T, R, S> aboutToSubmitCallback(AboutToSubmit<T, S> aboutToSubmitCallback) {
-      // TODO: split out decentralised event building to remove these fields for decentralised events.
       if (this.submitHandler != null) {
         throw new IllegalStateException("Cannot set both submitHandler and aboutToSubmitCallback");
       }
-      this.aboutToSubmitCallback = aboutToSubmitCallback;
+      this.runtimeAboutToSubmitCallback = aboutToSubmitCallback == null
+          ? null
+          : (request, context) -> aboutToSubmitCallback.handle(
+              caseDetails(request, context),
+              caseDetailsBefore(request, context)
+          );
       return this;
+    }
+
+    public EventBuilder<T, R, S> submitHandler(Submit<T, S> submitHandler) {
+      if (submitHandler != null && runtimeSubmittedCallback != null) {
+        throw new IllegalStateException("Cannot set both submitHandler and submittedCallback");
+      }
+      if (submitHandler != null && runtimeAboutToSubmitCallback != null) {
+        throw new IllegalStateException("Cannot set both submitHandler and aboutToSubmitCallback");
+      }
+      this.submitHandler = submitHandler;
+      return this;
+    }
+
+    public EventBuilder<T, R, S> startHandler(Start<T, S> startHandler) {
+      this.startHandler = startHandler;
+      if (startHandler != null) {
+        this.runtimeAboutToStartCallback = (request, context) -> AboutToStartOrSubmitResponse.builder()
+            .data(startHandler.start(startPayload(request, context)))
+            .build();
+      }
+      return this;
+    }
+
+    @SuppressWarnings("unchecked")
+    private CaseDetails<T, S> caseDetails(CallbackRequest request, RuntimeCallback.Context context) {
+      return (CaseDetails<T, S>) context.convertCaseDetails(request.getCaseDetails());
+    }
+
+    @SuppressWarnings("unchecked")
+    private CaseDetails<T, S> caseDetailsBefore(CallbackRequest request, RuntimeCallback.Context context) {
+      return (CaseDetails<T, S>) context.convertCaseDetails(
+          request.getCaseDetailsBefore(),
+          request.getCaseDetails().getCaseTypeId()
+      );
+    }
+
+    @SuppressWarnings("unchecked")
+    private EventPayload<T, S> startPayload(CallbackRequest request, RuntimeCallback.Context context) {
+      return (EventPayload<T, S>) context.startPayload(request);
     }
 
     // Hide lombok's generated builder methods for these fields to stop them polluting the public API.
@@ -216,6 +275,18 @@ public class Event<T, R extends HasRole, S> {
 
     private void dataClass(Class value) {
       this.dataClass = value;
+    }
+
+    private void runtimeAboutToStartCallback(RuntimeCallback<AboutToStartOrSubmitResponse> value) {
+      this.runtimeAboutToStartCallback = value;
+    }
+
+    private void runtimeAboutToSubmitCallback(RuntimeCallback<AboutToStartOrSubmitResponse> value) {
+      this.runtimeAboutToSubmitCallback = value;
+    }
+
+    private void runtimeSubmittedCallback(RuntimeCallback<SubmittedCallbackResponse> value) {
+      this.runtimeSubmittedCallback = value;
     }
 
     private void grants(SetMultimap<R, Permission> value) {

--- a/sdk/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/CaseEventGenerator.java
+++ b/sdk/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/CaseEventGenerator.java
@@ -79,13 +79,13 @@ class CaseEventGenerator<T, S, R extends HasRole> implements ConfigGenerator<T, 
     data.put("SecurityClassification", "Public");
 
     addCallbackIfConfigured(data, callbackHost, event,
-        event.getAboutToStartCallback() != null || event.getStartHandler() != null,
+        event.getRuntimeAboutToStartCallback() != null,
         CallbackMetadata.ABOUT_TO_START);
     addCallbackIfConfigured(data, callbackHost, event,
-        event.getAboutToSubmitCallback() != null,
+        event.getRuntimeAboutToSubmitCallback() != null,
         CallbackMetadata.ABOUT_TO_SUBMIT);
     addCallbackIfConfigured(data, callbackHost, event,
-        event.getSubmittedCallback() != null,
+        event.getRuntimeSubmittedCallback() != null,
         CallbackMetadata.SUBMITTED);
 
     return result;

--- a/sdk/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/runtime/CcdCallbackExecutor.java
+++ b/sdk/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/runtime/CcdCallbackExecutor.java
@@ -29,6 +29,24 @@ public class CcdCallbackExecutor {
   private final ResolvedConfigRegistry registry;
   private final ObjectMapper mapper;
   private final Map<String, JavaType> caseTypeToJavaType = Maps.newHashMap();
+  private final RuntimeCallback.Context callbackContext = new RuntimeCallback.Context() {
+
+    @Override
+    public CaseDetails<?, ?> convertCaseDetails(uk.gov.hmcts.reform.ccd.client.model.CaseDetails ccdDetails) {
+      return CcdCallbackExecutor.this.convertCaseDetails(ccdDetails);
+    }
+
+    @Override
+    public CaseDetails<?, ?> convertCaseDetails(uk.gov.hmcts.reform.ccd.client.model.CaseDetails ccdDetails,
+                                                String caseType) {
+      return CcdCallbackExecutor.this.convertCaseDetails(ccdDetails, caseType);
+    }
+
+    @Override
+    public EventPayload<?, ?> startPayload(CallbackRequest request) {
+      return CcdCallbackExecutor.this.startPayload(request);
+    }
+  };
 
   @Autowired
   public CcdCallbackExecutor(ResolvedConfigRegistry registry, ObjectMapper mapper) {
@@ -45,41 +63,20 @@ public class CcdCallbackExecutor {
   public AboutToStartOrSubmitResponse aboutToStart(CallbackRequest request) {
     log.info("About to start event ID: {}", request.getEventId());
 
-    var event = findCaseEvent(request);
-
-    if (event.getStartHandler() != null) {
-      var config = registry.getRequired(request.getCaseDetails().getCaseTypeId());
-      String json = mapper.writeValueAsString(request.getCaseDetails().getData());
-      var domainClass = mapper.readValue(json, config.getCaseClass());
-      EventPayload payload = new EventPayload<>(
-          request.getCaseDetails().getId(),
-          domainClass,
-          new LinkedMultiValueMap<>()
-      );
-
-      var response = event.getStartHandler().start(payload);
-      return AboutToStartOrSubmitResponse.builder().data(response).build();
-    }
-
-    return findCallback(request, Event::getAboutToStartCallback)
-        .handle(convertCaseDetails(request.getCaseDetails()));
+    return findCallback(request, Event::getRuntimeAboutToStartCallback).invoke(request, callbackContext);
   }
 
   @SneakyThrows
   public AboutToStartOrSubmitResponse aboutToSubmit(CallbackRequest request) {
     log.info("About to submit event ID: {}", request.getEventId());
 
-    return findCallback(request, Event::getAboutToSubmitCallback)
-        .handle(convertCaseDetails(request.getCaseDetails()),
-            convertCaseDetails(request.getCaseDetailsBefore(), request.getCaseDetails().getCaseTypeId()));
+    return findCallback(request, Event::getRuntimeAboutToSubmitCallback).invoke(request, callbackContext);
   }
 
   @SneakyThrows
   public SubmittedCallbackResponse submitted(CallbackRequest request) {
     log.info("Submitted event ID: {}", request.getEventId());
-    return findCallback(request, Event::getSubmittedCallback)
-        .handle(convertCaseDetails(request.getCaseDetails()),
-            convertCaseDetails(request.getCaseDetailsBefore(), request.getCaseDetails().getCaseTypeId()));
+    return findCallback(request, Event::getRuntimeSubmittedCallback).invoke(request, callbackContext);
   }
 
   @SneakyThrows
@@ -144,7 +141,18 @@ public class CcdCallbackExecutor {
     }
 
     String json = mapper.writeValueAsString(ccdDetails);
-    CaseDetails result = mapper.readValue(json, caseTypeToJavaType.get(caseType));
-    return result;
+    return mapper.readValue(json, caseTypeToJavaType.get(caseType));
+  }
+
+  @SneakyThrows
+  EventPayload<?, ?> startPayload(CallbackRequest request) {
+    var config = registry.getRequired(request.getCaseDetails().getCaseTypeId());
+    String json = mapper.writeValueAsString(request.getCaseDetails().getData());
+    var domainClass = mapper.readValue(json, config.getCaseClass());
+    return new EventPayload<>(
+        request.getCaseDetails().getId(),
+        domainClass,
+        new LinkedMultiValueMap<>()
+    );
   }
 }

--- a/sdk/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/runtime/RuntimeCallback.java
+++ b/sdk/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/runtime/RuntimeCallback.java
@@ -1,0 +1,23 @@
+package uk.gov.hmcts.ccd.sdk.runtime;
+
+import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
+import uk.gov.hmcts.ccd.sdk.api.EventPayload;
+import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
+
+@FunctionalInterface
+public interface RuntimeCallback<R> {
+
+  R invoke(CallbackRequest request, Context context);
+
+  interface Context {
+
+    CaseDetails<?, ?> convertCaseDetails(uk.gov.hmcts.reform.ccd.client.model.CaseDetails ccdDetails);
+
+    CaseDetails<?, ?> convertCaseDetails(
+        uk.gov.hmcts.reform.ccd.client.model.CaseDetails ccdDetails,
+        String caseType
+    );
+
+    EventPayload<?, ?> startPayload(CallbackRequest request);
+  }
+}

--- a/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/impl/LegacyCallbackSubmissionHandler.java
+++ b/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/impl/LegacyCallbackSubmissionHandler.java
@@ -102,7 +102,7 @@ class LegacyCallbackSubmissionHandler implements CaseSubmissionHandler {
     var response = new DecentralisedSubmitEventResponse();
     EventMetadata eventMetadata = null;
 
-    if (eventConfig.getAboutToSubmitCallback() != null) {
+    if (eventConfig.getRuntimeAboutToSubmitCallback() != null) {
       CallbackRequest request = buildCallbackRequest(event);
       AboutToStartOrSubmitResponse callbackResponse = executor.aboutToSubmit(request);
       eventMetadata = callbackResponse.getEventMetadata();
@@ -125,7 +125,7 @@ class LegacyCallbackSubmissionHandler implements CaseSubmissionHandler {
       response.setWarnings(callbackResponse.getWarnings());
     }
 
-    boolean hasSubmitted = eventConfig.getSubmittedCallback() != null;
+    boolean hasSubmitted = eventConfig.getRuntimeSubmittedCallback() != null;
     return new LegacySubmitOutcome(response, eventMetadata, hasSubmitted);
   }
 
@@ -134,7 +134,7 @@ class LegacyCallbackSubmissionHandler implements CaseSubmissionHandler {
     String eventId = event.getEventDetails().getEventId();
     Event<?, ?, ?> eventConfig = registry.getRequiredEvent(caseType, eventId);
 
-    if (eventConfig.getSubmittedCallback() == null) {
+    if (eventConfig.getRuntimeSubmittedCallback() == null) {
       return Optional.empty();
     }
 


### PR DESCRIPTION
Refactors resolved events so runtime callback dispatch is represented by a single wire-level callback invoker, while the existing SDK callback builder methods bind lambdas into that runtime form.

This keeps the existing public callback builder API in place, removes the duplicate typed callback state from resolved events, and lets the centralised and decentralised legacy callback paths dispatch through the same runtime callback fields.

Verified with:
./gradlew :sdk:ccd-config-generator:compileJava :sdk:decentralised-runtime:compileJava --no-daemon
./gradlew :sdk:ccd-config-generator:test :sdk:decentralised-runtime:test --no-daemon
./gradlew check -x :wa-task-management-api:check --no-daemon

The unscoped local check currently fails in the populated wa-task-management-api submodule because its checkstyle tasks look for config/checkstyle/checkstyle.xml in this repo root.