### PR TITLE
Disable ES queue during CCD migration

### DIFF
--- a/docs/ccd-data-migration-task.md
+++ b/docs/ccd-data-migration-task.md
@@ -43,9 +43,10 @@ transaction completes.
 
 The `ccd.case_data` Elasticsearch enqueue trigger is disabled while migration work is in progress
 because it fires after inserts and updates on `ccd.case_data` and would otherwise populate
-`ccd.es_queue` with stale revision entries. The queue is truncated when the task starts migration
-work because it is not in use until after cutover, final validation requires it to be empty, and the
-trigger is re-enabled before `CUTOVER` is marked complete.
+`ccd.es_queue` with stale revision entries. Existing queue rows for the migrated case types are
+deleted when the task starts migration work because those case types do not use the queue until after
+cutover. Final validation requires the migrated case types to have no queue rows, and the trigger is
+re-enabled in the same transaction that marks `CUTOVER` complete.
 
 ## Progress
 

--- a/docs/ccd-data-migration-task.md
+++ b/docs/ccd-data-migration-task.md
@@ -41,6 +41,12 @@ The runtime `case_data` revision trigger is deliberately disabled only inside th
 transaction so the final source-derived revision can be written. The trigger is re-enabled before the
 transaction completes.
 
+The `ccd.case_data` Elasticsearch enqueue trigger is disabled while migration work is in progress
+because it fires after inserts and updates on `ccd.case_data` and would otherwise populate
+`ccd.es_queue` with stale revision entries. Any queued rows for the migrating case types are removed
+when the task starts migration work, final validation requires the queue to be empty for those case
+types, and the trigger is re-enabled before `CUTOVER` is marked complete.
+
 ## Progress
 
 The decentralised runtime Flyway migration creates `ccd.ccd_data_migration_progress` with minimal

--- a/docs/ccd-data-migration-task.md
+++ b/docs/ccd-data-migration-task.md
@@ -43,9 +43,9 @@ transaction completes.
 
 The `ccd.case_data` Elasticsearch enqueue trigger is disabled while migration work is in progress
 because it fires after inserts and updates on `ccd.case_data` and would otherwise populate
-`ccd.es_queue` with stale revision entries. Any queued rows for the migrating case types are removed
-when the task starts migration work, final validation requires the queue to be empty for those case
-types, and the trigger is re-enabled before `CUTOVER` is marked complete.
+`ccd.es_queue` with stale revision entries. The queue is truncated when the task starts migration
+work because it is not in use until after cutover, final validation requires it to be empty, and the
+trigger is re-enabled before `CUTOVER` is marked complete.
 
 ## Progress
 

