### PR TITLE
Bump SDK Azure Service Bus dependencies

### DIFF
--- a/sdk/ccd-servicebus-support/build.gradle
+++ b/sdk/ccd-servicebus-support/build.gradle
@@ -2,6 +2,13 @@ dependencyManagement {
     imports {
         mavenBom 'com.azure.spring:spring-cloud-azure-dependencies:6.4.0'
     }
+    dependencies {
+        dependency 'com.azure:azure-core:1.58.1'
+        dependency 'com.azure:azure-core-amqp:2.12.0'
+        dependency 'com.azure:azure-core-http-netty:1.16.5'
+        dependency 'com.azure:azure-core-management:1.19.5'
+        dependency 'com.microsoft.azure:msal4j:1.25.0'
+    }
 }
 
 dependencies {


### PR DESCRIPTION
Pins newer stable Azure core and MSAL transitive dependencies in the SDK Service Bus support module while keeping Spring Cloud Azure on 6.4.0.