### PR TITLE
Bump ET CCD callbacks submodule

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -15,6 +15,11 @@ gradle.beforeProject { p ->
         // Prevent subproject build.gradle from failing on wrapper { }.
         p.ext.wrapper = { Closure c -> }
     }
+    if (p.path == ':et-shared') {
+        def etProject = gradle.rootProject.findProject(':et')
+        p.ext.jacksonVersion = etProject.jacksonVersion
+        p.ext.jacksonAnnotationsVersion = etProject.jacksonAnnotationsVersion
+    }
 }
 
 include 'test-projects'


### PR DESCRIPTION
This updates the ET CCD callbacks test project submodule to the latest hmcts/et-ccd-callbacks master commit.

The new pointer includes the latest decentralisation SDK update and the ES indexer disablement change from ET callbacks.
