### PR TITLE
Filter FDW case events by case type

### DIFF
--- a/docs/fdw-data-migration.md
+++ b/docs/fdw-data-migration.md
@@ -138,8 +138,15 @@ Optional environment variables:
 ```bash
 export DST_SCHEMA='ccd'          # defaults to ccd
 export FDW_SCHEMA='fdw_stage'    # defaults to fdw_stage
+export CASE_REVISION_OFFSET='1000000000'
 export DELTA_SINCE=''            # empty means full load
 ```
+
+`CASE_REVISION_OFFSET` is added to `ccd.case_data.case_revision` after event revisions are
+recalculated. The decentralised Elasticsearch indexer uses `case_data.case_revision` as the
+external Elasticsearch version, so the default high offset lets reindexed migrated cases overwrite
+any existing central CCD Elasticsearch document with a lower revision. Migrated `case_event`
+revisions remain sequential from `1` per case.
 
 Validate before applying:
 
@@ -196,7 +203,8 @@ The migration script:
 * upserts `case_event` rows from `fdw_stage.case_event` for cases already loaded into `ccd.case_data`
 * reruns `case_data` upsert to catch parent cases changed while events were copying
 * recalculates `case_event.version` and `case_event.case_revision`
-* updates `case_data.case_revision` with target triggers suppressed
+* updates `case_data.case_revision` to the max event revision plus `CASE_REVISION_OFFSET`, with
+  target triggers suppressed
 * checks for orphaned events
 * restores the event revision unique index and FK
 * resets `case_event_id_seq`

--- a/docs/fdw-data-migration.md
+++ b/docs/fdw-data-migration.md
@@ -199,14 +199,16 @@ only.
 The migration script:
 
 * temporarily drops the `case_event` FK and event revision unique index
+* temporarily disables `case_event` user triggers so delta upserts do not write audit rows
 * upserts `case_data` rows from `fdw_stage.case_data` with target triggers suppressed
 * upserts `case_event` rows from `fdw_stage.case_event` for cases already loaded into `ccd.case_data`
 * reruns `case_data` upsert to catch parent cases changed while events were copying
+* reruns `case_event` upsert to catch events for cases loaded or updated by the second `case_data` pass
 * recalculates `case_event.version` and `case_event.case_revision`
 * updates `case_data.case_revision` to the max event revision plus `CASE_REVISION_OFFSET`, with
   target triggers suppressed
 * checks for orphaned events
-* restores the event revision unique index and FK
+* restores the event revision unique index, FK and `case_event` user triggers
 * resets `case_event_id_seq`
 * runs final validation for counts, orphan events, duplicate event revisions and case revision alignment
 

--- a/scripts/migrate-ccd-data-fdw.sh
+++ b/scripts/migrate-ccd-data-fdw.sh
@@ -207,6 +207,9 @@ alter table :dst_schema.case_event
 drop constraint if exists case_event_case_data_id_fkey;
 
 drop index if exists :dst_schema.idx_case_event_case_data_revision_unique;
+
+alter table :dst_schema.case_event
+disable trigger user;
 SQL
 
   CONSTRAINTS_DROPPED=true
