### PR TITLE
HDPI-6452: Add FieldType enum value for DynamicList

### DIFF
--- a/sdk/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/type/FieldType.java
+++ b/sdk/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/type/FieldType.java
@@ -20,6 +20,7 @@ public enum FieldType {
   Collection,
   Label,
   CasePaymentHistoryViewer,
+  DynamicList,
   DynamicRadioList,
   DynamicMultiSelectList,
   Flags,

--- a/sdk/ccd-config-generator/src/test/java/uk/gov/hmcts/reform/fpl/model/CaseData.java
+++ b/sdk/ccd-config-generator/src/test/java/uk/gov/hmcts/reform/fpl/model/CaseData.java
@@ -399,10 +399,16 @@ public class CaseData {
   private String paymentHistoryField;
 
   @CCD(
-    label = "Select the solicitor PBA number you wish to use",
+    label = "Select the solicitor PBA number you wish to use (radio)",
     typeOverride = DynamicRadioList
   )
-  private DynamicList solicitorPbaNumber;
+  private DynamicList solicitorPbaNumberRadio;
+
+  @CCD(
+    label = "Select the solicitor PBA number you wish to use (dropdown)",
+    typeOverride = DynamicList
+  )
+  private DynamicList solicitorPbaNumberDropDown;
 
   @CCD(
     typeOverride = FixedList,

--- a/sdk/ccd-config-generator/src/test/resources/CARE_SUPERVISION_EPO/CaseField.json
+++ b/sdk/ccd-config-generator/src/test/resources/CARE_SUPERVISION_EPO/CaseField.json
@@ -993,8 +993,16 @@
   {
     "CaseTypeID": "CARE_SUPERVISION_EPO",
     "FieldType": "DynamicRadioList",
-    "ID": "solicitorPbaNumber",
-    "Label": "Select the solicitor PBA number you wish to use",
+    "ID": "solicitorPbaNumberRadio",
+    "Label": "Select the solicitor PBA number you wish to use (radio)",
+    "LiveFrom": "01/01/2017",
+    "SecurityClassification": "Public"
+  },
+  {
+    "CaseTypeID": "CARE_SUPERVISION_EPO",
+    "FieldType": "DynamicList",
+    "ID": "solicitorPbaNumberDropDown",
+    "Label": "Select the solicitor PBA number you wish to use (dropdown)",
     "LiveFrom": "01/01/2017",
     "SecurityClassification": "Public"
   },


### PR DESCRIPTION
### Change description ###

Add FieldType enum value for DynamicList. This is so we can use our own `DynamicStringList` implementation class for a DynamicList that takes a String `code` instead of a UUID.
