### PR TITLE
Update CaseLocation.java

### DIFF
--- a/sdk/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/type/CaseLocation.java
+++ b/sdk/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/type/CaseLocation.java
@@ -7,23 +7,23 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import uk.gov.hmcts.ccd.sdk.api.ComplexType;
 
-@NoArgsConstructor
-@Builder
-@Data
-@ComplexType(name = "CaseLocation")
-public class CaseLocation {
-
-  @JsonProperty("Region")
-  private String region;
-
-  @JsonProperty("BaseLocation")
-  private String baseLocation;
-
-  @JsonCreator
-  public CaseLocation(@JsonProperty("Region") String region,
-                      @JsonProperty("BaseLocation") String baseLocation) {
-    this.region = region;
-    this.baseLocation = baseLocation;
-  }
-
-}
+@NoArgsConstructor                                                                                                                                                                                                                     
+  @Builder                                                                                                                                                                                                                               
+  @Data                                                                                                                                                                                                                                  
+  @ComplexType(name = "CaseLocation")                                                                                                                                                                                                    
+  public class CaseLocation {                                                                                                                                                                                                            
+                                                                                                                                                                                                                                         
+    @JsonProperty("region")                                                                                                                                                                                                              
+    private String region;                                                                                                                                                                                                               
+                                                                                                                                                                                                                                         
+    @JsonProperty("baseLocation")                                                                                                                                                                                                        
+    private String baseLocation;                                                                                                                                                                                                         
+                                                                                                                                                                                                                                         
+    @JsonCreator                                                                                                                                                                                                                         
+    public CaseLocation(                                                                                                                                                                                                                 
+        @JsonProperty("region") @JsonAlias("Region") String region,                                                                                                                                                                      
+        @JsonProperty("baseLocation") @JsonAlias("BaseLocation") String baseLocation) {                                                                                                                                                  
+      this.region = region;                                                                                                                                                                                                              
+      this.baseLocation = baseLocation;                                                                                                                                                                                                  
+    }                                                                                                                                                                                                                                    
+  }                 

--- a/sdk/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/type/CaseLocation.java
+++ b/sdk/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/type/CaseLocation.java
@@ -7,23 +7,23 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import uk.gov.hmcts.ccd.sdk.api.ComplexType;
 
-@NoArgsConstructor                                                                                                                                                                                                                     
-  @Builder                                                                                                                                                                                                                               
-  @Data                                                                                                                                                                                                                                  
-  @ComplexType(name = "CaseLocation")                                                                                                                                                                                                    
-  public class CaseLocation {                                                                                                                                                                                                            
-                                                                                                                                                                                                                                         
-    @JsonProperty("region")                                                                                                                                                                                                              
-    private String region;                                                                                                                                                                                                               
-                                                                                                                                                                                                                                         
-    @JsonProperty("baseLocation")                                                                                                                                                                                                        
-    private String baseLocation;                                                                                                                                                                                                         
-                                                                                                                                                                                                                                         
-    @JsonCreator                                                                                                                                                                                                                         
-    public CaseLocation(                                                                                                                                                                                                                 
-        @JsonProperty("region") @JsonAlias("Region") String region,                                                                                                                                                                      
-        @JsonProperty("baseLocation") @JsonAlias("BaseLocation") String baseLocation) {                                                                                                                                                  
-      this.region = region;                                                                                                                                                                                                              
-      this.baseLocation = baseLocation;                                                                                                                                                                                                  
-    }                                                                                                                                                                                                                                    
-  }                 
+@NoArgsConstructor
+@Builder
+@Data
+@ComplexType(name = "CaseLocation")
+public class CaseLocation {
+
+  @JsonProperty("region")
+  private String region;
+
+  @JsonProperty("baseLocation")
+  private String baseLocation;
+
+  @JsonCreator
+  public CaseLocation(@JsonProperty("region") String region,
+                      @JsonProperty("baseLocation") String baseLocation) {
+    this.region = region;
+    this.baseLocation = baseLocation;
+  }
+
+}


### PR DESCRIPTION
### Change description ###
Update CaseLocation complex type to use what XUI actually looks for. 

[Jira](https://tools.hmcts.net/jira/browse/HDPI-7335)

With the update we now see:

<img width="2146" height="282" alt="image" src="https://github.com/user-attachments/assets/7ba81e32-ddb8-49fd-9df1-1486e515ef5c" />

Instead of:
<img width="2832" height="248" alt="image" src="https://github.com/user-attachments/assets/11f4868c-aa26-42bd-b734-cbaefb3823eb" />




Context:
When global search is used, a few fields are shown as a summary to the user. (screenshot).
You can see in the screenshot that these fields have been populated, except for Location.

Theory:
There is a case mismatch between what XUI is looking for, and what the config-gen makes.

Evidence:

I can see my caseManagementLocation data is populated in the index, just like our other self populating fields: <img width="760" height="170" alt="image" src="https://github.com/user-attachments/assets/65c49ae5-f9f1-46da-93b8-78d86ee52a3c" />

I have confirmed using the location APIs, that the two values provided should return a value, and that it does exist  court name is further down in data)
<img width="736" height="252" alt="image" src="https://github.com/user-attachments/assets/aa0f7df2-0fd8-4b60-8d9d-0e3f42611f4f" />



Network tab when making the search uses lowercase regionId and baseLocationId 
<img width="876" height="228" alt="image" src="https://github.com/user-attachments/assets/903a5a52-f469-44eb-8805-3b881c364f5b" />

CaseLocation in config generation uses uppercase Region and BaseLocation (noticeably not baseLocationId for some reason)  
<img width="351" height="210" alt="image" src="https://github.com/user-attachments/assets/fa0e769b-53f0-413d-81d4-c5bf6ef2545e" />


Checking other services index in aat shows lowercase usage:
<img width="568" height="138" alt="image" src="https://github.com/user-attachments/assets/32e23f40-af4e-4bf3-ba56-a2510816fda1" />

But I haven't got a user to check whether this populates correctly, I am assuming it does.

Civil Possessions have actually created their own Java type instead of using SDK which uses lowercase shown [here](https://github.com/hmcts/civil-service/blob/bd7032e00bc5b726d3ab83c44b0aef3e8ea2a92f/src/main/java/uk/gov/hmcts/reform/civil/model/genapplication/CaseLocationCivil.java#L12)
<img width="776" height="318" alt="image" src="https://github.com/user-attachments/assets/2f80a59b-0105-4c93-b468-cf03b35148fd" />



