### PR TITLE
Preserve proxied users in decentralised history

### DIFF
--- a/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/impl/AuditEventService.java
+++ b/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/impl/AuditEventService.java
@@ -100,7 +100,10 @@ class AuditEventService {
           security_classification,
           version,
           case_revision,
-          idempotency_key)
+          idempotency_key,
+          proxied_by,
+          proxied_by_first_name,
+          proxied_by_last_name)
         values (
           :data::jsonb,
           :event_id,
@@ -118,7 +121,10 @@ class AuditEventService {
           :security_classification::ccd.securityclassification,
           :version,
           :case_revision,
-          :idempotency_key
+          :idempotency_key,
+          :proxied_by,
+          :proxied_by_first_name,
+          :proxied_by_last_name
         )
         returning id, created_date
         """;
@@ -129,16 +135,32 @@ class AuditEventService {
         )
         .orElse(String.valueOf(currentView.getState()));
 
+    var auditUserId = user.userDetails().getUid();
+    var auditUserFirstName = user.userDetails().getGivenName();
+    var auditUserLastName = user.userDetails().getFamilyName();
+    String proxiedBy = null;
+    String proxiedByFirstName = null;
+    String proxiedByLastName = null;
+
+    if (eventDetails.getProxiedBy() != null && !eventDetails.getProxiedBy().isBlank()) {
+      auditUserId = eventDetails.getProxiedBy();
+      auditUserFirstName = eventDetails.getProxiedByFirstName();
+      auditUserLastName = eventDetails.getProxiedByLastName();
+      proxiedBy = user.userDetails().getUid();
+      proxiedByFirstName = user.userDetails().getGivenName();
+      proxiedByLastName = user.userDetails().getFamilyName();
+    }
+
     var params = new MapSqlParameterSource()
         .addValue("data", defaultMapper.writeValueAsString(currentView.getData()))
         .addValue("event_id", eventDetails.getEventId())
-        .addValue("user_id", user.userDetails().getUid())
+        .addValue("user_id", auditUserId)
         .addValue("case_data_id", event.getInternalCaseId())
         .addValue("case_type_id", eventDetails.getCaseType())
         .addValue("case_type_version", 1)
         .addValue("state_id", currentView.getState())
-        .addValue("user_first_name", user.userDetails().getGivenName())
-        .addValue("user_last_name", user.userDetails().getFamilyName())
+        .addValue("user_first_name", auditUserFirstName)
+        .addValue("user_last_name", auditUserLastName)
         .addValue("event_name", eventDetails.getEventName())
         .addValue("state_name", stateName)
         .addValue("summary", eventDetails.getSummary())
@@ -146,7 +168,10 @@ class AuditEventService {
         .addValue("security_classification", currentView.getSecurityClassification().toString())
         .addValue("version", currentView.getVersion())
         .addValue("case_revision", currentView.getRevision())
-        .addValue("idempotency_key", idempotencyKey);
+        .addValue("idempotency_key", idempotencyKey)
+        .addValue("proxied_by", proxiedBy)
+        .addValue("proxied_by_first_name", proxiedByFirstName)
+        .addValue("proxied_by_last_name", proxiedByLastName);
 
     var inserted = ndb.queryForObject(sql, params, this::mapInsertedAuditEvent);
 

--- a/test-projects/e2e/src/cftlibTest/java/uk/gov/hmcts/divorce/cftlib/TestWithCCD.java
+++ b/test-projects/e2e/src/cftlibTest/java/uk/gov/hmcts/divorce/cftlib/TestWithCCD.java
@@ -1983,21 +1983,53 @@ public class TestWithCCD extends CftlibTest {
         String token,
         long reference
     ) {
-        var body = Map.of(
-            "data", data,
-            "event", Map.of(
-                "id", eventId,
-                "summary", "summary",
-                "description", "description"
-            ),
-            "event_token", token,
-            "ignore_warning", false
-        );
+        return prepareEventRequestWithToken(user, eventId, data, token, reference, null);
+    }
+
+    @SneakyThrows
+    private HttpPost prepareEventRequestWithToken(
+        String user,
+        String eventId,
+        Map<String, ?> data,
+        String token,
+        long reference,
+        String onBehalfOfToken
+    ) {
+        var body = new LinkedHashMap<String, Object>();
+        body.put("data", data);
+        body.put("event", Map.of(
+            "id", eventId,
+            "summary", "summary",
+            "description", "description"
+        ));
+        body.put("event_token", token);
+        body.put("ignore_warning", false);
+        if (onBehalfOfToken != null) {
+            body.put("on_behalf_of_token", onBehalfOfToken);
+        }
 
         var e = buildRequest(user, BASE_URL + "/cases/" + reference + "/events", HttpPost::new);
         withCcdAccept(e, ACCEPT_CREATE_EVENT);
         e.setEntity(new StringEntity(mapper.writeValueAsString(body), ContentType.APPLICATION_JSON));
         return e;
+    }
+
+    @SneakyThrows
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> getLatestAuditEvent(String user, long reference, String eventId) {
+        var get = buildRequest(user, BASE_URL + "/cases/" + reference + "/events", HttpGet::new);
+        withCcdAccept(get, ACCEPT_CASE_EVENTS);
+
+        try (var response = HttpClientBuilder.create().build().execute(get)) {
+            Map<String, Object> result =
+                mapper.readValue(EntityUtils.toString(response.getEntity()), new TypeReference<>() {});
+            assertThat(response.getStatusLine().getStatusCode(), equalTo(200));
+            var auditEvents = (List<Map<String, Object>>) result.get("auditEvents");
+            return auditEvents.stream()
+                .filter(event -> eventId.equals(event.get("id")))
+                .findFirst()
+                .orElseThrow();
+        }
     }
 
     private void assertLatestEventMetadata(String eventId, String expectedSummary, String expectedDescription) {
@@ -2180,9 +2212,13 @@ public class TestWithCCD extends CftlibTest {
     @Order(19)
     @Test
     public void testDecentralisedEventStartAndSubmitHandlers() throws Exception {
+        String submittingUser = "TEST_CASE_WORKER_USER@mailinator.com";
+        String submittingUserToken = getAuthorisation(submittingUser);
+        var submittingUserInfo = idam.getUserInfo(submittingUserToken);
+
         // Verify start handler pre-populates data
         var start = ccdApi.startEvent(
-            getAuthorisation("TEST_CASE_WORKER_USER@mailinator.com"),
+            submittingUserToken,
             getServiceAuth(), String.valueOf(caseRef), DecentralisedCaseworkerAddNote.CASEWORKER_DECENTRALISED_ADD_NOTE);
 
         var startData = mapper.readValue(mapper.writeValueAsString(start.getCaseDetails().getData()), CaseData.class);
@@ -2213,6 +2249,59 @@ public class TestWithCCD extends CftlibTest {
         String lastNoteSql = "SELECT note FROM case_notes WHERE reference = :ref ORDER BY id DESC LIMIT 1";
         String latestNote = db.queryForObject(lastNoteSql, Map.of("ref", caseRef), String.class);
         assertThat(latestNote, equalTo(noteText));
+
+        var submittedEvent = getLatestAuditEvent(
+            submittingUser,
+            caseRef,
+            DecentralisedCaseworkerAddNote.CASEWORKER_DECENTRALISED_ADD_NOTE);
+
+        assertThat(submittedEvent.get("user_id"), equalTo(submittingUserInfo.getUid()));
+        assertThat(submittedEvent.get("user_first_name"), equalTo(submittingUserInfo.getGivenName()));
+        assertThat(submittedEvent.get("user_last_name"), equalTo(submittingUserInfo.getFamilyName()));
+        assertThat(submittedEvent.get("proxied_by"), nullValue());
+        assertThat(submittedEvent.get("proxied_by_first_name"), nullValue());
+        assertThat(submittedEvent.get("proxied_by_last_name"), nullValue());
+    }
+
+    @Order(19)
+    @Test
+    public void decentralisedEventHistoryPreservesOnBehalfUserAndProxy() throws Exception {
+        String submittingUser = "TEST_CASE_WORKER_USER@mailinator.com";
+        String onBehalfOfUser = "TEST_SOLICITOR@mailinator.com";
+        String submittingUserToken = getAuthorisation(submittingUser);
+        String onBehalfOfUserToken = getAuthorisation(onBehalfOfUser);
+        var submittingUserInfo = idam.getUserInfo(submittingUserToken);
+        var onBehalfOfUserInfo = idam.getUserInfo(onBehalfOfUserToken);
+        long proxiedCaseRef = createAdditionalCase(onBehalfOfUser);
+
+        var start = ccdApi.startEvent(
+            submittingUserToken,
+            getServiceAuth(),
+            String.valueOf(proxiedCaseRef),
+            DecentralisedCaseworkerAddNote.CASEWORKER_DECENTRALISED_ADD_NOTE);
+
+        var request = prepareEventRequestWithToken(
+            submittingUser,
+            DecentralisedCaseworkerAddNote.CASEWORKER_DECENTRALISED_ADD_NOTE,
+            Map.of("note", "Decentralised proxied history test"),
+            start.getToken(),
+            proxiedCaseRef,
+            onBehalfOfUserToken);
+
+        var response = HttpClientBuilder.create().build().execute(request);
+        assertThat(response.getStatusLine().getStatusCode(), equalTo(201));
+
+        var submittedEvent = getLatestAuditEvent(
+            submittingUser,
+            proxiedCaseRef,
+            DecentralisedCaseworkerAddNote.CASEWORKER_DECENTRALISED_ADD_NOTE);
+
+        assertThat(submittedEvent.get("user_id"), equalTo(onBehalfOfUserInfo.getUid()));
+        assertThat(submittedEvent.get("user_first_name"), equalTo(onBehalfOfUserInfo.getGivenName()));
+        assertThat(submittedEvent.get("user_last_name"), equalTo(onBehalfOfUserInfo.getFamilyName()));
+        assertThat(submittedEvent.get("proxied_by"), equalTo(submittingUserInfo.getUid()));
+        assertThat(submittedEvent.get("proxied_by_first_name"), equalTo(submittingUserInfo.getGivenName()));
+        assertThat(submittedEvent.get("proxied_by_last_name"), equalTo(submittingUserInfo.getFamilyName()));
     }
 
     @Order(19)


### PR DESCRIPTION
### Change description ###

Preserve CCD audit history semantics for decentralised events submitted with `on_behalf_of_token`.

CCD Data Store sends the on-behalf user through the decentralised event details and the authenticated caller through the Authorization header. The decentralised runtime now writes the on-behalf user to the audit user fields and the authenticated caller to the proxied-by fields, matching central CCD history. The cftlib coverage exercises the full submit and case event history API path.