### PR TITLE
Quote FDW setup identifiers

### DIFF
--- a/scripts/setup-ccd-data-fdw.sh
+++ b/scripts/setup-ccd-data-fdw.sh
@@ -151,14 +151,14 @@ setup_fdw() {
   log "Creating FDW server, user mapping and foreign tables..."
 
   psql_dst <<'SQL'
-create schema if not exists :fdw_schema;
+create schema if not exists :"fdw_schema";
 
-drop foreign table if exists :fdw_schema.case_event;
-drop foreign table if exists :fdw_schema.case_data;
+drop foreign table if exists :"fdw_schema".case_event;
+drop foreign table if exists :"fdw_schema".case_data;
 
-drop server if exists :fdw_server cascade;
+drop server if exists :"fdw_server" cascade;
 
-create server :fdw_server
+create server :"fdw_server"
 foreign data wrapper postgres_fdw
 options (
   host :'src_host',
@@ -168,17 +168,17 @@ options (
 );
 
 create user mapping for :local_user_sql
-server :fdw_server
+server :"fdw_server"
 options (
   user :'src_user',
   password :'src_password'
 );
 
-create foreign table :fdw_schema.case_data (
+create foreign table :"fdw_schema".case_data (
   reference bigint,
   version integer,
   created_date timestamp without time zone,
-  security_classification :dst_schema.securityclassification,
+  security_classification :"dst_schema".securityclassification,
   last_state_modified_date timestamp without time zone,
   resolved_ttl date,
   last_modified timestamp without time zone,
@@ -190,16 +190,16 @@ create foreign table :fdw_schema.case_data (
   id bigint,
   case_revision bigint
 )
-server :fdw_server
+server :"fdw_server"
 options (
   schema_name :'src_schema',
   table_name 'case_data'
 );
 
-create foreign table :fdw_schema.case_event (
+create foreign table :"fdw_schema".case_event (
   id bigint,
   created_date timestamp without time zone,
-  security_classification :dst_schema.securityclassification,
+  security_classification :"dst_schema".securityclassification,
   case_data_id bigint,
   case_type_version integer,
   event_id varchar(70),
@@ -220,7 +220,7 @@ create foreign table :fdw_schema.case_event (
   version integer,
   case_revision bigint
 )
-server :fdw_server
+server :"fdw_server"
 options (
   schema_name :'src_schema',
   table_name 'case_event'
@@ -232,9 +232,9 @@ grant_fdw_access() {
   log "Granting FDW access to ${LOCAL_USER_SQL}..."
 
   psql_dst <<'SQL'
-grant usage on foreign server :fdw_server to :local_user_sql;
-grant usage on schema :fdw_schema to :local_user_sql;
-grant select on :fdw_schema.case_data, :fdw_schema.case_event to :local_user_sql;
+grant usage on foreign server :"fdw_server" to :local_user_sql;
+grant usage on schema :"fdw_schema" to :local_user_sql;
+grant select on :"fdw_schema".case_data, :"fdw_schema".case_event to :local_user_sql;
 SQL
 }
 
@@ -247,13 +247,13 @@ select 'fdw case_event table' as check_name, to_regclass(:'fdw_schema' || '.case
 
 select 'source case_data reachable' as check_name, exists(
   select 1
-  from :fdw_schema.case_data
+  from :"fdw_schema".case_data
   limit 1
 ) as reachable;
 
 select 'source case_event reachable' as check_name, exists(
   select 1
-  from :fdw_schema.case_event
+  from :"fdw_schema".case_event
   limit 1
 ) as reachable;
 SQL

--- a/scripts/test-migrate-ccd-data-fdw.sh
+++ b/scripts/test-migrate-ccd-data-fdw.sh
@@ -15,6 +15,7 @@ FAILURE_LOG="/tmp/test-migrate-ccd-data-fdw-failure-$$.log"
 FDW_SRC_HOST="${FDW_SRC_HOST:-localhost}"
 FDW_SRC_PORT="${FDW_SRC_PORT:-5432}"
 FDW_SRC_SSLMODE="${FDW_SRC_SSLMODE:-disable}"
+FDW_SERVER="${FDW_SERVER:-source-server-with-dashes.example.test}"
 
 init_migration_test_env "fdw"
 trap cleanup_temp_dbs EXIT
@@ -30,6 +31,7 @@ run_fdw_setup() {
     SRC_PASSWORD="$PG_PASSWORD" \
     SRC_SSLMODE="$FDW_SRC_SSLMODE" \
     FDW_SCHEMA="$FDW_SCHEMA" \
+    FDW_SERVER="$FDW_SERVER" \
     LOCAL_USER_SQL="current_user" \
     "$SETUP_SCRIPT"
 
@@ -43,6 +45,7 @@ run_fdw_setup() {
     SRC_PASSWORD="$PG_PASSWORD" \
     SRC_SSLMODE="$FDW_SRC_SSLMODE" \
     FDW_SCHEMA="$FDW_SCHEMA" \
+    FDW_SERVER="$FDW_SERVER" \
     LOCAL_USER_SQL="current_user" \
     "$SETUP_SCRIPT" --apply
 }
@@ -59,13 +62,19 @@ run_fdw_migration() {
 }
 
 assert_fdw_setup() {
-  local extension_count foreign_table_count source_case_count
+  local extension_count foreign_server_count foreign_table_count source_case_count
 
   echo "Validating FDW setup"
   extension_count="$(psql_dst --quiet -tA <<'SQL'
 select count(*)
 from pg_extension
 where extname in ('postgres_fdw', 'pgcrypto');
+SQL
+)"
+  foreign_server_count="$(psql_dst --quiet -tA --set=fdw_server="$FDW_SERVER" <<'SQL'
+select count(*)
+from pg_foreign_server
+where srvname = :'fdw_server';
 SQL
 )"
   foreign_table_count="$(psql_dst --quiet -tA <<SQL
@@ -86,9 +95,10 @@ where case_type_id = :'case_type';
 SQL
 )"
 
-  if [[ "$extension_count" != "2" || "$foreign_table_count" != "2" || "$source_case_count" != "2" ]]; then
+  if [[ "$extension_count" != "2" || "$foreign_server_count" != "1" || "$foreign_table_count" != "2" || "$source_case_count" != "2" ]]; then
     echo "FDW setup validation failed:" \
-      "extensions=${extension_count}, tables=${foreign_table_count}, source_cases=${source_case_count}" >&2
+      "extensions=${extension_count}, server=${foreign_server_count}," \
+      "tables=${foreign_table_count}, source_cases=${source_case_count}" >&2
     exit 1
   fi
 }


### PR DESCRIPTION
## Summary
- quote dynamic FDW schema and server identifiers in setup SQL
- cover hostname-style FDW server names in the FDW migration test script

## Root cause
Postgres parsed an unquoted FDW server name like et-cos-postgres-v15-demo.postgres.database.azure.com as SQL syntax rather than as an identifier.

## Validation
- bash -n scripts/setup-ccd-data-fdw.sh scripts/test-migrate-ccd-data-fdw.sh scripts/migrate-ccd-data-fdw.sh

Full Gradle verification was attempted, but the run failed before the FDW scripts because Docker already had port 8080 bound and the docassembly service could not start.