### PR TITLE
Rename runtime indexing module and support multiple ES hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,11 +82,14 @@ For decentralised services you can opt in to specialised runtime features:
 ```groovy
 ccd {
   decentralised = true
-  runtimeIndexing = true // brings the decentralised Elasticsearch indexer into the main runtime classpath
+  runtimeIndexing = true // brings ccd-runtime-indexing into the main runtime classpath
 }
 ```
 
 When `runtimeIndexing` is enabled the decentralised indexer now relies on Spring’s scheduling infrastructure. Ensure the application that boots the SDK is annotated with `@EnableScheduling` so the indexer starts and stops with the rest of the Spring context.
+
+Set `ELASTIC_SEARCH_HOSTS` to the Elasticsearch HTTP endpoint or a comma-separated list of endpoints. For example:
+`ELASTIC_SEARCH_HOSTS=http://es-1:9200,http://es-2:9200`.
 
 ### Config generation
 

--- a/build.gradle
+++ b/build.gradle
@@ -75,7 +75,7 @@ subprojects.each { subproject ->
                 // Ensure the local SDK projects are packaged so they appear on the manifest classpath
                 task.dependsOn gradle.includedBuild('sdk').task(':ccd-config-generator:jar')
                 task.dependsOn gradle.includedBuild('sdk').task(':decentralised-runtime:jar')
-                task.dependsOn gradle.includedBuild('sdk').task(':cftlib-dev-only:jar')
+                task.dependsOn gradle.includedBuild('sdk').task(':ccd-runtime-indexing:jar')
                 task.dependsOn gradle.includedBuild('sdk').task(':ccd-servicebus-support:jar')
                 task.dependsOn gradle.includedBuild('sdk').task(':task-management:jar')
             }

--- a/docs/decentralised-runtime.md
+++ b/docs/decentralised-runtime.md
@@ -162,6 +162,10 @@ The SDK maintains a queue of cases requiring Elasticsearch indexing in `ccd.es_q
 
 - **Reindex helper:** `CaseReindexingService` (in `sdk/decentralised-runtime`) lets you count and enqueue cases modified since a given date. Autowire the bean and call `enqueueCasesModifiedSince(LocalDate)` to repopulate `ccd.es_queue` without bumping `case_revision`; the decentralised indexer uses `EXTERNAL_GTE` so same-revision rewrites are accepted while older revisions still conflict.
 
+The runtime indexer is provided by the `ccd-runtime-indexing` module when `runtimeIndexing = true`.
+Configure the target cluster with `ELASTIC_SEARCH_HOSTS`; multiple hosts can be supplied as a comma-separated
+list, for example `ELASTIC_SEARCH_HOSTS=http://es-1:9200,http://es-2:9200`.
+
 
 ## Transaction control
 

