### PR TITLE
Deprioritise elasticsearch reindexing vs updates to live cases.

### DIFF
--- a/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/CaseReindexingService.java
+++ b/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/CaseReindexingService.java
@@ -2,7 +2,8 @@ package uk.gov.hmcts.ccd.sdk;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Service;
 
@@ -10,10 +11,29 @@ import org.springframework.stereotype.Service;
  * Helper to queue or count cases that need Elasticsearch reindexing.
  */
 @Service
-@RequiredArgsConstructor
 public class CaseReindexingService {
 
+  private static final long DEFAULT_REINDEX_QUEUE_PRIORITY_OFFSET_SECONDS = 21_600;
+
   private final NamedParameterJdbcTemplate jdbcTemplate;
+  private final long reindexQueuePriorityOffsetSeconds;
+
+  public CaseReindexingService(NamedParameterJdbcTemplate jdbcTemplate) {
+    this(jdbcTemplate, DEFAULT_REINDEX_QUEUE_PRIORITY_OFFSET_SECONDS);
+  }
+
+  @Autowired
+  public CaseReindexingService(
+      NamedParameterJdbcTemplate jdbcTemplate,
+      @Value("${ccd.sdk.reindexing.queue-priority-offset-seconds:"
+          + DEFAULT_REINDEX_QUEUE_PRIORITY_OFFSET_SECONDS + "}") long reindexQueuePriorityOffsetSeconds
+  ) {
+    if (reindexQueuePriorityOffsetSeconds < 0) {
+      throw new IllegalArgumentException("ccd.sdk.reindexing.queue-priority-offset-seconds must not be negative");
+    }
+    this.jdbcTemplate = jdbcTemplate;
+    this.reindexQueuePriorityOffsetSeconds = reindexQueuePriorityOffsetSeconds;
+  }
 
   public long countCasesModifiedSince(LocalDate modifiedSince) {
     LocalDateTime since = modifiedSince.atStartOfDay();
@@ -32,17 +52,21 @@ public class CaseReindexingService {
   public int enqueueCasesModifiedSince(LocalDate modifiedSince) {
     LocalDateTime since = modifiedSince.atStartOfDay();
 
+    // enqueued_at denotes priority; we use an offset to deprioritise reindexing vs live updates to cases.
     return jdbcTemplate.update(
         """
-            insert into ccd.es_queue(reference, case_revision)
-            select reference, case_revision
+            insert into ccd.es_queue(reference, case_revision, enqueued_at)
+            select reference, case_revision, now() + (:priority_offset_seconds * interval '1 second')
             from ccd.case_data
             where coalesce(last_modified, created_date) >= :since
             on conflict (reference) do update
             set case_revision = greatest(ccd.es_queue.case_revision, excluded.case_revision),
-                enqueued_at = greatest(ccd.es_queue.enqueued_at, excluded.enqueued_at)
+                enqueued_at = least(ccd.es_queue.enqueued_at, excluded.enqueued_at)
             """,
-        java.util.Map.of("since", since)
+        java.util.Map.of(
+            "since", since,
+            "priority_offset_seconds", reindexQueuePriorityOffsetSeconds
+        )
     );
   }
 }

--- a/sdk/decentralised-runtime/src/main/resources/dataruntime-db/migration/V0020__prioritise_live_es_queue_updates.sql
+++ b/sdk/decentralised-runtime/src/main/resources/dataruntime-db/migration/V0020__prioritise_live_es_queue_updates.sql
@@ -1,0 +1,13 @@
+create or replace function ccd.enqueue_case_revision()
+returns trigger as $$
+begin
+  insert into ccd.es_queue(reference, case_revision)
+  values (NEW.reference, NEW.case_revision)
+  on conflict (reference) do update
+  set
+    case_revision = greatest(ccd.es_queue.case_revision, excluded.case_revision),
+    enqueued_at = least(ccd.es_queue.enqueued_at, excluded.enqueued_at);
+
+  return NEW;
+end;
+$$ language plpgsql;

--- a/sdk/decentralised-runtime/src/main/resources/dataruntime-db/migration/V0020__prioritise_live_es_queue_updates.sql
+++ b/sdk/decentralised-runtime/src/main/resources/dataruntime-db/migration/V0020__prioritise_live_es_queue_updates.sql
@@ -1,8 +1,8 @@
 create or replace function ccd.enqueue_case_revision()
 returns trigger as $$
 begin
-  insert into ccd.es_queue(reference, case_revision)
-  values (NEW.reference, NEW.case_revision)
+  insert into ccd.es_queue(reference, case_revision, enqueued_at)
+  values (NEW.reference, NEW.case_revision, now())
   on conflict (reference) do update
   set
     case_revision = greatest(ccd.es_queue.case_revision, excluded.case_revision),

--- a/sdk/decentralised-runtime/src/test/java/uk/gov/hmcts/ccd/sdk/impl/IdempotentReplayIntegrationTest.java
+++ b/sdk/decentralised-runtime/src/test/java/uk/gov/hmcts/ccd/sdk/impl/IdempotentReplayIntegrationTest.java
@@ -47,6 +47,8 @@ class IdempotentReplayIntegrationTest {
   private static final long CASE_REFERENCE_B = 2222000000000000L;
   private static final long UPSERT_CASE_REFERENCE = 3333000000000000L;
   private static final long REINDEX_CASE_REFERENCE = 4444000000000000L;
+  private static final long LOWER_PRIORITY_REINDEX_CASE_REFERENCE = 5555000000000000L;
+  private static final long LIVE_UPDATE_AFTER_REINDEX_CASE_REFERENCE = 6666000000000000L;
 
   @Autowired
   private NamedParameterJdbcTemplate jdbc;
@@ -153,7 +155,8 @@ class IdempotentReplayIntegrationTest {
     jdbc.update(
         """
         update ccd.es_queue
-           set case_revision = :stale_revision
+           set case_revision = :stale_revision,
+               enqueued_at = now() - interval '1 minute'
          where reference = :reference
         """,
         Map.of(
@@ -170,6 +173,86 @@ class IdempotentReplayIntegrationTest {
         Long.class
     );
     assertThat(queuedRevision).isEqualTo(5L);
+
+    Boolean keptLiveQueuePriority = jdbc.queryForObject(
+        """
+        select enqueued_at < now()
+        from ccd.es_queue
+        where reference = :reference
+        """,
+        Map.of("reference", REINDEX_CASE_REFERENCE),
+        Boolean.class
+    );
+    assertThat(keptLiveQueuePriority).isTrue();
+  }
+
+  @Test
+  void reindexingPlacesNewQueueRowsBehindLiveCaseUpdates() {
+    seedCaseData(LOWER_PRIORITY_REINDEX_CASE_REFERENCE, LOWER_PRIORITY_REINDEX_CASE_REFERENCE, 1, 5);
+    jdbc.update(
+        "delete from ccd.es_queue where reference = :reference",
+        Map.of("reference", LOWER_PRIORITY_REINDEX_CASE_REFERENCE)
+    );
+
+    reindexingService.enqueueCasesModifiedSince(LocalDate.now().minusDays(1));
+
+    Boolean lowerPriorityByDefault = jdbc.queryForObject(
+        """
+        select enqueued_at >= now() + interval '5 hours'
+        from ccd.es_queue
+        where reference = :reference
+        """,
+        Map.of("reference", LOWER_PRIORITY_REINDEX_CASE_REFERENCE),
+        Boolean.class
+    );
+    assertThat(lowerPriorityByDefault).isTrue();
+  }
+
+  @Test
+  void liveCaseUpdateRestoresQueuePriorityAfterReindexingQueuedTheCase() {
+    seedCaseData(LIVE_UPDATE_AFTER_REINDEX_CASE_REFERENCE, LIVE_UPDATE_AFTER_REINDEX_CASE_REFERENCE, 1, 5);
+    jdbc.update(
+        "delete from ccd.es_queue where reference = :reference",
+        Map.of("reference", LIVE_UPDATE_AFTER_REINDEX_CASE_REFERENCE)
+    );
+
+    reindexingService.enqueueCasesModifiedSince(LocalDate.now().minusDays(1));
+
+    Boolean lowerPriorityAfterReindex = jdbc.queryForObject(
+        """
+        select enqueued_at >= now() + interval '5 hours'
+        from ccd.es_queue
+        where reference = :reference
+        """,
+        Map.of("reference", LIVE_UPDATE_AFTER_REINDEX_CASE_REFERENCE),
+        Boolean.class
+    );
+    assertThat(lowerPriorityAfterReindex).isTrue();
+
+    jdbc.update(
+        """
+        update ccd.case_data
+           set case_revision = :revision,
+               last_modified = now()
+         where reference = :reference
+        """,
+        Map.of(
+            "reference", LIVE_UPDATE_AFTER_REINDEX_CASE_REFERENCE,
+            "revision", 6
+        )
+    );
+
+    Map<String, Object> queued = jdbc.queryForMap(
+        """
+        select case_revision,
+               enqueued_at < now() + interval '1 minute' as live_priority
+        from ccd.es_queue
+        where reference = :reference
+        """,
+        Map.of("reference", LIVE_UPDATE_AFTER_REINDEX_CASE_REFERENCE)
+    );
+    assertThat(queued.get("case_revision")).isEqualTo(6L);
+    assertThat(queued.get("live_priority")).isEqualTo(true);
   }
 
   private void seedCaseData(int version, long revision) {


### PR DESCRIPTION
Pushing enqueued_at into the future ensures other updates to cases take priority over reindexing.




