### PR TITLE
Improve CCD data migration event batching

### DIFF
--- a/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTask.java
+++ b/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTask.java
@@ -249,13 +249,13 @@ public class CcdDataMigrationTask implements Runnable {
         break;
       }
 
-      Long batchStartEventId = nextSourceEventIdAfter(localEventHwm, targetEventHwm);
-      if (batchStartEventId == null) {
+      Long batchEndEventHwm = nextSourceEventBatchEndAfter(localEventHwm, targetEventHwm);
+      if (batchEndEventHwm == null) {
         totals = totals.markCaughtUp();
         break;
       }
 
-      long batchEndEventHwm = batchEndEventHwm(batchStartEventId, targetEventHwm);
+      long batchStartEventId = localEventHwm + 1L;
       int events = transaction.execute(status -> copyNextEventBatch(batchStartEventId, batchEndEventHwm));
       if (events == 0) {
         totals = totals.markCaughtUp();
@@ -522,10 +522,15 @@ public class CcdDataMigrationTask implements Runnable {
     return hwm == null ? 0 : hwm;
   }
 
-  private Long nextSourceEventIdAfter(long localEventHwm, long targetEventHwm) {
+  private Long nextSourceEventBatchEndAfter(long localEventHwm, long targetEventHwm) {
     return db.queryForObject(
         """
-        select min(ce.id)
+        -- The + 0 prevents PostgreSQL's min/max optimisation from walking pk_case_event
+        -- when the case_type_id predicate is sparse on the source CCD table.
+        select coalesce(
+          (array_agg(ce.id + 0 order by ce.id))[:eventBatchSize],
+          max(ce.id + 0)
+        )
         from fdw_stage.case_event ce
         where ce.case_type_id in (:caseTypeIds)
           and ce.id > :localEventHwm
@@ -533,16 +538,10 @@ public class CcdDataMigrationTask implements Runnable {
         """,
         baseParams()
             .addValue("localEventHwm", localEventHwm)
-            .addValue("targetEventHwm", targetEventHwm),
+            .addValue("targetEventHwm", targetEventHwm)
+            .addValue("eventBatchSize", options.eventBatchSize()),
         Long.class
     );
-  }
-
-  private long batchEndEventHwm(long batchStartEventId, long targetEventHwm) {
-    long batchWindowEnd = batchStartEventId > Long.MAX_VALUE - options.eventBatchSize() + 1
-        ? Long.MAX_VALUE
-        : batchStartEventId + options.eventBatchSize() - 1L;
-    return Math.min(batchWindowEnd, targetEventHwm);
   }
 
   private long captureCutoverEventHighWaterMark() {

--- a/sdk/decentralised-runtime/src/test/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTaskIntegrationTest.java
+++ b/sdk/decentralised-runtime/src/test/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTaskIntegrationTest.java
@@ -122,6 +122,22 @@ class CcdDataMigrationTaskIntegrationTest {
   }
 
   @Test
+  void preloadBatchesByMatchingSourceEventsNotGlobalEventIdWindow() {
+    insertSourceCase(10, 1000000000000010L, 1, "Submitted", "{\"field\":\"one\"}");
+    insertSourceCaseEvent(101, 10, "create", "Submitted", "{\"field\":\"one\"}", minutesAgo(60));
+    insertSourceCaseEvent(1001, 10, "update", "Updated", "{\"field\":\"two\"}", minutesAgo(60));
+    insertSourceCaseEvent(2001, 10, "close", "Closed", "{\"field\":\"three\"}", minutesAgo(60));
+    insertSourceCaseEvent(102, 10, "other", "Submitted", "{\"field\":\"other\"}", "OtherCase", minutesAgo(60));
+
+    CcdDataMigrationRunResult result = task(PRELOAD_EVENTS, 2, 1).runMigration();
+
+    assertThat(result.caughtUp()).isFalse();
+    assertThat(result.eventsProcessed()).isEqualTo(2);
+    assertThat(countRows("ccd.case_event")).isEqualTo(2);
+    assertThat(localEventHwm()).isEqualTo(1001);
+  }
+
+  @Test
   void cutoverPausesBeforeFinalRefreshWhenRuntimeLimitStopsEventCopying() {
     insertSourceCase(10, 1000000000000010L, 1, "Submitted", "{\"field\":\"one\"}");
     insertSourceCaseEvent(101, 10, "create", "Submitted", "{\"field\":\"one\"}", minutesAgo(60));


### PR DESCRIPTION
This changes the CCD data migration preload batching so each batch is bounded by the next configured number of matching source events, rather than by the next fixed global CCD event id window.

The previous range calculation was inefficient for sparse case types because a 10,000 id window could contain very few migrated events. The new boundary query is pushed down through FDW and uses the case type predicate when calculating the batch end high-water mark, while the existing range-based copy path remains unchanged.

A regression test covers sparse source event ids to ensure a batch copies the configured number of matching migrated events instead of only the events inside a small global id range.