--- a/sdk/ccd-gradle-plugin/src/main/groovy/uk/gov/hmcts/ccd/sdk/CcdSdkPlugin.java
+++ b/sdk/ccd-gradle-plugin/src/main/groovy/uk/gov/hmcts/ccd/sdk/CcdSdkPlugin.java
@@ -81,7 +81,7 @@ public class CcdSdkPlugin implements Plugin<Project> {
         String version = getVersion();
         project.getDependencies().add("implementation", "com.github.hmcts:decentralised-runtime:"
             + version);
-        String dependencyNotation = "com.github.hmcts:cftlib-dev-only:" + version;
+        String dependencyNotation = "com.github.hmcts:ccd-runtime-indexing:" + version;
         if (config.runtimeIndexing) {
           project.getDependencies().add("implementation", dependencyNotation);
         } else {

--- a/sdk/ccd-runtime-indexing/build.gradle
+++ b/sdk/ccd-runtime-indexing/build.gradle
@@ -16,6 +16,9 @@ dependencies {
 
     compileOnly 'org.projectlombok:lombok:1.18.46'
     annotationProcessor 'org.projectlombok:lombok:1.18.46'
+
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 java {
@@ -28,4 +31,8 @@ tasks.withType(Javadoc).configureEach {
     // Module intentionally exposes no public API; allow empty javadoc output without breaking publishes.
     failOnError = false
     options.addBooleanOption("Xdoclint:none", true)
+}
+
+tasks.withType(Test).configureEach {
+    useJUnitPlatform()
 }

--- a/sdk/ccd-runtime-indexing/src/main/java/uk/gov/hmcts/ccd/sdk/DecentralisedESIndexer.java
+++ b/sdk/ccd-runtime-indexing/src/main/java/uk/gov/hmcts/ccd/sdk/DecentralisedESIndexer.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.ccd.sdk;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -38,12 +39,46 @@ class DecentralisedESIndexer implements DisposableBean {
   @Autowired
   public DecentralisedESIndexer(JdbcTemplate jdbcTemplate, TransactionTemplate transactionTemplate,
                                 @Value("${ELASTIC_SEARCH_HOSTS:http://localhost:9200}")
-                                String elasticSearchHost) {
+                                String elasticSearchHosts) {
     this.jdbcTemplate = jdbcTemplate;
     this.transactionTemplate = transactionTemplate;
-    this.client = RestClient.builder(HttpHost.create(elasticSearchHost)).build();
+    var hosts = parseElasticSearchHosts(elasticSearchHosts);
+    this.client = RestClient.builder(hosts)
+        .setFailureListener(new RestClient.FailureListener() {
+          @Override
+          public void onFailure(org.elasticsearch.client.Node node) {
+            log.warn("Decentralised ES indexer marked Elasticsearch host {} as failed", node.getHost());
+          }
+        })
+        .build();
 
-    log.info("Starting decentralised ES indexer targeting {}", elasticSearchHost);
+    log.info("Starting decentralised ES indexer targeting {}", Arrays.toString(hosts));
+  }
+
+  static HttpHost[] parseElasticSearchHosts(String elasticSearchHosts) {
+    if (elasticSearchHosts == null || elasticSearchHosts.trim().isEmpty()) {
+      throw new IllegalArgumentException("ELASTIC_SEARCH_HOSTS must contain at least one Elasticsearch host");
+    }
+
+    var entries = elasticSearchHosts.split(",", -1);
+    var hosts = new HttpHost[entries.length];
+    for (int i = 0; i < entries.length; i++) {
+      var host = entries[i].trim();
+      if (host.isEmpty()) {
+        throw new IllegalArgumentException("ELASTIC_SEARCH_HOSTS contains an empty host entry");
+      }
+      try {
+        hosts[i] = HttpHost.create(host);
+        if (hosts[i].getHostName() == null
+            || hosts[i].getHostName().isBlank()
+            || hosts[i].getHostName().startsWith(":")) {
+          throw new IllegalArgumentException("Host name must not be blank");
+        }
+      } catch (IllegalArgumentException ex) {
+        throw new IllegalArgumentException("Invalid Elasticsearch host in ELASTIC_SEARCH_HOSTS: " + host, ex);
+      }
+    }
+    return hosts;
   }
 
   @Scheduled(fixedDelayString = "${ccd.sdk.decentralised.poll-interval-ms:250}")

--- a/sdk/ccd-runtime-indexing/src/test/java/uk/gov/hmcts/ccd/sdk/DecentralisedESIndexerTest.java
+++ b/sdk/ccd-runtime-indexing/src/test/java/uk/gov/hmcts/ccd/sdk/DecentralisedESIndexerTest.java
@@ -1,0 +1,71 @@
+package uk.gov.hmcts.ccd.sdk;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class DecentralisedESIndexerTest {
+
+  @Test
+  void parsesSingleHostWithScheme() {
+    var hosts = DecentralisedESIndexer.parseElasticSearchHosts("https://es-master:9243");
+
+    assertThat(hosts).hasSize(1);
+    assertThat(hosts[0].getSchemeName()).isEqualTo("https");
+    assertThat(hosts[0].getHostName()).isEqualTo("es-master");
+    assertThat(hosts[0].getPort()).isEqualTo(9243);
+  }
+
+  @Test
+  void parsesSingleHostWithoutSchemeAsHttp() {
+    var hosts = DecentralisedESIndexer.parseElasticSearchHosts("es-master:9200");
+
+    assertThat(hosts).hasSize(1);
+    assertThat(hosts[0].getSchemeName()).isEqualTo("http");
+    assertThat(hosts[0].getHostName()).isEqualTo("es-master");
+    assertThat(hosts[0].getPort()).isEqualTo(9200);
+  }
+
+  @Test
+  void parsesMultipleCommaSeparatedHosts() {
+    var hosts = DecentralisedESIndexer.parseElasticSearchHosts(
+        "http://es-one:9200,https://es-two:9243,es-three:9200");
+
+    assertThat(hosts).hasSize(3);
+    assertThat(hosts[0].toURI()).isEqualTo("http://es-one:9200");
+    assertThat(hosts[1].toURI()).isEqualTo("https://es-two:9243");
+    assertThat(hosts[2].toURI()).isEqualTo("http://es-three:9200");
+  }
+
+  @Test
+  void trimsWhitespaceAroundHosts() {
+    var hosts = DecentralisedESIndexer.parseElasticSearchHosts(" http://es-one:9200 , es-two:9200 ");
+
+    assertThat(hosts).hasSize(2);
+    assertThat(hosts[0].toURI()).isEqualTo("http://es-one:9200");
+    assertThat(hosts[1].toURI()).isEqualTo("http://es-two:9200");
+  }
+
+  @Test
+  void rejectsBlankHostConfiguration() {
+    assertThatThrownBy(() -> DecentralisedESIndexer.parseElasticSearchHosts("  "))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("ELASTIC_SEARCH_HOSTS must contain at least one Elasticsearch host");
+  }
+
+  @Test
+  void rejectsEmptyCommaSeparatedEntry() {
+    assertThatThrownBy(() -> DecentralisedESIndexer.parseElasticSearchHosts("http://es-one:9200, ,es-two:9200"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("ELASTIC_SEARCH_HOSTS contains an empty host entry");
+  }
+
+  @Test
+  void rejectsMalformedHost() {
+    assertThatThrownBy(() -> DecentralisedESIndexer.parseElasticSearchHosts("http://:9200"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid Elasticsearch host in ELASTIC_SEARCH_HOSTS: http://:9200")
+        .hasCauseInstanceOf(IllegalArgumentException.class);
+  }
+}

--- a/sdk/settings.gradle
+++ b/sdk/settings.gradle
@@ -1,1 +1,1 @@
-include 'ccd-gradle-plugin', 'ccd-config-generator', 'decentralised-runtime', 'cftlib-dev-only', 'ccd-servicebus-support', 'task-management'
+include 'ccd-gradle-plugin', 'ccd-config-generator', 'decentralised-runtime', 'ccd-runtime-indexing', 'ccd-servicebus-support', 'task-management'


### PR DESCRIPTION
Renames the former cftlib-dev-only SDK module to ccd-runtime-indexing now that the Elasticsearch indexer is part of the decentralised runtime path rather than dev-only wiring.

The indexer now accepts a comma-separated ELASTIC_SEARCH_HOSTS value and passes the parsed hosts to the Elasticsearch REST client, preserving existing single-host values while allowing the client to rotate across multiple nodes and mark failed nodes. The SDK plugin now pulls in the renamed artifact, and the runtime docs describe the host configuration format.