### PR TITLE
Stop Renovate proposing Boot 4 dependency lines

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -22,6 +22,43 @@
         "org.springframework.boot"
       ],
       "enabled": false
+    },
+    {
+      "description": "Spring Cloud 2025.1.x targets Spring Boot 4; keep this repo on the Boot 3 compatible 2025.0.x line.",
+      "matchPackageNames": [
+        "org.springframework.cloud:spring-cloud-dependencies"
+      ],
+      "allowedVersions": "/^2025\\.0\\./"
+    },
+    {
+      "description": "Azure Spring 7.x targets Spring Boot 4; keep this repo on the Boot 3 compatible 6.x line.",
+      "matchPackageNames": [
+        "com.azure.spring:spring-cloud-azure-dependencies",
+        "com.azure.spring:spring-cloud-azure-starter-servicebus-jms"
+      ],
+      "allowedVersions": "<7.0.0"
+    },
+    {
+      "description": "These HMCTS client major versions target Spring Boot 4; keep this repo on the Boot 3 compatible lines.",
+      "matchPackageNames": [
+        "com.github.hmcts:service-auth-provider-java-client",
+        "com.github.hmcts:core-case-data-store-client"
+      ],
+      "allowedVersions": "<6.0.0"
+    },
+    {
+      "description": "IDAM client 4.x targets Spring Boot 4; keep this repo on the Boot 3 compatible 3.x line.",
+      "matchPackageNames": [
+        "com.github.hmcts:idam-java-client"
+      ],
+      "allowedVersions": "<4.0.0"
+    },
+    {
+      "description": "Case document AM client 1.60.x targets Spring Boot 4; keep this repo on the Boot 3 compatible 1.59.x line.",
+      "matchPackageNames": [
+        "com.github.hmcts:ccd-case-document-am-client"
+      ],
+      "allowedVersions": "<1.60.0"
     }
   ]
 }


### PR DESCRIPTION
Stops Renovate proposing dependency lines that target Spring Boot 4 while this repo remains on Spring Boot 3.

The rules keep Spring Cloud, Azure Spring and the affected HMCTS clients on their Boot 3-compatible lines until a deliberate Boot 4 migration is done.

Validated with jq against .github/renovate.json.