@@ -295,6 +298,9 @@ load_case_events() {
   log "Loading/upserting case_event with temporary version/case_revision values..."
 
   psql_dst <<'SQL'
+begin;
+set local session_replication_role = replica;
+
 insert into :dst_schema.case_event (
     id,
     created_date,
@@ -371,6 +377,8 @@ set
     proxied_by = excluded.proxied_by,
     proxied_by_first_name = excluded.proxied_by_first_name,
     proxied_by_last_name = excluded.proxied_by_last_name;
+
+commit;
 SQL
 }
 
@@ -449,6 +457,9 @@ add constraint case_event_case_data_id_fkey
 foreign key (case_data_id)
 references :dst_schema.case_data(id)
 on delete cascade;
+
+alter table :dst_schema.case_event
+enable trigger user;
 SQL
   then
     CONSTRAINTS_DROPPED=false
@@ -581,6 +592,8 @@ main() {
 
   # Important: catch parent cases created while events were being copied.
   load_case_data
+  # Then catch events for cases loaded or updated by the second case_data pass.
+  load_case_events
 
   recalculate_revisions
   validate_no_orphans

--- a/scripts/migrate-ccd-data-fdw.sh
+++ b/scripts/migrate-ccd-data-fdw.sh
@@ -29,6 +29,7 @@ DST_SCHEMA="${DST_SCHEMA:-ccd}"
 FDW_SCHEMA="${FDW_SCHEMA:-fdw_stage}"
 
 CASE_TYPE_IDS_SQL="${CASE_TYPE_IDS_SQL:-'TEST_CASE_TYPE'}"
+CASE_REVISION_OFFSET="${CASE_REVISION_OFFSET:-1000000000}"
 
 # Optional. Empty means full load.
 # Example: DELTA_SINCE="2026-04-30 10:00:00"
@@ -56,11 +57,13 @@ Environment variables:
   DST_SCHEMA
   FDW_SCHEMA
   CASE_TYPE_IDS_SQL
+  CASE_REVISION_OFFSET optional; defaults to 1000000000
   DELTA_SINCE optional, e.g. "2026-04-30 10:00:00"
 
 Example:
   export DST_DSN='postgresql://user:pass@dest.postgres.database.azure.com:5432/appdb?sslmode=require'
   export CASE_TYPE_IDS_SQL="'ET_EnglandWales','ET_Scotland','ET_Admin'"
+  export CASE_REVISION_OFFSET='1000000000'
 
   ./scripts/migrate-ccd-data-fdw.sh
   ./scripts/migrate-ccd-data-fdw.sh --apply
@@ -97,6 +100,13 @@ require_psql() {
   fi
 }
 
+validate_case_revision_offset() {
+  if [[ ! "$CASE_REVISION_OFFSET" =~ ^[0-9]+$ ]]; then
+    log "ERROR: CASE_REVISION_OFFSET must be a non-negative integer"
+    exit 1
+  fi
+}
+
 psql_dst() {
   psql "$DST_DSN" \
     --set=ON_ERROR_STOP=on \
@@ -104,6 +114,7 @@ psql_dst() {
     --set=dst_schema="$DST_SCHEMA" \
     --set=fdw_schema="$FDW_SCHEMA" \
     --set=case_type_ids="$CASE_TYPE_IDS_SQL" \
+    --set=case_revision_offset="$CASE_REVISION_OFFSET" \
     --set=delta_since="$DELTA_SINCE" \
     "$@"
 }
@@ -390,7 +401,7 @@ begin;
 set local session_replication_role = replica;
 
 update :dst_schema.case_data cd
-set case_revision = evt.event_count
+set case_revision = evt.event_count + (:case_revision_offset)::bigint
 from (
     select
         case_data_id,
@@ -503,7 +514,8 @@ with case_revision_check as (
         cd.id,
         cd.case_revision,
         count(ce.id)::bigint as event_count,
-        coalesce(max(ce.case_revision), 0)::bigint as max_event_revision
+        coalesce(max(ce.case_revision), 0)::bigint as max_event_revision,
+        coalesce(max(ce.case_revision), 0)::bigint + (:case_revision_offset)::bigint as expected_case_revision
     from :dst_schema.case_data cd
     left join :dst_schema.case_event ce
       on ce.case_data_id = cd.id
@@ -512,8 +524,8 @@ with case_revision_check as (
 )
 select count(*)
 from case_revision_check
-where case_revision is distinct from event_count
-   or case_revision is distinct from max_event_revision;
+where case_revision is distinct from expected_case_revision
+   or event_count is distinct from max_event_revision;
 SQL
 )"
 
@@ -546,8 +558,10 @@ cleanup_on_exit() {
 main() {
   parse_args "$@"
   require_psql
+  validate_case_revision_offset
 
   log "DELTA_SINCE=${DELTA_SINCE:-<empty: full load>}"
+  log "CASE_REVISION_OFFSET=${CASE_REVISION_OFFSET}"
 
   validate_connection
   validate_can_disable_triggers

--- a/scripts/migrate-ccd-data-fdw.sh
+++ b/scripts/migrate-ccd-data-fdw.sh
@@ -335,6 +335,7 @@ from :fdw_schema.case_event ce
 join :dst_schema.case_data cd
   on cd.id = ce.case_data_id
 where cd.case_type_id in (:case_type_ids)
+and ce.case_type_id in (:case_type_ids)
 and (
     nullif(:'delta_since', '') is null
     or ce.created_date >= nullif(:'delta_since', '')::timestamp

--- a/scripts/migrate-ccd-data-fdw.sh
+++ b/scripts/migrate-ccd-data-fdw.sh
@@ -203,6 +203,8 @@ prepare_target() {
   log "Dropping constraints/indexes that block placeholder event revisions..."
 
   psql_dst <<'SQL'
+begin;
+
 alter table :dst_schema.case_event
 drop constraint if exists case_event_case_data_id_fkey;
 
@@ -210,6 +212,8 @@ drop index if exists :dst_schema.idx_case_event_case_data_revision_unique;
 
 alter table :dst_schema.case_event
 disable trigger user;
+
+commit;
 SQL
 
   CONSTRAINTS_DROPPED=true

--- a/scripts/migrate-ccd-data.sh
+++ b/scripts/migrate-ccd-data.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 SRC_DSN="${SRC_DSN:-postgresql://postgres:postgres@localhost:6432/datastore}"
 DST_DSN="${DST_DSN:-postgresql://postgres:postgres@localhost:6432/postgres}"
 CASE_TYPE="${CASE_TYPE:-TEST_CASE_TYPE}"
+CASE_REVISION_OFFSET="${CASE_REVISION_OFFSET:-1000000000}"
 DO_APPLY=false
 
 log() {
@@ -14,6 +15,13 @@ log() {
 require_psql() {
   if ! command -v psql >/dev/null 2>&1; then
     log "ERROR: psql is required on PATH"
+    exit 1
+  fi
+}
+
+validate_case_revision_offset() {
+  if [[ ! "$CASE_REVISION_OFFSET" =~ ^[0-9]+$ ]]; then
+    log "ERROR: CASE_REVISION_OFFSET must be a non-negative integer"
     exit 1
   fi
 }
@@ -201,7 +209,7 @@ EOF
 }
 
 align_case_revisions() {
-  log "Aligning case_data.case_revision with migrated event counts..."
+  log "Aligning case_data.case_revision with migrated event counts plus offset..."
   # We have seen CCD cases where case versions and event counts drift; ensure revisions match event history
   # before enforcing any uniqueness or writing new events.
   psql "$DST_DSN" --set=ON_ERROR_STOP=on --no-psqlrc --quiet <<EOF
@@ -215,11 +223,11 @@ WITH ev AS (
   GROUP BY cd.id
 )
 UPDATE ccd.case_data cd
-SET case_revision = ev.event_count
+SET case_revision = ev.event_count + ${CASE_REVISION_OFFSET}
 FROM ev
 WHERE cd.id = ev.case_data_id
   AND cd.case_type_id = '${CASE_TYPE}'
-  AND cd.case_revision IS DISTINCT FROM ev.event_count;
+  AND cd.case_revision IS DISTINCT FROM ev.event_count + ${CASE_REVISION_OFFSET};
 COMMIT;
 EOF
 }
@@ -253,6 +261,8 @@ report_counts() {
 main() {
   parse_args "$@"
   require_psql
+  validate_case_revision_offset
+  log "CASE_REVISION_OFFSET=${CASE_REVISION_OFFSET}"
   validate_connections
   validate_can_disable_triggers
   validate_target_empty

--- a/scripts/migration-test/lib.sh
+++ b/scripts/migration-test/lib.sh
@@ -12,6 +12,7 @@ PG_PASSWORD="${PG_PASSWORD:-postgres}"
 CASE_TYPE="${CASE_TYPE:-CriminalInjuriesCompensation}"
 OTHER_CASE_TYPE="${OTHER_CASE_TYPE:-OtherCaseType}"
 FDW_SCHEMA="${FDW_SCHEMA:-fdw_stage}"
+CASE_REVISION_OFFSET="${CASE_REVISION_OFFSET:-1000000000}"
 
 export PGPASSWORD="$PG_PASSWORD"
 
@@ -47,6 +48,7 @@ psql_src() {
     --no-psqlrc \
     --set=case_type="$CASE_TYPE" \
     --set=other_case_type="$OTHER_CASE_TYPE" \
+    --set=case_revision_offset="$CASE_REVISION_OFFSET" \
     "$@"
 }
 
@@ -56,6 +58,7 @@ psql_dst() {
     --no-psqlrc \
     --set=case_type="$CASE_TYPE" \
     --set=other_case_type="$OTHER_CASE_TYPE" \
+    --set=case_revision_offset="$CASE_REVISION_OFFSET" \
     "$@"
 }
 
@@ -173,14 +176,15 @@ SQL
 assert_case_revision_alignment() {
   local mismatch_count
 
-  echo "Validating migrated case revisions match event counts and max revisions"
+  echo "Validating migrated case revisions match event revisions plus offset"
   mismatch_count="$(psql_dst --quiet -tA <<'SQL'
 with revision_check as (
     select
         cd.id,
         cd.case_revision,
         count(ce.id)::bigint as event_count,
-        coalesce(max(ce.case_revision), 0)::bigint as max_event_revision
+        coalesce(max(ce.case_revision), 0)::bigint as max_event_revision,
+        coalesce(max(ce.case_revision), 0)::bigint + :'case_revision_offset'::bigint as expected_case_revision
     from ccd.case_data cd
     left join ccd.case_event ce
       on ce.case_data_id = cd.id
@@ -189,8 +193,8 @@ with revision_check as (
 )
 select count(*)
 from revision_check
-where case_revision is distinct from event_count
-   or case_revision is distinct from max_event_revision;
+where case_revision is distinct from expected_case_revision
+   or event_count is distinct from max_event_revision;
 SQL
 )"
 

--- a/scripts/test-migrate-ccd-data-fdw.sh
+++ b/scripts/test-migrate-ccd-data-fdw.sh
@@ -57,6 +57,7 @@ run_fdw_migration() {
     DST_DSN="$DST_DSN" \
     FDW_SCHEMA="$FDW_SCHEMA" \
     CASE_TYPE_IDS_SQL="'${CASE_TYPE}'" \
+    CASE_REVISION_OFFSET="$CASE_REVISION_OFFSET" \
     "${extra_env[@]}" \
     "$MIGRATION_SCRIPT" --apply
 }
@@ -168,7 +169,11 @@ assert_case_event_constraints_present
 assert_constraints_restored_after_failure
 
 echo "Running FDW migration script (validation mode only)"
-DST_DSN="$DST_DSN" FDW_SCHEMA="$FDW_SCHEMA" CASE_TYPE_IDS_SQL="'${CASE_TYPE}'" "$MIGRATION_SCRIPT"
+DST_DSN="$DST_DSN" \
+  FDW_SCHEMA="$FDW_SCHEMA" \
+  CASE_TYPE_IDS_SQL="'${CASE_TYPE}'" \
+  CASE_REVISION_OFFSET="$CASE_REVISION_OFFSET" \
+  "$MIGRATION_SCRIPT"
 
 echo "Running FDW migration script (apply mode)"
 run_fdw_migration


### PR DESCRIPTION
## Summary
- add a direct case_type_id predicate to the FDW case_event load
- add CASE_REVISION_OFFSET for migrated case_data.case_revision, defaulting to 1000000000
- apply the same revision offset behaviour to the classic and FDW migration scripts
- document and test the revision offset behaviour

## Why
The rehearsal showed the case_event load spending hours inside postgres_fdw. The existing query filtered via the local case_data join, which may require more remote event rows to be fetched before filtering.

The decentralised Elasticsearch indexer uses case_data.case_revision as the external Elasticsearch version. Raising migrated case revisions helps reindexed migrated cases overwrite any existing central CCD Elasticsearch document with a lower revision while leaving migrated case_event revisions sequential per case.

## Validation
- bash -n scripts/migrate-ccd-data.sh scripts/migrate-ccd-data-fdw.sh scripts/test-migrate-ccd-data.sh scripts/test-migrate-ccd-data-fdw.sh scripts/migration-test/lib.sh
- git diff --check -- scripts/migrate-ccd-data.sh scripts/migrate-ccd-data-fdw.sh scripts/test-migrate-ccd-data.sh scripts/test-migrate-ccd-data-fdw.sh scripts/migration-test/lib.sh docs/fdw-data-migration.md
- ./gradlew verifyCcdMigration was attempted locally, but the CFT environment stayed at repeated DB not yet available messages before reaching the migration scripts.