### PR TITLE
Add ES indexer poller switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ When `runtimeIndexing` is enabled the decentralised indexer now relies on Spring
 Set `ELASTIC_SEARCH_HOSTS` to the Elasticsearch HTTP endpoint or a comma-separated list of endpoints. For example:
 `ELASTIC_SEARCH_HOSTS=http://es-1:9200,http://es-2:9200`.
 
+The poller is enabled by default. To leave the runtime indexing library on the classpath while temporarily
+disabling the decentralised Elasticsearch poller, set
+`CCD_SDK_DECENTRALISED_ES_INDEXER_ENABLED=false`.
+
 ### Config generation
 
 The `generateCCDConfig` task generates the configuration in JSON format to the configured folder:

--- a/sdk/ccd-runtime-indexing/src/main/java/uk/gov/hmcts/ccd/sdk/DecentralisedESIndexer.java
+++ b/sdk/ccd-runtime-indexing/src/main/java/uk/gov/hmcts/ccd/sdk/DecentralisedESIndexer.java
@@ -22,7 +22,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.support.TransactionTemplate;
 
 @ConditionalOnProperty(
-    name = "ccd.sdk.decentralised",
+    name = "ccd.sdk.decentralised.es-indexer.enabled",
     havingValue = "true",
     matchIfMissing = true)
 @Component

--- a/sdk/ccd-runtime-indexing/src/test/java/uk/gov/hmcts/ccd/sdk/DecentralisedESIndexerTest.java
+++ b/sdk/ccd-runtime-indexing/src/test/java/uk/gov/hmcts/ccd/sdk/DecentralisedESIndexerTest.java
@@ -1,11 +1,41 @@
 package uk.gov.hmcts.ccd.sdk;
 
-import org.junit.jupiter.api.Test;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+import org.springframework.transaction.support.TransactionTemplate;
+
 class DecentralisedESIndexerTest {
+
+  private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+      .withUserConfiguration(DecentralisedESIndexer.class)
+      .withBean(JdbcTemplate.class, () -> new JdbcTemplate(new DriverManagerDataSource()))
+      .withBean(TransactionTemplate.class, () ->
+          new TransactionTemplate(new DataSourceTransactionManager(new DriverManagerDataSource())));
+
+  @Test
+  void startsIndexerWhenIndexerConfigurationIsMissing() {
+    contextRunner.run(context -> assertThat(context).hasSingleBean(DecentralisedESIndexer.class));
+  }
+
+  @Test
+  void doesNotStartIndexerWhenDisabled() {
+    contextRunner
+        .withPropertyValues("ccd.sdk.decentralised.es-indexer.enabled=false")
+        .run(context -> assertThat(context).doesNotHaveBean(DecentralisedESIndexer.class));
+  }
+
+  @Test
+  void startsIndexerWhenExplicitlyEnabled() {
+    contextRunner
+        .withPropertyValues("ccd.sdk.decentralised.es-indexer.enabled=true")
+        .run(context -> assertThat(context).hasSingleBean(DecentralisedESIndexer.class));
+  }
 
   @Test
   void parsesSingleHostWithScheme() {


### PR DESCRIPTION
## Summary

- add a dedicated runtime switch for the decentralised Elasticsearch poller
- leave the poller enabled by default so existing decentralised services retain their behaviour
- document `CCD_SDK_DECENTRALISED_ES_INDEXER_ENABLED=false` for deployments that need to suppress polling temporarily

## Why

ET needs to disable the runtime Elasticsearch poller during its initial migration without changing the decentralised Gradle configuration, which controls runtime dependencies and classpath composition.

## Impact

Setting `CCD_SDK_DECENTRALISED_ES_INDEXER_ENABLED=false` prevents `DecentralisedESIndexer` from being created. The runtime indexing library remains available on the application classpath.

## Validation

- `./gradlew -p sdk :ccd-runtime-indexing:test`
