### PR TITLE
Suppress triggers for all migration writes

### DIFF
--- a/scripts/migrate-ccd-data-fdw.sh
+++ b/scripts/migrate-ccd-data-fdw.sh
@@ -393,6 +393,9 @@ recalculate_revisions() {
 create index if not exists idx_tmp_case_event_case_data_id_id
 on :dst_schema.case_event (case_data_id, id);
 
+begin;
+set local session_replication_role = replica;
+
 update :dst_schema.case_event t
 set
     version = s.rn::int,
@@ -408,6 +411,8 @@ from (
     where case_type_id in (:case_type_ids)
 ) s
 where t.id = s.id;
+
+commit;
 
 begin;
 set local session_replication_role = replica;

--- a/scripts/migrate-ccd-data.sh
+++ b/scripts/migrate-ccd-data.sh
@@ -177,6 +177,8 @@ COPY (
 EOF
 )
   insert_sql=$(cat <<'EOF'
+BEGIN;
+SET LOCAL session_replication_role = replica;
 COPY ccd.case_event (
     id,
     created_date,
@@ -201,6 +203,7 @@ COPY ccd.case_event (
     proxied_by_last_name,
     idempotency_key
 ) FROM STDIN WITH (FORMAT CSV);
+COMMIT;
 EOF
 )
 

--- a/scripts/migration-test/lib.sh
+++ b/scripts/migration-test/lib.sh
@@ -93,6 +93,29 @@ delete from ccd.case_data;
 SQL
 }
 
+install_trigger_guards() {
+  echo "Installing target trigger guards"
+  psql_dst <<'SQL'
+create or replace function ccd.fail_if_migration_trigger_fires()
+returns trigger as $$
+begin
+    raise exception 'Migration write trigger fired on %.% during %',
+        tg_table_schema, tg_table_name, tg_op;
+end;
+$$ language plpgsql;
+
+drop trigger if exists migration_test_case_data_guard on ccd.case_data;
+create trigger migration_test_case_data_guard
+before insert or update on ccd.case_data
+for each row execute function ccd.fail_if_migration_trigger_fires();
+
+drop trigger if exists migration_test_case_event_guard on ccd.case_event;
+create trigger migration_test_case_event_guard
+before insert or update on ccd.case_event
+for each row execute function ccd.fail_if_migration_trigger_fires();
+SQL
+}
+
 assert_target_empty() {
   local dst_cases dst_events
 

--- a/scripts/test-migrate-ccd-data-fdw.sh
+++ b/scripts/test-migrate-ccd-data-fdw.sh
@@ -163,6 +163,7 @@ SQL
 create_temp_dbs
 seed_source_data
 clear_target_data
+install_trigger_guards
 run_fdw_setup
 assert_fdw_setup
 assert_case_event_constraints_present

--- a/scripts/test-migrate-ccd-data.sh
+++ b/scripts/test-migrate-ccd-data.sh
@@ -14,6 +14,7 @@ trap cleanup_temp_dbs EXIT
 create_temp_dbs
 seed_source_data
 clear_target_data
+install_trigger_guards
 
 assert_case_event_constraints_present
 


### PR DESCRIPTION
## Summary
- run the FDW case-event revision update with transaction-local trigger suppression
- run the classic case-event COPY with transaction-local trigger suppression
- install fail-fast case_data and case_event triggers in both migration test paths

## Why
The bulk case-data and FDW case-event imports already used session_replication_role = replica, but the FDW case-event revision update and classic case-event COPY did not. Those writes could therefore invoke application, revision, or indexing triggers during migration.

SET LOCAL limits replica mode to the current transaction and automatically restores normal trigger behaviour at COMMIT or rollback, so the change cannot leave triggers disabled for later application traffic.

## Validation
- bash -n scripts/migrate-ccd-data-fdw.sh scripts/migrate-ccd-data.sh scripts/migration-test/lib.sh scripts/test-migrate-ccd-data.sh scripts/test-migrate-ccd-data-fdw.sh
- git diff --check
- ./gradlew verifyCcdMigration -i was attempted locally, but the CFT environment remained at Idam not ready before reaching the migration tests; the PR migration-check will run the database regression in CI