### PR TITLE
Bump ccd-lib to 0.19.2186

### DIFF
--- a/sdk/decentralised-runtime/build.gradle
+++ b/sdk/decentralised-runtime/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     implementation platform(SpringBootPlugin.BOM_COORDINATES)
     implementation project(':ccd-config-generator')
     // A filtered set of useful CCD POJOs including DTOs and other utilities.
-    implementation ('com.github.hmcts.rse-cft-lib:ccd-lib:0.19.1953') {
+    implementation ('com.github.hmcts.rse-cft-lib:ccd-lib:0.19.2186') {
         transitive = false
     }
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-web'


### PR DESCRIPTION
Bumps the decentralised runtime ccd-lib dependency to 0.19.2186.