### PR TITLE
Require decentralised flag for runtime indexing

### DIFF
--- a/sdk/ccd-runtime-indexing/src/main/java/uk/gov/hmcts/ccd/sdk/DecentralisedESIndexer.java
+++ b/sdk/ccd-runtime-indexing/src/main/java/uk/gov/hmcts/ccd/sdk/DecentralisedESIndexer.java
@@ -23,8 +23,7 @@ import org.springframework.transaction.support.TransactionTemplate;
 
 @ConditionalOnProperty(
     name = "ccd.sdk.decentralised",
-    havingValue = "true",
-    matchIfMissing = true)
+    havingValue = "true")
 @Component
 @Slf4j
 class DecentralisedESIndexer implements DisposableBean {

--- a/sdk/ccd-runtime-indexing/src/test/java/uk/gov/hmcts/ccd/sdk/DecentralisedESIndexerTest.java
+++ b/sdk/ccd-runtime-indexing/src/test/java/uk/gov/hmcts/ccd/sdk/DecentralisedESIndexerTest.java
@@ -1,11 +1,41 @@
 package uk.gov.hmcts.ccd.sdk;
 
-import org.junit.jupiter.api.Test;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+import org.springframework.transaction.support.TransactionTemplate;
+
 class DecentralisedESIndexerTest {
+
+  private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+      .withUserConfiguration(DecentralisedESIndexer.class)
+      .withBean(JdbcTemplate.class, () -> new JdbcTemplate(new DriverManagerDataSource()))
+      .withBean(TransactionTemplate.class, () ->
+          new TransactionTemplate(new DataSourceTransactionManager(new DriverManagerDataSource())));
+
+  @Test
+  void doesNotStartIndexerWhenDecentralisedConfigurationIsMissing() {
+    contextRunner.run(context -> assertThat(context).doesNotHaveBean(DecentralisedESIndexer.class));
+  }
+
+  @Test
+  void doesNotStartIndexerWhenDecentralisedConfigurationIsFalse() {
+    contextRunner
+        .withPropertyValues("ccd.sdk.decentralised=false")
+        .run(context -> assertThat(context).doesNotHaveBean(DecentralisedESIndexer.class));
+  }
+
+  @Test
+  void startsIndexerWhenDecentralisedConfigurationIsTrue() {
+    contextRunner
+        .withPropertyValues("ccd.sdk.decentralised=true")
+        .run(context -> assertThat(context).hasSingleBean(DecentralisedESIndexer.class));
+  }
 
   @Test
   void parsesSingleHostWithScheme() {


### PR DESCRIPTION
## Summary

- require `ccd.sdk.decentralised=true` before creating the runtime Elasticsearch indexer
- keep the indexer disabled when the property is missing or explicitly false
- cover the missing, false, and true activation states with application-context tests

## Why

The ET application artifact includes the runtime indexing module because its Gradle configuration enables both decentralised support and runtime indexing. Production is not currently running in decentralised mode and does not set `CCD_SDK_DECENTRALISED`.

Previously, `matchIfMissing=true` treated that absent production setting as enabled. The application could therefore start the indexer against the ET database and poll `ccd.es_queue`. Production also has no `ELASTIC_SEARCH_HOSTS` value, so any indexing request would default to `http://localhost:9200`.

The current FDW migration suppresses database triggers and does not populate `ccd.es_queue`, so the migrated rows themselves would not be indexed immediately. However, any existing queue entries or normal updates made after migration could be picked up and trigger Elasticsearch indexing attempts. Requiring the explicit decentralised flag removes that risk.

## Impact

- non-decentralised environments no longer start or poll the runtime indexer
- decentralised environments with `CCD_SDK_DECENTRALISED=true` retain the existing indexing behaviour

## Validation

- `./gradlew -p sdk :ccd-runtime-indexing:test`
