### PR TITLE
Clarify testing strategy guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,17 +14,11 @@
 
 gradlew `e2e:cftlibtest` runs a `CallbackLoggingFilter` that captures every HTTP request/response hitting the embedded CCD stack (callbacks plus persistence endpoints) and writes JSON lines to `build/logs/http-traffic.log`. Use that file when you need to inspect payloads instead of relying on stdout.
 
-# To run all tests
-
-./gradlew -i allTests
-
-# Style
-
-Max line length 120 chars
-
 # Dirs
 
 /sdk - contains the CCD SDK tooling
+
+# Automated tests must adhere to guidance in docs/testing-strategy.md
 
 # CCD & Architecture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -3,6 +3,13 @@
 The SDK's tests are primarily [Cftlib](https://github.com/hmcts/rse-cft-lib)-based functional tests
 that run against an isolated full CCD stack.
 
+Test behaviour rather than implementation. Avoid mocks unless there is no practical integration or full-stack route.
+
+Prefer Spring integration tests or `e2e:cftlibTest` full-stack tests for SDK behaviour; prefer adding new assertions to existing tests where appropriate.
+
+Config generator changes should be covered by extending the existing JSON diff-based golden files.
+
+Changes that deviate from this strategy should explain why in the PR.
 
 ## Data Migration and CCD Definition Diff Checks
 


### PR DESCRIPTION
Updates the agent guidance to point test changes at the testing strategy document and clarifies the expected testing approach for SDK and config generator changes.