--- a/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTask.java
+++ b/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTask.java
@@ -176,8 +176,11 @@ public class CcdDataMigrationTask implements Runnable {
   private CcdDataMigrationRunResult cutover() {
     Progress progress = getOrCreateProgress();
     if (STATUS_COMPLETE.equals(progress.status())) {
-      enableElasticsearchQueueTrigger();
-      validateFinal(progress.requiredCutoverEventHwm());
+      transaction.execute(status -> {
+        validateFinal(progress.requiredCutoverEventHwm());
+        enableElasticsearchQueueTrigger();
+        return null;
+      });
       return new CcdDataMigrationRunResult(true, 0, 0, 0, true, false);
     }
 
@@ -209,9 +212,7 @@ public class CcdDataMigrationTask implements Runnable {
     }
     final int refreshedCases = refreshCutoverCaseData();
     resetSequences();
-    validateFinal(cutoverEventHwm);
-    enableElasticsearchQueueTrigger();
-    markComplete();
+    completeCutover(cutoverEventHwm);
 
     log.info(
         "Completed CCD data migration cutover taskName={} cutoverEventHwm={} batches={} refreshedCases={} events={} "
@@ -579,6 +580,15 @@ public class CcdDataMigrationTask implements Runnable {
     );
   }
 
+  private void completeCutover(long cutoverEventHwm) {
+    transaction.execute(status -> {
+      validateFinal(cutoverEventHwm);
+      enableElasticsearchQueueTrigger();
+      markComplete();
+      return null;
+    });
+  }
+
   private void validateFinal(long eventHwm) {
     log.info("CCD data migration final counts taskName={} caseData={}", options.taskName(), queryCounts("case_data"));
     log.info("CCD data migration final counts taskName={} caseEvent={}", options.taskName(), queryCounts("case_event"));
@@ -624,17 +634,30 @@ public class CcdDataMigrationTask implements Runnable {
 
   private void prepareElasticsearchQueueForMigration() {
     disableElasticsearchQueueTrigger();
-    truncateElasticsearchQueue();
+    deleteElasticsearchQueueRowsForMigration();
   }
 
-  private void truncateElasticsearchQueue() {
-    db.getJdbcTemplate().execute("truncate table ccd.es_queue");
+  private void deleteElasticsearchQueueRowsForMigration() {
+    db.update(
+        """
+        delete from ccd.es_queue queue
+        using ccd.case_data case_data
+        where queue.reference = case_data.reference
+          and case_data.case_type_id in (:caseTypeIds)
+        """,
+        baseParams()
+    );
   }
 
   private long countElasticsearchQueueRows() {
     Long rows = db.queryForObject(
-        "select count(*) from ccd.es_queue",
-        Map.of(),
+        """
+        select count(*)
+        from ccd.es_queue queue
+        join ccd.case_data case_data on case_data.reference = queue.reference
+        where case_data.case_type_id in (:caseTypeIds)
+        """,
+        baseParams(),
         Long.class
     );
     return rows == null ? 0 : rows;

--- a/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTask.java
+++ b/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTask.java
@@ -582,11 +582,11 @@ public class CcdDataMigrationTask implements Runnable {
   private void validateFinal(long eventHwm) {
     log.info("CCD data migration final counts taskName={} caseData={}", options.taskName(), queryCounts("case_data"));
     log.info("CCD data migration final counts taskName={} caseEvent={}", options.taskName(), queryCounts("case_event"));
-    long esQueueRows = countMigratedElasticsearchQueueRows();
+    long esQueueRows = countElasticsearchQueueRows();
     log.info("CCD data migration final counts taskName={} esQueue={}", options.taskName(), esQueueRows);
     if (esQueueRows > 0) {
       throw new CcdDataMigrationException(
-          "CCD data migration left " + esQueueRows + " Elasticsearch queue rows for migrated case types"
+          "CCD data migration left " + esQueueRows + " Elasticsearch queue rows"
       );
     }
   }
@@ -624,30 +624,17 @@ public class CcdDataMigrationTask implements Runnable {
 
   private void prepareElasticsearchQueueForMigration() {
     disableElasticsearchQueueTrigger();
-    deleteMigratedElasticsearchQueueRows();
+    truncateElasticsearchQueue();
   }
 
-  private void deleteMigratedElasticsearchQueueRows() {
-    db.update(
-        """
-        delete from ccd.es_queue queue
-        using ccd.case_data cd
-        where queue.reference = cd.reference
-          and cd.case_type_id in (:caseTypeIds)
-        """,
-        baseParams()
-    );
+  private void truncateElasticsearchQueue() {
+    db.getJdbcTemplate().execute("truncate table ccd.es_queue");
   }
 
-  private long countMigratedElasticsearchQueueRows() {
+  private long countElasticsearchQueueRows() {
     Long rows = db.queryForObject(
-        """
-        select count(*)
-        from ccd.es_queue queue
-        join ccd.case_data cd on cd.reference = queue.reference
-        where cd.case_type_id in (:caseTypeIds)
-        """,
-        baseParams(),
+        "select count(*) from ccd.es_queue",
+        Map.of(),
         Long.class
     );
     return rows == null ? 0 : rows;

--- a/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTask.java
+++ b/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTask.java
@@ -147,6 +147,7 @@ public class CcdDataMigrationTask implements Runnable {
       );
     }
 
+    prepareElasticsearchQueueForMigration();
     long targetEventHwm = sourceEventHighWaterMark();
     CopyTotals totals = copyEventBatches(targetEventHwm);
     long localEventHwm = localEventHighWaterMark();
@@ -175,10 +176,12 @@ public class CcdDataMigrationTask implements Runnable {
   private CcdDataMigrationRunResult cutover() {
     Progress progress = getOrCreateProgress();
     if (STATUS_COMPLETE.equals(progress.status())) {
+      enableElasticsearchQueueTrigger();
       validateFinal(progress.requiredCutoverEventHwm());
       return new CcdDataMigrationRunResult(true, 0, 0, 0, true, false);
     }
 
+    prepareElasticsearchQueueForMigration();
     long cutoverEventHwm = progress.cutoverEventHwm() == null
         ? captureCutoverEventHighWaterMark()
         : progress.cutoverEventHwm();
@@ -207,6 +210,7 @@ public class CcdDataMigrationTask implements Runnable {
     final int refreshedCases = refreshCutoverCaseData();
     resetSequences();
     validateFinal(cutoverEventHwm);
+    enableElasticsearchQueueTrigger();
     markComplete();
 
     log.info(
@@ -578,6 +582,13 @@ public class CcdDataMigrationTask implements Runnable {
   private void validateFinal(long eventHwm) {
     log.info("CCD data migration final counts taskName={} caseData={}", options.taskName(), queryCounts("case_data"));
     log.info("CCD data migration final counts taskName={} caseEvent={}", options.taskName(), queryCounts("case_event"));
+    long esQueueRows = countMigratedElasticsearchQueueRows();
+    log.info("CCD data migration final counts taskName={} esQueue={}", options.taskName(), esQueueRows);
+    if (esQueueRows > 0) {
+      throw new CcdDataMigrationException(
+          "CCD data migration left " + esQueueRows + " Elasticsearch queue rows for migrated case types"
+      );
+    }
   }
 
   private List<Map<String, Object>> queryCounts(String tableName) {
@@ -611,12 +622,51 @@ public class CcdDataMigrationTask implements Runnable {
         """);
   }
 
+  private void prepareElasticsearchQueueForMigration() {
+    disableElasticsearchQueueTrigger();
+    deleteMigratedElasticsearchQueueRows();
+  }
+
+  private void deleteMigratedElasticsearchQueueRows() {
+    db.update(
+        """
+        delete from ccd.es_queue queue
+        using ccd.case_data cd
+        where queue.reference = cd.reference
+          and cd.case_type_id in (:caseTypeIds)
+        """,
+        baseParams()
+    );
+  }
+
+  private long countMigratedElasticsearchQueueRows() {
+    Long rows = db.queryForObject(
+        """
+        select count(*)
+        from ccd.es_queue queue
+        join ccd.case_data cd on cd.reference = queue.reference
+        where cd.case_type_id in (:caseTypeIds)
+        """,
+        baseParams(),
+        Long.class
+    );
+    return rows == null ? 0 : rows;
+  }
+
   private void disableCaseDataRevisionTrigger() {
     db.getJdbcTemplate().execute("alter table ccd.case_data disable trigger trigger_increment_case_revision");
   }
 
   private void enableCaseDataRevisionTrigger() {
     db.getJdbcTemplate().execute("alter table ccd.case_data enable trigger trigger_increment_case_revision");
+  }
+
+  private void disableElasticsearchQueueTrigger() {
+    db.getJdbcTemplate().execute("alter table ccd.case_data disable trigger trigger_enqueue_case_revision");
+  }
+
+  private void enableElasticsearchQueueTrigger() {
+    db.getJdbcTemplate().execute("alter table ccd.case_data enable trigger trigger_enqueue_case_revision");
   }
 
   private void validateProgressTableReady() {

--- a/sdk/decentralised-runtime/src/test/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTaskIntegrationTest.java
+++ b/sdk/decentralised-runtime/src/test/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTaskIntegrationTest.java
@@ -76,6 +76,8 @@ class CcdDataMigrationTaskIntegrationTest {
     assertThat(caseEventRevision(101)).isEqualTo(1);
     assertThat(caseEventRevision(102)).isEqualTo(2);
     assertThat(caseRevision(10)).isZero();
+    assertElasticsearchQueueEmpty();
+    assertThat(caseDataTriggerEnabled("trigger_enqueue_case_revision")).isFalse();
     assertTargetProtectionsPresent();
   }
 
@@ -100,6 +102,8 @@ class CcdDataMigrationTaskIntegrationTest {
     assertThat(caseEventRevision(102)).isEqualTo(2);
     assertThat(caseRevision(10)).isEqualTo(CASE_REVISION_OFFSET + 2);
     assertThat(caseEventSequenceLastValue()).isGreaterThanOrEqualTo(102);
+    assertElasticsearchQueueEmpty();
+    assertThat(caseDataTriggerEnabled("trigger_enqueue_case_revision")).isTrue();
     assertTargetProtectionsPresent();
   }
 
@@ -119,6 +123,7 @@ class CcdDataMigrationTaskIntegrationTest {
     assertThat(countRows("ccd.case_event")).isEqualTo(2);
     assertThat(localEventHwm()).isEqualTo(102);
     assertThat(caseEventRevision(102)).isEqualTo(2);
+    assertElasticsearchQueueEmpty();
   }
 
   @Test
@@ -150,6 +155,8 @@ class CcdDataMigrationTaskIntegrationTest {
     assertThat(localEventHwm()).isEqualTo(101);
     assertThat(countRows("ccd.case_event")).isEqualTo(1);
     assertThat(caseRevision(10)).isZero();
+    assertElasticsearchQueueEmpty();
+    assertThat(caseDataTriggerEnabled("trigger_enqueue_case_revision")).isFalse();
   }
 
   @Test
@@ -227,6 +234,8 @@ class CcdDataMigrationTaskIntegrationTest {
     assertThat(countRows("ccd.case_data", PERF_CASE_TYPE)).isEqualTo((long) caseCount);
     assertThat(countRows("ccd.case_event", PERF_CASE_TYPE)).isEqualTo(expectedEvents);
     assertThat(progressStatus()).isEqualTo("COMPLETE");
+    assertElasticsearchQueueEmpty();
+    assertThat(caseDataTriggerEnabled("trigger_enqueue_case_revision")).isTrue();
     assertTargetProtectionsPresent();
     assertThat(elapsed).isLessThan(maxElapsed);
   }
@@ -372,6 +381,7 @@ class CcdDataMigrationTaskIntegrationTest {
         """);
     jdbc.getJdbcTemplate().execute("alter table ccd.case_event enable trigger user");
     jdbc.getJdbcTemplate().execute("alter table ccd.case_data enable trigger trigger_increment_case_revision");
+    jdbc.getJdbcTemplate().execute("alter table ccd.case_data enable trigger trigger_enqueue_case_revision");
   }
 
   private void insertSourceCase(long id, long reference, int version, String state, String data) {
@@ -847,6 +857,23 @@ class CcdDataMigrationTaskIntegrationTest {
         Map.of(),
         Boolean.class
     ));
+  }
+
+  private boolean caseDataTriggerEnabled(String triggerName) {
+    return Boolean.TRUE.equals(jdbc.queryForObject(
+        """
+        select tgenabled <> 'D'
+        from pg_trigger
+        where tgrelid = 'ccd.case_data'::regclass
+          and tgname = :triggerName
+        """,
+        Map.of("triggerName", triggerName),
+        Boolean.class
+    ));
+  }
+
+  private void assertElasticsearchQueueEmpty() {
+    assertThat(countRows("ccd.es_queue")).isZero();
   }
 
   private void assertTargetProtectionsPresent() {

--- a/sdk/decentralised-runtime/src/test/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTaskIntegrationTest.java
+++ b/sdk/decentralised-runtime/src/test/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTaskIntegrationTest.java
@@ -108,6 +108,34 @@ class CcdDataMigrationTaskIntegrationTest {
   }
 
   @Test
+  void cutoverDeletesOnlyMigratedCaseTypeElasticsearchQueueRows() {
+    insertSourceCase(10, 1000000000000010L, 1, "Submitted", "{\"field\":\"one\"}");
+    insertSourceCaseEvent(101, 10, "create", "Submitted", "{\"field\":\"one\"}", minutesAgo(60));
+    insertTargetCase(20, 1000000000000020L, 1, "Submitted", "{\"field\":\"other\"}", "OtherCase", 1);
+
+    CcdDataMigrationRunResult result = task(CUTOVER, 10, 10).runMigration();
+
+    assertThat(result.caughtUp()).isTrue();
+    assertThat(progressStatus()).isEqualTo("COMPLETE");
+    assertElasticsearchQueueEmpty("TestCase");
+    assertThat(countElasticsearchQueueRows("OtherCase")).isEqualTo(1);
+    assertThat(caseDataTriggerEnabled("trigger_enqueue_case_revision")).isTrue();
+  }
+
+  @Test
+  void completedCutoverRerunValidatesBeforeReEnablingElasticsearchQueueTrigger() {
+    insertTargetCase(10, 1000000000000010L, 1, "Submitted", "{\"field\":\"one\"}", 1);
+    createCompleteProgress(101);
+    jdbc.getJdbcTemplate().execute("alter table ccd.case_data disable trigger trigger_enqueue_case_revision");
+
+    assertThatThrownBy(() -> task(CUTOVER, 10, 10).runMigration())
+        .isInstanceOf(CcdDataMigrationException.class)
+        .hasMessageContaining("CCD data migration left 1 Elasticsearch queue rows");
+
+    assertThat(caseDataTriggerEnabled("trigger_enqueue_case_revision")).isFalse();
+  }
+
+  @Test
   void preloadResumesFromLocalTargetEventHighWaterMark() {
     insertSourceCase(10, 1000000000000010L, 1, "Submitted", "{\"field\":\"one\"}");
     insertSourceCaseEvent(101, 10, "create", "Submitted", "{\"field\":\"one\"}", minutesAgo(60));
@@ -518,6 +546,18 @@ class CcdDataMigrationTaskIntegrationTest {
   }
 
   private void insertTargetCase(long id, long reference, int version, String state, String data, long caseRevision) {
+    insertTargetCase(id, reference, version, state, data, "TestCase", caseRevision);
+  }
+
+  private void insertTargetCase(
+      long id,
+      long reference,
+      int version,
+      String state,
+      String data,
+      String caseTypeId,
+      long caseRevision
+  ) {
     jdbc.update(
         """
         insert into ccd.case_data (
@@ -544,7 +584,7 @@ class CcdDataMigrationTaskIntegrationTest {
           null,
           timestamp '2024-01-01 00:00:00',
           'TEST',
-          'TestCase',
+          :caseTypeId,
           :state,
           :data::jsonb,
           '{}'::jsonb,
@@ -558,6 +598,7 @@ class CcdDataMigrationTaskIntegrationTest {
             .addValue("version", version)
             .addValue("state", state)
             .addValue("data", data)
+            .addValue("caseTypeId", caseTypeId)
             .addValue("caseRevision", caseRevision)
     );
   }
@@ -646,6 +687,30 @@ class CcdDataMigrationTaskIntegrationTest {
             .addValue("configHash", CcdDataMigrationTaskOptions.builder(List.of("TestCase"))
                 .build()
                 .migrationConfigHash())
+    );
+  }
+
+  private void createCompleteProgress(long cutoverEventHwm) {
+    jdbc.update(
+        """
+        insert into ccd.ccd_data_migration_progress (
+          task_name,
+          config_hash,
+          status,
+          cutover_event_hwm
+        ) values (
+          :taskName,
+          :configHash,
+          'COMPLETE',
+          :cutoverEventHwm
+        )
+        """,
+        new MapSqlParameterSource()
+            .addValue("taskName", "ccd-data-migration")
+            .addValue("configHash", CcdDataMigrationTaskOptions.builder(List.of("TestCase"))
+                .build()
+                .migrationConfigHash())
+            .addValue("cutoverEventHwm", cutoverEventHwm)
     );
   }
 
@@ -750,6 +815,19 @@ class CcdDataMigrationTaskIntegrationTest {
   private long countRows(String tableName, String caseTypeId) {
     return jdbc.queryForObject(
         "select count(*) from " + tableName + " where case_type_id = :caseTypeId",
+        Map.of("caseTypeId", caseTypeId),
+        Long.class
+    );
+  }
+
+  private long countElasticsearchQueueRows(String caseTypeId) {
+    return jdbc.queryForObject(
+        """
+        select count(*)
+        from ccd.es_queue queue
+        join ccd.case_data case_data on case_data.reference = queue.reference
+        where case_data.case_type_id = :caseTypeId
+        """,
         Map.of("caseTypeId", caseTypeId),
         Long.class
     );
@@ -860,7 +938,7 @@ class CcdDataMigrationTaskIntegrationTest {
   }
 
   private boolean caseDataTriggerEnabled(String triggerName) {
-    return Boolean.TRUE.equals(jdbc.queryForObject(
+    List<Boolean> rows = jdbc.queryForList(
         """
         select tgenabled <> 'D'
         from pg_trigger
@@ -869,11 +947,17 @@ class CcdDataMigrationTaskIntegrationTest {
         """,
         Map.of("triggerName", triggerName),
         Boolean.class
-    ));
+    );
+    assertThat(rows).hasSize(1);
+    return Boolean.TRUE.equals(rows.get(0));
   }
 
   private void assertElasticsearchQueueEmpty() {
     assertThat(countRows("ccd.es_queue")).isZero();
+  }
+
+  private void assertElasticsearchQueueEmpty(String caseTypeId) {
+    assertThat(countElasticsearchQueueRows(caseTypeId)).isZero();
   }
 
   private void assertTargetProtectionsPresent() {


### PR DESCRIPTION
## Summary
- disable the case data Elasticsearch enqueue trigger while CCD data migration work is in progress
- truncate ccd.es_queue during migration startup and validate it remains empty before completion
- add integration coverage and operator documentation

## Testing
- ./gradlew :sdk:decentralised-runtime:test --tests uk.gov.hmcts.ccd.sdk.migration.CcdDataMigrationTaskIntegrationTest
- ./gradlew :sdk:decentralised-runtime:check