### PR TITLE
Handle additive CCD case details fields

### DIFF
--- a/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/config/CcdWireFormatConfiguration.java
+++ b/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/config/CcdWireFormatConfiguration.java
@@ -1,0 +1,34 @@
+package uk.gov.hmcts.ccd.sdk.config;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.context.annotation.Bean;
+import uk.gov.hmcts.ccd.domain.model.definition.CaseDetails;
+
+@AutoConfiguration
+public class CcdWireFormatConfiguration {
+
+  /**
+   * Make CCD's CaseDetails class forward compatible to new fields
+   * by mixing in a @JsonIgnoreProperties during deserialisation.
+   */
+  @Bean
+  public static BeanPostProcessor ccdCaseDetailsUnknownFieldsObjectMapperPostProcessor() {
+    return new BeanPostProcessor() {
+      @Override
+      public Object postProcessBeforeInitialization(Object bean, String beanName) throws BeansException {
+        if (bean instanceof ObjectMapper mapper) {
+          mapper.addMixIn(CaseDetails.class, IgnoreUnknownCcdCaseDetails.class);
+        }
+        return bean;
+      }
+    };
+  }
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  private interface IgnoreUnknownCcdCaseDetails {
+  }
+}

--- a/sdk/decentralised-runtime/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/sdk/decentralised-runtime/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,3 +1,4 @@
+uk.gov.hmcts.ccd.sdk.config.CcdWireFormatConfiguration
 uk.gov.hmcts.ccd.sdk.config.DecentralisedDataConfiguration
 uk.gov.hmcts.ccd.sdk.config.DefinitionMapperConfiguration
 uk.gov.hmcts.ccd.config.MessagingPropertiesAutoConfiguration

--- a/test-projects/e2e/src/cftlibTest/java/uk/gov/hmcts/divorce/cftlib/TestWithCCD.java
+++ b/test-projects/e2e/src/cftlibTest/java/uk/gov/hmcts/divorce/cftlib/TestWithCCD.java
@@ -663,6 +663,8 @@ public class TestWithCCD extends CftlibTest {
         caseDetails.put("case_data", Map.of());
         caseDetails.put("security_classification", "PUBLIC");
         caseDetails.put("version", 1);
+        // Simulates CCD adding another top-level CaseDetails field.
+        caseDetails.put("future_callback_message", "hello here is a random new field!");
 
         Map<String, Object> payload = Map.of(
             "internal_case_id", internalCaseId,


### PR DESCRIPTION
CCD can add fields to the CaseDetails payload sent to decentralised persistence controllers. Services using the SDK deserialize that payload with their application ObjectMapper, which may be strict and may not use Spring Boot's Jackson builder customizers.

This adds decentralised runtime auto-configuration that registers a CaseDetails mix-in on ObjectMapper beans so additive CaseDetails fields are ignored. It also extends the CFTLib persistence-controller test payload with an unknown CaseDetails field so the direct wire format path is covered.
