### PR TITLE
Preserve empty case data objects

### DIFF
--- a/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/config/CcdCaseDataMapperConfiguration.java
+++ b/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/config/CcdCaseDataMapperConfiguration.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.ccd.sdk.config;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.context.annotation.Bean;
 
@@ -15,7 +14,6 @@ public class CcdCaseDataMapperConfiguration {
    * ObjectMapper used when serialising case data back to CCD's JSON wire shape.
    */
   @Bean(name = CCD_CASE_DATA_OBJECT_MAPPER)
-  @Qualifier(CCD_CASE_DATA_OBJECT_MAPPER)
   public ObjectMapper ccdCaseDataObjectMapper(ObjectMapper mapper) {
     return mapper.copy().setSerializationInclusion(JsonInclude.Include.NON_NULL);
   }

--- a/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/config/CcdCaseDataMapperConfiguration.java
+++ b/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/config/CcdCaseDataMapperConfiguration.java
@@ -1,0 +1,22 @@
+package uk.gov.hmcts.ccd.sdk.config;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@AutoConfiguration
+public class CcdCaseDataMapperConfiguration {
+
+  public static final String CCD_CASE_DATA_OBJECT_MAPPER = "ccdCaseDataObjectMapper";
+
+  /**
+   * ObjectMapper used when serialising case data back to CCD's JSON wire shape.
+   */
+  @Bean(name = CCD_CASE_DATA_OBJECT_MAPPER)
+  @Qualifier(CCD_CASE_DATA_OBJECT_MAPPER)
+  public ObjectMapper ccdCaseDataObjectMapper(ObjectMapper mapper) {
+    return mapper.copy().setSerializationInclusion(JsonInclude.Include.NON_NULL);
+  }
+}

--- a/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/config/CcdCaseDataMapperConfiguration.java
+++ b/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/config/CcdCaseDataMapperConfiguration.java
@@ -15,6 +15,7 @@ public class CcdCaseDataMapperConfiguration {
    */
   @Bean(name = CCD_CASE_DATA_OBJECT_MAPPER)
   public ObjectMapper ccdCaseDataObjectMapper(ObjectMapper mapper) {
+    // NON_NULL will retain eg. empty maps, required by certain contracts eg. AAC service & notice of change.
     return mapper.copy().setSerializationInclusion(JsonInclude.Include.NON_NULL);
   }
 }

--- a/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/impl/CaseProjectionService.java
+++ b/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/impl/CaseProjectionService.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.core.ResolvableType;
 import org.springframework.stereotype.Service;
 import org.springframework.util.ClassUtils;
@@ -18,6 +19,7 @@ import uk.gov.hmcts.ccd.sdk.CaseView;
 import uk.gov.hmcts.ccd.sdk.CaseViewRequest;
 import uk.gov.hmcts.ccd.sdk.ResolvedCCDConfig;
 import uk.gov.hmcts.ccd.sdk.ResolvedConfigRegistry;
+import uk.gov.hmcts.ccd.sdk.config.CcdCaseDataMapperConfiguration;
 
 /**
  * Central place for loading {@link DecentralisedCaseDetails} with the
@@ -37,6 +39,7 @@ class CaseProjectionService {
   private final GlobalSearchProcessorService globalSearchProcessorService;
 
   CaseProjectionService(CaseDataRepository caseDataRepository,
+                        @Qualifier(CcdCaseDataMapperConfiguration.CCD_CASE_DATA_OBJECT_MAPPER)
                         ObjectMapper mapper,
                         List<CaseView<?, ?>> caseViews,
                         ResolvedConfigRegistry configRegistry,

--- a/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/impl/LegacyCallbackSubmissionHandler.java
+++ b/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/impl/LegacyCallbackSubmissionHandler.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Optional;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.ccd.data.casedetails.SecurityClassification;
 import uk.gov.hmcts.ccd.decentralised.dto.DecentralisedCaseEvent;
@@ -17,6 +18,7 @@ import uk.gov.hmcts.ccd.sdk.api.EventMetadata;
 import uk.gov.hmcts.ccd.sdk.api.Webhook;
 import uk.gov.hmcts.ccd.sdk.api.callback.AboutToStartOrSubmitResponse;
 import uk.gov.hmcts.ccd.sdk.api.callback.SubmitResponse;
+import uk.gov.hmcts.ccd.sdk.config.CcdCaseDataMapperConfiguration;
 import uk.gov.hmcts.ccd.sdk.runtime.CcdCallbackExecutor;
 import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
@@ -41,6 +43,7 @@ class LegacyCallbackSubmissionHandler implements CaseSubmissionHandler {
 
   LegacyCallbackSubmissionHandler(ResolvedConfigRegistry registry,
                                   CcdCallbackExecutor executor,
+                                  @Qualifier(CcdCaseDataMapperConfiguration.CCD_CASE_DATA_OBJECT_MAPPER)
                                   ObjectMapper mapper) {
     this.registry = registry;
     this.executor = executor;

--- a/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/impl/json/JsonCallbackBridge.java
+++ b/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/impl/json/JsonCallbackBridge.java
@@ -43,6 +43,7 @@ import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
 import uk.gov.hmcts.ccd.sdk.api.callback.AboutToStartOrSubmitResponse;
 import uk.gov.hmcts.ccd.sdk.api.callback.AboutToSubmit;
 import uk.gov.hmcts.ccd.sdk.api.callback.Submitted;
+import uk.gov.hmcts.ccd.sdk.config.CcdCaseDataMapperConfiguration;
 import uk.gov.hmcts.reform.ccd.client.model.SubmittedCallbackResponse;
 
 @Component
@@ -62,6 +63,7 @@ public class JsonCallbackBridge {
   private final Map<String, String> externalCallbackBaseUrls;
 
   JsonCallbackBridge(ApplicationContext applicationContext,
+                     @Qualifier(CcdCaseDataMapperConfiguration.CCD_CASE_DATA_OBJECT_MAPPER)
                      ObjectMapper mapper,
                      @Qualifier("requestMappingHandlerMapping")
                      RequestMappingHandlerMapping handlerMapping,

--- a/sdk/decentralised-runtime/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/sdk/decentralised-runtime/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,4 +1,5 @@
 uk.gov.hmcts.ccd.sdk.config.CcdWireFormatConfiguration
+uk.gov.hmcts.ccd.sdk.config.CcdCaseDataMapperConfiguration
 uk.gov.hmcts.ccd.sdk.migration.CcdDataMigrationAutoConfiguration
 uk.gov.hmcts.ccd.sdk.config.DecentralisedDataConfiguration
 uk.gov.hmcts.ccd.sdk.config.DefinitionMapperConfiguration

--- a/sdk/decentralised-runtime/src/test/java/uk/gov/hmcts/ccd/sdk/impl/json/JsonCallbackBridgeTest.java
+++ b/sdk/decentralised-runtime/src/test/java/uk/gov/hmcts/ccd/sdk/impl/json/JsonCallbackBridgeTest.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.ccd.sdk.impl.json;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
@@ -15,10 +16,14 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
+import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
+import uk.gov.hmcts.ccd.sdk.api.callback.AboutToStartOrSubmitResponse;
+import uk.gov.hmcts.ccd.sdk.config.CcdCaseDataMapperConfiguration;
 
 class JsonCallbackBridgeTest {
 
-  private final ObjectMapper mapper = new ObjectMapper();
+  private final ObjectMapper mapper = new CcdCaseDataMapperConfiguration()
+      .ccdCaseDataObjectMapper(new ObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_EMPTY));
 
   @AfterEach
   void resetRequestContext() {
@@ -65,6 +70,25 @@ class JsonCallbackBridgeTest {
   }
 
   @Test
+  void preservesEmptyNestedCaseDataObjectsInLocalCallbackResponse() {
+    JsonCallbackBridge bridge = bridgeWith(
+        new MockEnvironment().withProperty("decentralisation.local-callback-placeholder", "ET_COS_URL"),
+        new LocalCallbackController()
+    );
+    CaseDetails<Object, Object> caseDetails = CaseDetails.builder()
+        .data(new NocCaseData(null))
+        .build();
+
+    AboutToStartOrSubmitResponse response = bridge.aboutToSubmit(
+        "${ET_COS_URL}/callbacks/noc-about-to-submit",
+        "local"
+    ).handle(caseDetails, null);
+
+    NocCaseData responseData = (NocCaseData) response.getData();
+    assertThat(responseData.changeOrganisationRequestField().OrganisationToAdd()).isNotNull();
+  }
+
+  @Test
   void failsFastWhenCallbackIsNeitherLocalNorAbsoluteExternalUrl() {
     JsonCallbackBridge bridge = bridgeWith(new MockEnvironment());
 
@@ -104,5 +128,24 @@ class JsonCallbackBridgeTest {
     Map<String, Object> aboutToSubmit(@RequestBody Map<String, Object> request) {
       return Map.of("source", "local", "event_id", request.get("event_id"));
     }
+
+    @PostMapping("/noc-about-to-submit")
+    NocCallbackResponse nocAboutToSubmit(@RequestBody Map<String, Object> request) {
+      return new NocCallbackResponse(new NocCaseData(
+          new ChangeOrganisationRequestField(new OrganisationToAdd())
+      ));
+    }
+  }
+
+  private record NocCallbackResponse(NocCaseData data) {
+  }
+
+  private record NocCaseData(ChangeOrganisationRequestField changeOrganisationRequestField) {
+  }
+
+  private record ChangeOrganisationRequestField(OrganisationToAdd OrganisationToAdd) {
+  }
+
+  private record OrganisationToAdd() {
   }
 }

--- a/sdk/decentralised-runtime/src/test/java/uk/gov/hmcts/ccd/sdk/impl/json/JsonCallbackBridgeTest.java
+++ b/sdk/decentralised-runtime/src/test/java/uk/gov/hmcts/ccd/sdk/impl/json/JsonCallbackBridgeTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
@@ -132,7 +133,7 @@ class JsonCallbackBridgeTest {
     @PostMapping("/noc-about-to-submit")
     NocCallbackResponse nocAboutToSubmit(@RequestBody Map<String, Object> request) {
       return new NocCallbackResponse(new NocCaseData(
-          new ChangeOrganisationRequestField(new OrganisationToAdd())
+          new ChangeOrganisationRequestField(new OrganisationToAdd(null))
       ));
     }
   }
@@ -146,6 +147,6 @@ class JsonCallbackBridgeTest {
   private record ChangeOrganisationRequestField(OrganisationToAdd OrganisationToAdd) {
   }
 
-  private record OrganisationToAdd() {
+  private record OrganisationToAdd(@JsonProperty("OrganisationID") String organisationId) {
   }
 }


### PR DESCRIPTION
### Change description ###

Adds a CCD case data ObjectMapper that serialises case data with NON_NULL inclusion.

CCD and AAC can use empty objects as markers in flows such as notice of change. 
