### PR TITLE
Fix FDW migration test harness

### DIFF
--- a/scripts/migration-test/lib.sh
+++ b/scripts/migration-test/lib.sh
@@ -32,6 +32,8 @@ init_migration_test_env() {
 }
 
 cleanup_temp_dbs() {
+  local exit_code=$?
+
   for db in "$SRC_DB" "$DST_DB"; do
     "$PSQL_BIN" -d "${BASE_DSN}/postgres" "${BASE_CONN_ARGS[@]}" --set=ON_ERROR_STOP=on --command \
       "select pg_terminate_backend(pid) from pg_stat_activity where datname = '${db}' and pid <> pg_backend_pid();" \
@@ -40,6 +42,8 @@ cleanup_temp_dbs() {
 
   "$DROPDB_BIN" "${BASE_CONN_ARGS[@]}" --if-exists "$SRC_DB" >/dev/null 2>&1 || true
   "$DROPDB_BIN" "${BASE_CONN_ARGS[@]}" --if-exists "$DST_DB" >/dev/null 2>&1 || true
+
+  return "$exit_code"
 }
 
 psql_src() {

--- a/scripts/test-migrate-ccd-data-fdw.sh
+++ b/scripts/test-migrate-ccd-data-fdw.sh
@@ -51,14 +51,19 @@ run_fdw_setup() {
 }
 
 run_fdw_migration() {
-  local extra_env=("${@:1}")
+  local env_args=(
+    "DST_DSN=$DST_DSN"
+    "FDW_SCHEMA=$FDW_SCHEMA"
+    "CASE_TYPE_IDS_SQL='${CASE_TYPE}'"
+    "CASE_REVISION_OFFSET=$CASE_REVISION_OFFSET"
+  )
+
+  if (($# > 0)); then
+    env_args+=("$@")
+  fi
 
   env \
-    DST_DSN="$DST_DSN" \
-    FDW_SCHEMA="$FDW_SCHEMA" \
-    CASE_TYPE_IDS_SQL="'${CASE_TYPE}'" \
-    CASE_REVISION_OFFSET="$CASE_REVISION_OFFSET" \
-    "${extra_env[@]}" \
+    "${env_args[@]}" \
     "$MIGRATION_SCRIPT" --apply
 }
 


### PR DESCRIPTION
This fixes the FDW migration test harness so the apply path runs on macOS Bash 3.2. The helper now builds a non-empty env argument array before appending optional overrides, avoiding `extra_env[@]: unbound variable` when no overrides are passed.

The shared cleanup trap now preserves the script's original exit code after dropping temp databases. That keeps setup or migration failures visible instead of letting successful cleanup make the harness look green.

Verified locally with the FDW migration harness, the classic migration harness, `git diff --check`, and a negative run using an invalid Postgres port to confirm failures still exit non-zero.
