### PR TITLE
Improve CCD data migration batch query

### DIFF
--- a/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationProperties.java
+++ b/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationProperties.java
@@ -18,6 +18,7 @@ public class CcdDataMigrationProperties {
   private long caseRevisionOffset = 1_000_000_000L;
   private int maxBatchesPerRun = Integer.MAX_VALUE;
   private Duration maxRunTime;
+  private Duration statementTimeout = Duration.ofMinutes(10);
 
   CcdDataMigrationTaskOptions toOptions() {
     if (caseTypeIds == null || caseTypeIds.isEmpty()) {
@@ -31,6 +32,7 @@ public class CcdDataMigrationProperties {
         .caseRevisionOffset(caseRevisionOffset)
         .maxBatchesPerRun(maxBatchesPerRun)
         .maxRunTime(maxRunTime)
+        .statementTimeout(statementTimeout)
         .build();
   }
 }

--- a/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTask.java
+++ b/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTask.java
@@ -255,12 +255,7 @@ public class CcdDataMigrationTask implements Runnable {
         break;
       }
 
-      Long batchEndEventHwm = nextSourceEventBatchEndAfter(localEventHwm, targetEventHwm);
-      if (batchEndEventHwm == null) {
-        totals = totals.markCaughtUp();
-        break;
-      }
-
+      long batchEndEventHwm = nextSourceEventBatchEndAfter(localEventHwm, targetEventHwm);
       long batchStartEventId = localEventHwm + 1L;
       int events = transaction.execute(status -> {
         applyMigrationStatementTimeout();
@@ -536,7 +531,7 @@ public class CcdDataMigrationTask implements Runnable {
     });
   }
 
-  private Long nextSourceEventBatchEndAfter(long localEventHwm, long targetEventHwm) {
+  private long nextSourceEventBatchEndAfter(long localEventHwm, long targetEventHwm) {
     Long batchEndEventHwm = withMigrationStatementTimeout(() -> db.query(
         """
         select ce.id

--- a/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTask.java
+++ b/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTask.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.BooleanSupplier;
+import java.util.function.Supplier;
 import javax.sql.DataSource;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.env.Environment;
@@ -261,7 +262,10 @@ public class CcdDataMigrationTask implements Runnable {
       }
 
       long batchStartEventId = localEventHwm + 1L;
-      int events = transaction.execute(status -> copyNextEventBatch(batchStartEventId, batchEndEventHwm));
+      int events = transaction.execute(status -> {
+        applyMigrationStatementTimeout();
+        return copyNextEventBatch(batchStartEventId, batchEndEventHwm);
+      });
       if (events == 0) {
         totals = totals.markCaughtUp();
         break;
@@ -420,6 +424,7 @@ public class CcdDataMigrationTask implements Runnable {
 
   private int refreshCutoverCaseData() {
     return transaction.execute(status -> {
+      applyMigrationStatementTimeout();
       disableCaseDataRevisionTrigger();
       try {
         int refreshedCases = syncCaseDataForCutover();
@@ -502,51 +507,54 @@ public class CcdDataMigrationTask implements Runnable {
   }
 
   private long sourceEventHighWaterMark() {
-    Long hwm = db.queryForObject(
-        """
-        select coalesce(max(ce.id), 0)
-        from fdw_stage.case_event ce
-        where ce.case_type_id in (:caseTypeIds)
-        """,
-        baseParams(),
-        Long.class
-    );
-    return hwm == null ? 0 : hwm;
+    return withMigrationStatementTimeout(() -> {
+      Long hwm = db.queryForObject(
+          """
+          select coalesce(max(ce.id), 0)
+          from fdw_stage.case_event ce
+          where ce.case_type_id in (:caseTypeIds)
+          """,
+          baseParams(),
+          Long.class
+      );
+      return hwm == null ? 0 : hwm;
+    });
   }
 
   private long localEventHighWaterMark() {
-    Long hwm = db.queryForObject(
-        """
-        select coalesce(max(ce.id), 0)
-        from ccd.case_event ce
-        where ce.case_type_id in (:caseTypeIds)
-        """,
-        baseParams(),
-        Long.class
-    );
-    return hwm == null ? 0 : hwm;
+    return withMigrationStatementTimeout(() -> {
+      Long hwm = db.queryForObject(
+          """
+          select coalesce(max(ce.id), 0)
+          from ccd.case_event ce
+          where ce.case_type_id in (:caseTypeIds)
+          """,
+          baseParams(),
+          Long.class
+      );
+      return hwm == null ? 0 : hwm;
+    });
   }
 
   private Long nextSourceEventBatchEndAfter(long localEventHwm, long targetEventHwm) {
-    return db.queryForObject(
+    Long batchEndEventHwm = withMigrationStatementTimeout(() -> db.query(
         """
-        -- The + 0 prevents PostgreSQL's min/max optimisation from walking pk_case_event
-        -- when the case_type_id predicate is sparse on the source CCD table.
-        select coalesce(
-          (array_agg(ce.id + 0 order by ce.id))[:eventBatchSize],
-          max(ce.id + 0)
-        )
+        select ce.id
         from fdw_stage.case_event ce
         where ce.case_type_id in (:caseTypeIds)
           and ce.id > :localEventHwm
           and ce.id <= :targetEventHwm
+        order by ce.id
+        offset :eventBatchOffset
+        limit 1
         """,
         baseParams()
             .addValue("localEventHwm", localEventHwm)
             .addValue("targetEventHwm", targetEventHwm)
-            .addValue("eventBatchSize", options.eventBatchSize()),
-        Long.class
-    );
+            .addValue("eventBatchOffset", options.eventBatchSize() - 1),
+        rs -> rs.next() ? rs.getLong(1) : null
+    ));
+    return batchEndEventHwm == null ? targetEventHwm : batchEndEventHwm;
   }
 
   private long captureCutoverEventHighWaterMark() {
@@ -582,6 +590,7 @@ public class CcdDataMigrationTask implements Runnable {
 
   private void completeCutover(long cutoverEventHwm) {
     transaction.execute(status -> {
+      applyMigrationStatementTimeout();
       validateFinal(cutoverEventHwm);
       enableElasticsearchQueueTrigger();
       markComplete();
@@ -815,6 +824,24 @@ public class CcdDataMigrationTask implements Runnable {
 
   private boolean isTimeLimitReached(LocalDateTime stopAt) {
     return stopAt != null && !LocalDateTime.now(clock).isBefore(stopAt);
+  }
+
+  private <T> T withMigrationStatementTimeout(Supplier<T> operation) {
+    return transaction.execute(status -> {
+      applyMigrationStatementTimeout();
+      return operation.get();
+    });
+  }
+
+  private void applyMigrationStatementTimeout() {
+    if (options.statementTimeout() == null) {
+      return;
+    }
+    db.getJdbcTemplate().queryForObject(
+        "select set_config('statement_timeout', ?, true)",
+        String.class,
+        options.statementTimeout().toMillis() + "ms"
+    );
   }
 
   private MapSqlParameterSource eventBatchParams(long batchStartEventId, long batchEndEventHwm) {

--- a/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTaskOptions.java
+++ b/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTaskOptions.java
@@ -17,10 +17,12 @@ public record CcdDataMigrationTaskOptions(
     int eventBatchSize,
     long caseRevisionOffset,
     int maxBatchesPerRun,
-    Duration maxRunTime
+    Duration maxRunTime,
+    Duration statementTimeout
 ) {
   private static final String TARGET_SCHEMA = "ccd";
   private static final String FDW_SCHEMA = "fdw_stage";
+  private static final Duration DEFAULT_STATEMENT_TIMEOUT = Duration.ofMinutes(10);
 
   public CcdDataMigrationTaskOptions {
     taskName = requireText(taskName, "taskName");
@@ -38,6 +40,9 @@ public record CcdDataMigrationTaskOptions(
     }
     if (maxRunTime != null && !maxRunTime.isPositive()) {
       throw new IllegalArgumentException("maxRunTime must be positive when set");
+    }
+    if (statementTimeout != null && !statementTimeout.isPositive()) {
+      throw new IllegalArgumentException("statementTimeout must be positive when set");
     }
   }
 
@@ -109,6 +114,7 @@ public record CcdDataMigrationTaskOptions(
     private long caseRevisionOffset = 1_000_000_000L;
     private int maxBatchesPerRun = Integer.MAX_VALUE;
     private Duration maxRunTime;
+    private Duration statementTimeout = DEFAULT_STATEMENT_TIMEOUT;
 
     private Builder(List<String> caseTypeIds) {
       this.caseTypeIds = caseTypeIds;
@@ -144,6 +150,11 @@ public record CcdDataMigrationTaskOptions(
       return this;
     }
 
+    public Builder statementTimeout(Duration statementTimeout) {
+      this.statementTimeout = statementTimeout;
+      return this;
+    }
+
     public CcdDataMigrationTaskOptions build() {
       return new CcdDataMigrationTaskOptions(
           taskName,
@@ -152,7 +163,8 @@ public record CcdDataMigrationTaskOptions(
           eventBatchSize,
           caseRevisionOffset,
           maxBatchesPerRun,
-          maxRunTime
+          maxRunTime,
+          statementTimeout
       );
     }
   }

--- a/sdk/decentralised-runtime/src/test/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTaskOptionsTest.java
+++ b/sdk/decentralised-runtime/src/test/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTaskOptionsTest.java
@@ -19,6 +19,7 @@ class CcdDataMigrationTaskOptionsTest {
     assertThat(options.caseRevisionOffset()).isEqualTo(1_000_000_000L);
     assertThat(options.maxBatchesPerRun()).isEqualTo(Integer.MAX_VALUE);
     assertThat(options.maxRunTime()).isNull();
+    assertThat(options.statementTimeout()).isEqualTo(Duration.ofMinutes(10));
   }
 
   @Test
@@ -28,6 +29,7 @@ class CcdDataMigrationTaskOptionsTest {
         .eventBatchSize(1)
         .maxBatchesPerRun(1)
         .maxRunTime(Duration.ofMinutes(10))
+        .statementTimeout(Duration.ofSeconds(30))
         .build();
 
     var second = CcdDataMigrationTaskOptions.builder(List.of("CaseA", "CaseB"))
@@ -35,6 +37,7 @@ class CcdDataMigrationTaskOptionsTest {
         .eventBatchSize(500)
         .maxBatchesPerRun(500)
         .maxRunTime(Duration.ofHours(4))
+        .statementTimeout(Duration.ofMinutes(15))
         .build();
 
     assertThat(second.migrationConfigHash()).isEqualTo(first.migrationConfigHash());
@@ -68,6 +71,15 @@ class CcdDataMigrationTaskOptionsTest {
         .build())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("maxRunTime");
+  }
+
+  @Test
+  void rejectsNonPositiveStatementTimeout() {
+    assertThatThrownBy(() -> CcdDataMigrationTaskOptions.builder(List.of("TestCase"))
+        .statementTimeout(Duration.ZERO)
+        .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("statementTimeout");
   }
 
 }


### PR DESCRIPTION
### Change description ###

Updates the CCD data migration preload batch boundary query to find the event id at the configured batch offset instead of aggregating all matching event ids.

This keeps the existing high-water-mark migration flow, avoids building large event id arrays, and adds a transaction-local statement_timeout with a 10 minute default for migration SQL.