### PR TITLE
Bound CCD data migration by source event windows

### DIFF
--- a/docs/ccd-data-migration-task.md
+++ b/docs/ccd-data-migration-task.md
@@ -30,7 +30,7 @@ The preload path keeps the target tables constraint-valid after every committed 
 * the unique `(case_data_id, case_revision)` index stays in place
 * `case_event.version` and `case_event.case_revision` are calculated before insert
 * `case_event` user triggers are not disabled
-* resume position is derived from target `case_event` after each committed batch
+* resume position is stored as a source event high-water mark after each committed batch
 
 Preloaded `case_data` is provisional. Its purpose is to satisfy the event FK. Every copied event
 batch inserts missing parent source `case_data` rows for that batch. `CUTOVER` overwrites target
@@ -57,10 +57,14 @@ state:
 * `config_hash`
 * `status`: `PRELOAD`, `CUTOVER`, or `COMPLETE`
 * `cutover_event_hwm`
+* `source_event_hwm`
 * timestamps
 
 The migration configuration hash covers the migration identity. Runtime limits such as
-`eventBatchSize`, `maxBatchesPerRun`, `maxRunTime`, and `mode` can change between invocations.
+`eventIdWindowSize`, `maxBatchesPerRun`, `maxRunTime`, and `mode` can change between invocations.
+If the migration identity changes after a task has already created a progress row, the task fails
+fast rather than resuming under different source filters. Operators must either keep the same
+identity configuration or explicitly reset/use a new `task-name` after confirming the target state.
 
 ## Configuration
 
@@ -75,7 +79,8 @@ ccd:
     case-type-ids:
       - ET_EnglandWales
       - ET_Scotland
-    event-batch-size: 10000
+    source-jurisdiction: EMPLOYMENT
+    event-id-window-size: 1000000
     max-batches-per-run: 100
     max-run-time: 4h
     case-revision-offset: 1000000000
@@ -163,6 +168,6 @@ Override the dataset with system properties:
   --tests '*CcdDataMigrationTaskIntegrationTest.migratesSeededDatasetWithinPerfHarnessLimit' \
   -Dccd.data-migration.perf.cases=10000 \
   -Dccd.data-migration.perf.events-per-case=5 \
-  -Dccd.data-migration.perf.event-batch-size=1000 \
+  -Dccd.data-migration.perf.event-id-window-size=1000 \
   -Dccd.data-migration.perf.max-seconds=900
 ```

--- a/docs/ccd-data-migration-task.md
+++ b/docs/ccd-data-migration-task.md
@@ -30,7 +30,7 @@ The preload path keeps the target tables constraint-valid after every committed 
 * the unique `(case_data_id, case_revision)` index stays in place
 * `case_event.version` and `case_event.case_revision` are calculated before insert
 * `case_event` user triggers are not disabled
-* resume position is stored as a source event high-water mark after each committed batch
+* resume position is stored as a source `case_event.id` window position after each committed batch
 
 Preloaded `case_data` is provisional. Its purpose is to satisfy the event FK. Every copied event
 batch inserts missing parent source `case_data` rows for that batch. `CUTOVER` overwrites target

--- a/sdk/decentralised-runtime/build.gradle
+++ b/sdk/decentralised-runtime/build.gradle
@@ -44,7 +44,7 @@ tasks.withType(Test).configureEach {
     [
         'ccd.data-migration.perf.cases',
         'ccd.data-migration.perf.events-per-case',
-        'ccd.data-migration.perf.event-batch-size',
+        'ccd.data-migration.perf.event-id-window-size',
         'ccd.data-migration.perf.max-seconds'
     ].each { propertyName ->
         def propertyValue = System.getProperty(propertyName)

--- a/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationProperties.java
+++ b/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationProperties.java
@@ -14,25 +14,31 @@ public class CcdDataMigrationProperties {
   private String taskName = "ccd-data-migration";
   private CcdDataMigrationMode mode = CcdDataMigrationMode.PRELOAD_EVENTS;
   private List<String> caseTypeIds = new ArrayList<>();
-  private int eventBatchSize = 10_000;
+  private int eventIdWindowSize = 1_000_000;
+  private Integer eventBatchSize;
   private long caseRevisionOffset = 1_000_000_000L;
   private int maxBatchesPerRun = Integer.MAX_VALUE;
   private Duration maxRunTime;
   private Duration statementTimeout = Duration.ofMinutes(10);
+  private String sourceJurisdiction;
 
   CcdDataMigrationTaskOptions toOptions() {
     if (caseTypeIds == null || caseTypeIds.isEmpty()) {
       throw new IllegalStateException("ccd.data-migration.case-type-ids must be configured when enabled");
     }
+    if (sourceJurisdiction == null || sourceJurisdiction.isBlank()) {
+      throw new IllegalStateException("ccd.data-migration.source-jurisdiction must be configured when enabled");
+    }
 
     return CcdDataMigrationTaskOptions.builder(caseTypeIds)
         .taskName(taskName)
         .mode(mode)
-        .eventBatchSize(eventBatchSize)
+        .eventIdWindowSize(eventBatchSize == null ? eventIdWindowSize : eventBatchSize)
         .caseRevisionOffset(caseRevisionOffset)
         .maxBatchesPerRun(maxBatchesPerRun)
         .maxRunTime(maxRunTime)
         .statementTimeout(statementTimeout)
+        .sourceJurisdiction(sourceJurisdiction)
         .build();
   }
 }

--- a/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationProperties.java
+++ b/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationProperties.java
@@ -14,7 +14,7 @@ public class CcdDataMigrationProperties {
   private String taskName = "ccd-data-migration";
   private CcdDataMigrationMode mode = CcdDataMigrationMode.PRELOAD_EVENTS;
   private List<String> caseTypeIds = new ArrayList<>();
-  private int eventIdWindowSize = 1_000_000;
+  private Integer eventIdWindowSize;
   private Integer eventBatchSize;
   private long caseRevisionOffset = 1_000_000_000L;
   private int maxBatchesPerRun = Integer.MAX_VALUE;
@@ -33,12 +33,22 @@ public class CcdDataMigrationProperties {
     return CcdDataMigrationTaskOptions.builder(caseTypeIds)
         .taskName(taskName)
         .mode(mode)
-        .eventIdWindowSize(eventBatchSize == null ? eventIdWindowSize : eventBatchSize)
+        .eventIdWindowSize(resolvedEventIdWindowSize())
         .caseRevisionOffset(caseRevisionOffset)
         .maxBatchesPerRun(maxBatchesPerRun)
         .maxRunTime(maxRunTime)
         .statementTimeout(statementTimeout)
         .sourceJurisdiction(sourceJurisdiction)
         .build();
+  }
+
+  private int resolvedEventIdWindowSize() {
+    if (eventIdWindowSize != null) {
+      return eventIdWindowSize;
+    }
+    if (eventBatchSize != null) {
+      return eventBatchSize;
+    }
+    return 1_000_000;
   }
 }

--- a/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationProperties.java
+++ b/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationProperties.java
@@ -14,8 +14,7 @@ public class CcdDataMigrationProperties {
   private String taskName = "ccd-data-migration";
   private CcdDataMigrationMode mode = CcdDataMigrationMode.PRELOAD_EVENTS;
   private List<String> caseTypeIds = new ArrayList<>();
-  private Integer eventIdWindowSize;
-  private Integer eventBatchSize;
+  private int eventIdWindowSize = 1_000_000;
   private long caseRevisionOffset = 1_000_000_000L;
   private int maxBatchesPerRun = Integer.MAX_VALUE;
   private Duration maxRunTime;
@@ -33,7 +32,7 @@ public class CcdDataMigrationProperties {
     return CcdDataMigrationTaskOptions.builder(caseTypeIds)
         .taskName(taskName)
         .mode(mode)
-        .eventIdWindowSize(resolvedEventIdWindowSize())
+        .eventIdWindowSize(eventIdWindowSize)
         .caseRevisionOffset(caseRevisionOffset)
         .maxBatchesPerRun(maxBatchesPerRun)
         .maxRunTime(maxRunTime)
@@ -42,13 +41,4 @@ public class CcdDataMigrationProperties {
         .build();
   }
 
-  private int resolvedEventIdWindowSize() {
-    if (eventIdWindowSize != null) {
-      return eventIdWindowSize;
-    }
-    if (eventBatchSize != null) {
-      return eventBatchSize;
-    }
-    return 1_000_000;
-  }
 }

--- a/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTask.java
+++ b/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTask.java
@@ -508,12 +508,8 @@ public class CcdDataMigrationTask implements Runnable {
     return withMigrationStatementTimeout(() -> {
       Long hwm = db.queryForObject(
           """
-          select coalesce(max(ce.id), 0)
-          from fdw_stage.case_event ce
-          join fdw_stage.case_data cd on cd.id = ce.case_data_id
-          where cd.jurisdiction = :sourceJurisdiction
-            and cd.case_type_id in (:caseTypeIds)
-            and ce.case_type_id in (:caseTypeIds)
+          select coalesce(max(id), 0)
+          from fdw_stage.case_event
           """,
           baseParams(),
           Long.class

--- a/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTask.java
+++ b/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTask.java
@@ -291,15 +291,20 @@ public class CcdDataMigrationTask implements Runnable {
   private int copyNextEventBatch(long batchStartEventId, long batchEndEventHwm) {
     return db.update(
         """
-        with source_cases as materialized (
-          select distinct on (cd.id) cd.*
-          from fdw_stage.case_data cd
-          join fdw_stage.case_event ce on ce.case_data_id = cd.id
+        with events_to_insert as materialized (
+          select ce.*
+          from fdw_stage.case_event ce
+          join fdw_stage.case_data cd on cd.id = ce.case_data_id
           where cd.jurisdiction = :sourceJurisdiction
             and cd.case_type_id in (:caseTypeIds)
             and ce.case_type_id in (:caseTypeIds)
             and ce.id >= :batchStartEventId
             and ce.id <= :batchEndEventHwm
+        ),
+        source_cases as materialized (
+          select distinct on (cd.id) cd.*
+          from fdw_stage.case_data cd
+          join events_to_insert ce on ce.case_data_id = cd.id
           order by cd.id
         ),
         inserted_cases as (
@@ -337,16 +342,6 @@ public class CcdDataMigrationTask implements Runnable {
           from source_cases cd
           on conflict do nothing
           returning id
-        ),
-        events_to_insert as materialized (
-          select ce.*
-          from fdw_stage.case_event ce
-          join fdw_stage.case_data cd on cd.id = ce.case_data_id
-          where cd.jurisdiction = :sourceJurisdiction
-            and cd.case_type_id in (:caseTypeIds)
-            and ce.case_type_id in (:caseTypeIds)
-            and ce.id >= :batchStartEventId
-            and ce.id <= :batchEndEventHwm
         ),
         affected_cases as (
           select distinct case_data_id
@@ -452,6 +447,7 @@ public class CcdDataMigrationTask implements Runnable {
             supplementary_data = coalesce(source.supplementary_data, jsonb_build_object())
         from fdw_stage.case_data source
         where target.id = source.id
+          and source.jurisdiction = :sourceJurisdiction
           and source.case_type_id in (:caseTypeIds)
           and (
             target.reference,
@@ -489,15 +485,19 @@ public class CcdDataMigrationTask implements Runnable {
     return db.update(
         """
         with event_counts as (
-          select case_data_id, max(case_revision)::bigint as max_revision
-          from ccd.case_event
-          where case_type_id in (:caseTypeIds)
-          group by case_data_id
+          select ce.case_data_id, max(ce.case_revision)::bigint as max_revision
+          from ccd.case_event ce
+          join ccd.case_data cd on cd.id = ce.case_data_id
+          where cd.jurisdiction = :sourceJurisdiction
+            and cd.case_type_id in (:caseTypeIds)
+            and ce.case_type_id in (:caseTypeIds)
+          group by ce.case_data_id
         )
         update ccd.case_data target
         set case_revision = event_counts.max_revision + :caseRevisionOffset
         from event_counts
         where target.id = event_counts.case_data_id
+          and target.jurisdiction = :sourceJurisdiction
           and target.case_type_id in (:caseTypeIds)
         """,
         baseParams().addValue("caseRevisionOffset", options.caseRevisionOffset())
@@ -566,13 +566,18 @@ public class CcdDataMigrationTask implements Runnable {
 
   private long effectiveSourceEventHighWaterMark(long targetEventHwm) {
     long progressEventHwm = sourceEventProgressHighWaterMark();
+    if (progressEventHwm > 0) {
+      return progressEventHwm;
+    }
+
     long localEventHwm = localEventHighWaterMark();
-    long effectiveEventHwm = Math.max(progressEventHwm, localEventHwm);
-    if (effectiveEventHwm > 0) {
-      if (progressEventHwm < effectiveEventHwm) {
-        updateSourceEventProgressHighWaterMark(effectiveEventHwm);
-      }
-      return effectiveEventHwm;
+    if (localEventHwm > 0) {
+      throw new CcdDataMigrationException(
+          "CCD data migration target already contains migrated events but source_event_hwm is zero"
+              + " taskName=" + options.taskName()
+              + " localEventHwm=" + localEventHwm
+              + " targetEventHwm=" + targetEventHwm
+      );
     }
     return 0;
   }
@@ -643,16 +648,20 @@ public class CcdDataMigrationTask implements Runnable {
       case "case_data" -> """
           select case_type_id, count(*) as count
           from ccd.case_data
-          where case_type_id in (:caseTypeIds)
+          where jurisdiction = :sourceJurisdiction
+            and case_type_id in (:caseTypeIds)
           group by case_type_id
           order by case_type_id
           """;
       case "case_event" -> """
-          select case_type_id, count(*) as count
-          from ccd.case_event
-          where case_type_id in (:caseTypeIds)
-          group by case_type_id
-          order by case_type_id
+          select ce.case_type_id, count(*) as count
+          from ccd.case_event ce
+          join ccd.case_data cd on cd.id = ce.case_data_id
+          where cd.jurisdiction = :sourceJurisdiction
+            and cd.case_type_id in (:caseTypeIds)
+            and ce.case_type_id in (:caseTypeIds)
+          group by ce.case_type_id
+          order by ce.case_type_id
           """;
       default -> throw new IllegalArgumentException("Unsupported table name: " + tableName);
     };
@@ -680,6 +689,7 @@ public class CcdDataMigrationTask implements Runnable {
         delete from ccd.es_queue queue
         using ccd.case_data case_data
         where queue.reference = case_data.reference
+          and case_data.jurisdiction = :sourceJurisdiction
           and case_data.case_type_id in (:caseTypeIds)
         """,
         baseParams()
@@ -692,7 +702,8 @@ public class CcdDataMigrationTask implements Runnable {
         select count(*)
         from ccd.es_queue queue
         join ccd.case_data case_data on case_data.reference = queue.reference
-        where case_data.case_type_id in (:caseTypeIds)
+        where case_data.jurisdiction = :sourceJurisdiction
+          and case_data.case_type_id in (:caseTypeIds)
         """,
         baseParams(),
         Long.class

--- a/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTask.java
+++ b/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTask.java
@@ -105,12 +105,12 @@ public class CcdDataMigrationTask implements Runnable {
 
   public final CcdDataMigrationRunResult runMigration() {
     log.info(
-        "Starting CCD data migration task taskName={} mode={} caseTypeIds={} eventBatchSize={} "
+        "Starting CCD data migration task taskName={} mode={} caseTypeIds={} eventIdWindowSize={} "
             + "maxBatchesPerRun={} maxRunTime={}",
         options.taskName(),
         options.mode(),
         options.caseTypeIds(),
-        options.eventBatchSize(),
+        options.eventIdWindowSize(),
         options.maxBatchesPerRun(),
         options.maxRunTime()
     );
@@ -151,8 +151,8 @@ public class CcdDataMigrationTask implements Runnable {
     prepareElasticsearchQueueForMigration();
     long targetEventHwm = sourceEventHighWaterMark();
     CopyTotals totals = copyEventBatches(targetEventHwm);
-    long localEventHwm = localEventHighWaterMark();
-    boolean caughtUp = localEventHwm >= targetEventHwm;
+    long sourceEventHwm = sourceEventProgressHighWaterMark();
+    boolean caughtUp = sourceEventHwm >= targetEventHwm;
     log.info(
         "Completed CCD data migration preload taskName={} targetEventHwm={} batches={} cases={} events={} "
             + "caughtUp={} stoppedByTimeLimit={}",
@@ -190,14 +190,14 @@ public class CcdDataMigrationTask implements Runnable {
         ? captureCutoverEventHighWaterMark()
         : progress.cutoverEventHwm();
     CopyTotals totals = copyEventBatches(cutoverEventHwm);
-    long localEventHwm = localEventHighWaterMark();
-    if (totals.stoppedByTimeLimit() || localEventHwm < cutoverEventHwm) {
+    long sourceEventHwm = sourceEventProgressHighWaterMark();
+    if (totals.stoppedByTimeLimit() || sourceEventHwm < cutoverEventHwm) {
       log.info(
-          "CCD data migration cutover paused before final refresh taskName={} cutoverEventHwm={} localEventHwm={} "
+          "CCD data migration cutover paused before final refresh taskName={} cutoverEventHwm={} sourceEventHwm={} "
               + "batches={} events={} stoppedByTimeLimit={}",
           options.taskName(),
           cutoverEventHwm,
-          localEventHwm,
+          sourceEventHwm,
           totals.batches(),
           totals.events(),
           totals.stoppedByTimeLimit()
@@ -249,29 +249,27 @@ public class CcdDataMigrationTask implements Runnable {
     LocalDateTime stopAt = calculateStopAt();
 
     for (int i = 0; i < options.maxBatchesPerRun(); i++) {
-      long localEventHwm = localEventHighWaterMark();
-      if (localEventHwm >= targetEventHwm) {
+      long sourceEventHwm = effectiveSourceEventHighWaterMark(targetEventHwm);
+      if (sourceEventHwm >= targetEventHwm) {
         totals = totals.markCaughtUp();
         break;
       }
 
-      long batchEndEventHwm = nextSourceEventBatchEndAfter(localEventHwm, targetEventHwm);
-      long batchStartEventId = localEventHwm + 1L;
+      long batchEndEventHwm = nextFixedEventWindowEnd(sourceEventHwm, targetEventHwm);
+      long batchStartEventId = sourceEventHwm + 1L;
       int events = transaction.execute(status -> {
         applyMigrationStatementTimeout();
-        return copyNextEventBatch(batchStartEventId, batchEndEventHwm);
+        int copiedEvents = copyNextEventBatch(batchStartEventId, batchEndEventHwm);
+        updateSourceEventProgressHighWaterMark(batchEndEventHwm);
+        return copiedEvents;
       });
-      if (events == 0) {
-        totals = totals.markCaughtUp();
-        break;
-      }
       totals = totals.plus(events);
       log.info(
-          "CCD data migration progress taskName={} mode={} localEventHwm={} targetEventHwm={} "
+          "CCD data migration progress taskName={} mode={} sourceEventHwm={} targetEventHwm={} "
               + "batchStartEventId={} batchEndEventHwm={} batchEvents={} totalBatches={} totalEvents={}",
           options.taskName(),
           options.mode(),
-          localEventHwm,
+          sourceEventHwm,
           targetEventHwm,
           batchStartEventId,
           batchEndEventHwm,
@@ -281,7 +279,7 @@ public class CcdDataMigrationTask implements Runnable {
       );
 
       if (isTimeLimitReached(stopAt)) {
-        log.info("Stopping CCD data migration taskName={} after event batch because time limit was reached",
+        log.info("Stopping CCD data migration taskName={} after event id window because time limit was reached",
             options.taskName());
         totals = totals.markStoppedByTimeLimit();
         break;
@@ -297,7 +295,9 @@ public class CcdDataMigrationTask implements Runnable {
           select distinct on (cd.id) cd.*
           from fdw_stage.case_data cd
           join fdw_stage.case_event ce on ce.case_data_id = cd.id
-          where ce.case_type_id in (:caseTypeIds)
+          where cd.jurisdiction = :sourceJurisdiction
+            and cd.case_type_id in (:caseTypeIds)
+            and ce.case_type_id in (:caseTypeIds)
             and ce.id >= :batchStartEventId
             and ce.id <= :batchEndEventHwm
           order by cd.id
@@ -341,7 +341,10 @@ public class CcdDataMigrationTask implements Runnable {
         events_to_insert as materialized (
           select ce.*
           from fdw_stage.case_event ce
-          where ce.case_type_id in (:caseTypeIds)
+          join fdw_stage.case_data cd on cd.id = ce.case_data_id
+          where cd.jurisdiction = :sourceJurisdiction
+            and cd.case_type_id in (:caseTypeIds)
+            and ce.case_type_id in (:caseTypeIds)
             and ce.id >= :batchStartEventId
             and ce.id <= :batchEndEventHwm
         ),
@@ -507,7 +510,10 @@ public class CcdDataMigrationTask implements Runnable {
           """
           select coalesce(max(ce.id), 0)
           from fdw_stage.case_event ce
-          where ce.case_type_id in (:caseTypeIds)
+          join fdw_stage.case_data cd on cd.id = ce.case_data_id
+          where cd.jurisdiction = :sourceJurisdiction
+            and cd.case_type_id in (:caseTypeIds)
+            and ce.case_type_id in (:caseTypeIds)
           """,
           baseParams(),
           Long.class
@@ -522,7 +528,10 @@ public class CcdDataMigrationTask implements Runnable {
           """
           select coalesce(max(ce.id), 0)
           from ccd.case_event ce
-          where ce.case_type_id in (:caseTypeIds)
+          join ccd.case_data cd on cd.id = ce.case_data_id
+          where cd.jurisdiction = :sourceJurisdiction
+            and cd.case_type_id in (:caseTypeIds)
+            and ce.case_type_id in (:caseTypeIds)
           """,
           baseParams(),
           Long.class
@@ -531,25 +540,53 @@ public class CcdDataMigrationTask implements Runnable {
     });
   }
 
-  private long nextSourceEventBatchEndAfter(long localEventHwm, long targetEventHwm) {
-    Long batchEndEventHwm = withMigrationStatementTimeout(() -> db.query(
+  private long sourceEventProgressHighWaterMark() {
+    Long hwm = db.queryForObject(
         """
-        select ce.id
-        from fdw_stage.case_event ce
-        where ce.case_type_id in (:caseTypeIds)
-          and ce.id > :localEventHwm
-          and ce.id <= :targetEventHwm
-        order by ce.id
-        offset :eventBatchOffset
-        limit 1
+        select source_event_hwm
+        from ccd.ccd_data_migration_progress
+        where task_name = :taskName
         """,
-        baseParams()
-            .addValue("localEventHwm", localEventHwm)
-            .addValue("targetEventHwm", targetEventHwm)
-            .addValue("eventBatchOffset", options.eventBatchSize() - 1),
-        rs -> rs.next() ? rs.getLong(1) : null
-    ));
-    return batchEndEventHwm == null ? targetEventHwm : batchEndEventHwm;
+        Map.of("taskName", options.taskName()),
+        Long.class
+    );
+    return hwm == null ? 0 : hwm;
+  }
+
+  private void updateSourceEventProgressHighWaterMark(long sourceEventHwm) {
+    db.update(
+        """
+        update ccd.ccd_data_migration_progress
+        set source_event_hwm = :sourceEventHwm,
+            updated_at = now() at time zone 'UTC'
+        where task_name = :taskName
+        """,
+        Map.of(
+            "taskName", options.taskName(),
+            "sourceEventHwm", sourceEventHwm
+        )
+    );
+  }
+
+  private long effectiveSourceEventHighWaterMark(long targetEventHwm) {
+    long progressEventHwm = sourceEventProgressHighWaterMark();
+    long localEventHwm = localEventHighWaterMark();
+    long effectiveEventHwm = Math.max(progressEventHwm, localEventHwm);
+    if (effectiveEventHwm > 0) {
+      if (progressEventHwm < effectiveEventHwm) {
+        updateSourceEventProgressHighWaterMark(effectiveEventHwm);
+      }
+      return effectiveEventHwm;
+    }
+    return 0;
+  }
+
+  private long nextFixedEventWindowEnd(long sourceEventHwm, long targetEventHwm) {
+    long eventIdWindowSize = options.eventIdWindowSize();
+    long windowEnd = sourceEventHwm > Long.MAX_VALUE - eventIdWindowSize
+        ? Long.MAX_VALUE
+        : sourceEventHwm + eventIdWindowSize;
+    return Math.min(windowEnd, targetEventHwm);
   }
 
   private long captureCutoverEventHighWaterMark() {
@@ -695,6 +732,7 @@ public class CcdDataMigrationTask implements Runnable {
             'config_hash',
             'status',
             'cutover_event_hwm',
+            'source_event_hwm',
             'created_at',
             'updated_at'
           )
@@ -702,7 +740,7 @@ public class CcdDataMigrationTask implements Runnable {
         Map.of("schema", TARGET_SCHEMA),
         Integer.class
     );
-    if (columnCount == null || columnCount != 6) {
+    if (columnCount == null || columnCount != 7) {
       throw new CcdDataMigrationException(
           "CCD data migration progress table is missing or incomplete. "
               + "Run the decentralised-runtime Flyway migrations before starting the task."
@@ -732,7 +770,8 @@ public class CcdDataMigrationTask implements Runnable {
         """
         select config_hash,
                status,
-               cutover_event_hwm
+               cutover_event_hwm,
+               source_event_hwm
         from ccd.ccd_data_migration_progress
         where task_name = :taskName
         """,
@@ -767,7 +806,8 @@ public class CcdDataMigrationTask implements Runnable {
     return new Progress(
         rs.getString("config_hash"),
         rs.getString("status"),
-        cutoverEventHwm
+        cutoverEventHwm,
+        rs.getLong("source_event_hwm")
     );
   }
 
@@ -846,7 +886,9 @@ public class CcdDataMigrationTask implements Runnable {
   }
 
   private MapSqlParameterSource baseParams() {
-    return new MapSqlParameterSource().addValue("caseTypeIds", options.caseTypeIds());
+    return new MapSqlParameterSource()
+        .addValue("caseTypeIds", options.caseTypeIds())
+        .addValue("sourceJurisdiction", options.sourceJurisdiction());
   }
 
   private AdvisoryLock tryLock() {
@@ -951,7 +993,7 @@ public class CcdDataMigrationTask implements Runnable {
     }
   }
 
-  private record Progress(String configHash, String status, Long cutoverEventHwm) {
+  private record Progress(String configHash, String status, Long cutoverEventHwm, long sourceEventHwm) {
     long requiredCutoverEventHwm() {
       if (cutoverEventHwm == null) {
         throw new CcdDataMigrationException("cutover_event_hwm is not set for completed migration");

--- a/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTaskOptions.java
+++ b/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTaskOptions.java
@@ -14,11 +14,12 @@ public record CcdDataMigrationTaskOptions(
     String taskName,
     CcdDataMigrationMode mode,
     List<String> caseTypeIds,
-    int eventBatchSize,
+    int eventIdWindowSize,
     long caseRevisionOffset,
     int maxBatchesPerRun,
     Duration maxRunTime,
-    Duration statementTimeout
+    Duration statementTimeout,
+    String sourceJurisdiction
 ) {
   private static final String TARGET_SCHEMA = "ccd";
   private static final String FDW_SCHEMA = "fdw_stage";
@@ -28,9 +29,10 @@ public record CcdDataMigrationTaskOptions(
     taskName = requireText(taskName, "taskName");
     mode = mode == null ? CcdDataMigrationMode.PRELOAD_EVENTS : mode;
     caseTypeIds = List.copyOf(requireCaseTypeIds(caseTypeIds));
+    sourceJurisdiction = requireText(sourceJurisdiction, "sourceJurisdiction");
 
-    if (eventBatchSize < 1) {
-      throw new IllegalArgumentException("eventBatchSize must be greater than zero");
+    if (eventIdWindowSize < 1) {
+      throw new IllegalArgumentException("eventIdWindowSize must be greater than zero");
     }
     if (caseRevisionOffset < 0) {
       throw new IllegalArgumentException("caseRevisionOffset must be zero or greater");
@@ -57,6 +59,7 @@ public record CcdDataMigrationTaskOptions(
   String migrationConfigSummary() {
     return "targetSchema=" + TARGET_SCHEMA
         + ", fdwSchema=" + FDW_SCHEMA
+        + ", sourceJurisdiction=" + sourceJurisdiction
         + ", caseTypeIds=" + canonicalCaseTypeIds()
         + ", caseRevisionOffset=" + caseRevisionOffset;
   }
@@ -67,14 +70,26 @@ public record CcdDataMigrationTaskOptions(
         .collect(Collectors.joining(","));
   }
 
+  /**
+   * Returns the event id window size.
+   *
+   * @deprecated use {@link #eventIdWindowSize()}.
+   */
+  @Deprecated(forRemoval = false)
+  public int eventBatchSize() {
+    return eventIdWindowSize;
+  }
+
   private String migrationConfigFingerprint() {
-    return String.join(
-        "\n",
+    var fields = new ArrayList<String>();
+    fields.addAll(List.of(
         "targetSchema=" + TARGET_SCHEMA,
         "fdwSchema=" + FDW_SCHEMA,
+        "sourceJurisdiction=" + sourceJurisdiction,
         "caseTypeIds=" + canonicalCaseTypeIds(),
         "caseRevisionOffset=" + caseRevisionOffset
-    );
+    ));
+    return String.join("\n", fields);
   }
 
   private static String sha256(String value) {
@@ -110,11 +125,12 @@ public record CcdDataMigrationTaskOptions(
     private String taskName = "ccd-data-migration";
     private CcdDataMigrationMode mode = CcdDataMigrationMode.PRELOAD_EVENTS;
     private final List<String> caseTypeIds;
-    private int eventBatchSize = 10_000;
+    private int eventIdWindowSize = 1_000_000;
     private long caseRevisionOffset = 1_000_000_000L;
     private int maxBatchesPerRun = Integer.MAX_VALUE;
     private Duration maxRunTime;
     private Duration statementTimeout = DEFAULT_STATEMENT_TIMEOUT;
+    private String sourceJurisdiction;
 
     private Builder(List<String> caseTypeIds) {
       this.caseTypeIds = caseTypeIds;
@@ -130,9 +146,19 @@ public record CcdDataMigrationTaskOptions(
       return this;
     }
 
-    public Builder eventBatchSize(int eventBatchSize) {
-      this.eventBatchSize = eventBatchSize;
+    public Builder eventIdWindowSize(int eventIdWindowSize) {
+      this.eventIdWindowSize = eventIdWindowSize;
       return this;
+    }
+
+    /**
+     * Sets the event id window size.
+     *
+     * @deprecated use {@link #eventIdWindowSize(int)}.
+     */
+    @Deprecated(forRemoval = false)
+    public Builder eventBatchSize(int eventBatchSize) {
+      return eventIdWindowSize(eventBatchSize);
     }
 
     public Builder caseRevisionOffset(long caseRevisionOffset) {
@@ -155,16 +181,22 @@ public record CcdDataMigrationTaskOptions(
       return this;
     }
 
+    public Builder sourceJurisdiction(String sourceJurisdiction) {
+      this.sourceJurisdiction = sourceJurisdiction;
+      return this;
+    }
+
     public CcdDataMigrationTaskOptions build() {
       return new CcdDataMigrationTaskOptions(
           taskName,
           mode,
           caseTypeIds,
-          eventBatchSize,
+          eventIdWindowSize,
           caseRevisionOffset,
           maxBatchesPerRun,
           maxRunTime,
-          statementTimeout
+          statementTimeout,
+          sourceJurisdiction
       );
     }
   }

--- a/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTaskOptions.java
+++ b/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTaskOptions.java
@@ -70,16 +70,6 @@ public record CcdDataMigrationTaskOptions(
         .collect(Collectors.joining(","));
   }
 
-  /**
-   * Returns the event id window size.
-   *
-   * @deprecated use {@link #eventIdWindowSize()}.
-   */
-  @Deprecated(forRemoval = false)
-  public int eventBatchSize() {
-    return eventIdWindowSize;
-  }
-
   private String migrationConfigFingerprint() {
     var fields = new ArrayList<String>();
     fields.addAll(List.of(
@@ -149,16 +139,6 @@ public record CcdDataMigrationTaskOptions(
     public Builder eventIdWindowSize(int eventIdWindowSize) {
       this.eventIdWindowSize = eventIdWindowSize;
       return this;
-    }
-
-    /**
-     * Sets the event id window size.
-     *
-     * @deprecated use {@link #eventIdWindowSize(int)}.
-     */
-    @Deprecated(forRemoval = false)
-    public Builder eventBatchSize(int eventBatchSize) {
-      return eventIdWindowSize(eventBatchSize);
     }
 
     public Builder caseRevisionOffset(long caseRevisionOffset) {

--- a/sdk/decentralised-runtime/src/main/resources/dataruntime-db/migration/V0021__data_migration_source_event_hwm.sql
+++ b/sdk/decentralised-runtime/src/main/resources/dataruntime-db/migration/V0021__data_migration_source_event_hwm.sql
@@ -1,0 +1,2 @@
+alter table ccd.ccd_data_migration_progress
+add column source_event_hwm bigint not null default 0;

--- a/sdk/decentralised-runtime/src/test/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationAutoConfigurationTest.java
+++ b/sdk/decentralised-runtime/src/test/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationAutoConfigurationTest.java
@@ -33,7 +33,8 @@ class CcdDataMigrationAutoConfigurationTest {
         .withPropertyValues(
             "ccd.data-migration.enabled=true",
             "ccd.data-migration.case-type-ids[0]=TestCase",
-            "ccd.data-migration.event-batch-size=500",
+            "ccd.data-migration.source-jurisdiction=TEST",
+            "ccd.data-migration.event-id-window-size=500",
             "ccd.data-migration.max-batches-per-run=10"
         )
         .run(context -> assertThat(context).hasSingleBean(CcdDataMigrationTask.class));
@@ -48,12 +49,25 @@ class CcdDataMigrationAutoConfigurationTest {
   }
 
   @Test
+  void failsClearlyWhenEnabledWithoutSourceJurisdiction() {
+    contextRunner
+        .withPropertyValues(
+            "ccd.data-migration.enabled=true",
+            "ccd.data-migration.case-type-ids[0]=TestCase"
+        )
+        .run(context -> assertThat(context.getStartupFailure())
+            .hasMessageContaining("ccd.data-migration.source-jurisdiction must be configured when enabled"));
+  }
+
+  @Test
   void backsOffWhenServiceProvidesTaskBean() {
     contextRunner
         .withBean(CcdDataMigrationTask.class, () -> new CcdDataMigrationTask(
             new NamedParameterJdbcTemplate(mock(DataSource.class)),
             mock(PlatformTransactionManager.class),
-            CcdDataMigrationTaskOptions.builder(List.of("ServiceCase")).build(),
+            CcdDataMigrationTaskOptions.builder(List.of("ServiceCase"))
+                .sourceJurisdiction("TEST")
+                .build(),
             () -> false
         ))
         .withPropertyValues("ccd.data-migration.enabled=true")

--- a/sdk/decentralised-runtime/src/test/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTaskIntegrationTest.java
+++ b/sdk/decentralised-runtime/src/test/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTaskIntegrationTest.java
@@ -220,6 +220,7 @@ class CcdDataMigrationTaskIntegrationTest {
     assertThat(result.caughtUp()).isTrue();
     assertThat(result.eventsProcessed()).isZero();
     assertThat(countRows("ccd.case_event")).isZero();
+    assertThat(sourceEventHwm()).isEqualTo(101);
   }
 
   @Test

--- a/sdk/decentralised-runtime/src/test/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTaskIntegrationTest.java
+++ b/sdk/decentralised-runtime/src/test/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTaskIntegrationTest.java
@@ -65,7 +65,7 @@ class CcdDataMigrationTaskIntegrationTest {
     insertSourceCaseEvent(101, 10, "create", "Submitted", "{\"field\":\"one\"}", minutesAgo(60));
     insertSourceCaseEvent(102, 10, "update", "Updated", "{\"field\":\"two\"}", LocalDateTime.now());
 
-    CcdDataMigrationRunResult result = task(PRELOAD_EVENTS, 10, 10).runMigration();
+    CcdDataMigrationRunResult result = task(PRELOAD_EVENTS, 1000, 10).runMigration();
 
     assertThat(result.caughtUp()).isTrue();
     assertThat(result.eventsProcessed()).isEqualTo(2);
@@ -85,12 +85,12 @@ class CcdDataMigrationTaskIntegrationTest {
   void cutoverCopiesRemainingEventsRefreshesCaseDataAndMarksComplete() {
     insertSourceCase(10, 1000000000000010L, 1, "Submitted", "{\"field\":\"one\"}");
     insertSourceCaseEvent(101, 10, "create", "Submitted", "{\"field\":\"one\"}", minutesAgo(60));
-    task(PRELOAD_EVENTS, 10, 10).runMigration();
+    task(PRELOAD_EVENTS, 1000, 10).runMigration();
 
     updateSourceCase(10, 2, "Updated", "{\"field\":\"cutover\"}");
     insertSourceCaseEvent(102, 10, "update", "Updated", "{\"field\":\"cutover\"}", LocalDateTime.now());
 
-    CcdDataMigrationRunResult result = task(CUTOVER, 10, 10).runMigration();
+    CcdDataMigrationRunResult result = task(CUTOVER, 1000, 10).runMigration();
 
     assertThat(result.caughtUp()).isTrue();
     assertThat(progressStatus()).isEqualTo("COMPLETE");
@@ -113,7 +113,7 @@ class CcdDataMigrationTaskIntegrationTest {
     insertSourceCaseEvent(101, 10, "create", "Submitted", "{\"field\":\"one\"}", minutesAgo(60));
     insertTargetCase(20, 1000000000000020L, 1, "Submitted", "{\"field\":\"other\"}", "OtherCase", 1);
 
-    CcdDataMigrationRunResult result = task(CUTOVER, 10, 10).runMigration();
+    CcdDataMigrationRunResult result = task(CUTOVER, 1000, 10).runMigration();
 
     assertThat(result.caughtUp()).isTrue();
     assertThat(progressStatus()).isEqualTo("COMPLETE");
@@ -155,19 +155,71 @@ class CcdDataMigrationTaskIntegrationTest {
   }
 
   @Test
-  void preloadBatchesByMatchingSourceEventsNotGlobalEventIdWindow() {
+  void preloadBatchesByFixedSourceEventIdWindow() {
     insertSourceCase(10, 1000000000000010L, 1, "Submitted", "{\"field\":\"one\"}");
     insertSourceCaseEvent(101, 10, "create", "Submitted", "{\"field\":\"one\"}", minutesAgo(60));
     insertSourceCaseEvent(1001, 10, "update", "Updated", "{\"field\":\"two\"}", minutesAgo(60));
     insertSourceCaseEvent(2001, 10, "close", "Closed", "{\"field\":\"three\"}", minutesAgo(60));
     insertSourceCaseEvent(102, 10, "other", "Submitted", "{\"field\":\"other\"}", "OtherCase", minutesAgo(60));
 
-    CcdDataMigrationRunResult result = task(PRELOAD_EVENTS, 2, 1).runMigration();
+    CcdDataMigrationRunResult result = task(PRELOAD_EVENTS, 1000, 1).runMigration();
 
     assertThat(result.caughtUp()).isFalse();
+    assertThat(result.eventsProcessed()).isEqualTo(1);
+    assertThat(countRows("ccd.case_event")).isEqualTo(1);
+    assertThat(localEventHwm()).isEqualTo(101);
+    assertThat(sourceEventHwm()).isEqualTo(1000);
+  }
+
+  @Test
+  void preloadAdvancesAcrossEmptySourceEventIdWindows() {
+    insertSourceCase(10, 1000000000000010L, 1, "Submitted", "{\"field\":\"one\"}");
+    insertSourceCaseEvent(101, 10, "create", "Submitted", "{\"field\":\"one\"}", minutesAgo(60));
+    insertSourceCaseEvent(1001, 10, "update", "Updated", "{\"field\":\"two\"}", minutesAgo(60));
+
+    CcdDataMigrationRunResult firstRun = task(PRELOAD_EVENTS, 100, 1).runMigration();
+    CcdDataMigrationRunResult secondRun = task(PRELOAD_EVENTS, 100, 1).runMigration();
+    CcdDataMigrationRunResult thirdRun = task(PRELOAD_EVENTS, 100, 1).runMigration();
+
+    assertThat(firstRun.eventsProcessed()).isZero();
+    assertThat(secondRun.caughtUp()).isFalse();
+    assertThat(secondRun.eventsProcessed()).isEqualTo(1);
+    assertThat(thirdRun.eventsProcessed()).isZero();
+    assertThat(localEventHwm()).isEqualTo(101);
+    assertThat(sourceEventHwm()).isEqualTo(300);
+  }
+
+  @Test
+  void preloadBatchBoundaryUsesSourceJurisdiction() {
+    insertSourceCase(10, 1000000000000010L, 1, "Submitted", "{\"field\":\"one\"}");
+    insertSourceCase(20, 1000000000000020L, 1, "Submitted", "{\"field\":\"other\"}", "OTHER", "TestCase");
+    insertSourceCaseEvent(101, 10, "create", "Submitted", "{\"field\":\"one\"}", minutesAgo(60));
+    insertSourceCaseEvent(102, 20, "other-create", "Submitted", "{\"field\":\"other\"}", "TestCase", minutesAgo(60));
+    insertSourceCaseEvent(1001, 10, "update", "Updated", "{\"field\":\"two\"}", minutesAgo(60));
+
+    CcdDataMigrationRunResult result = task(PRELOAD_EVENTS, 1001, 1).runMigration();
+
     assertThat(result.eventsProcessed()).isEqualTo(2);
     assertThat(countRows("ccd.case_event")).isEqualTo(2);
     assertThat(localEventHwm()).isEqualTo(1001);
+    assertThat(sourceEventHwm()).isEqualTo(1001);
+  }
+
+  @Test
+  void preloadTreatsUnmatchedSourceJurisdictionAsCaughtUp() {
+    insertSourceCase(10, 1000000000000010L, 1, "Submitted", "{\"field\":\"one\"}");
+    insertSourceCaseEvent(101, 10, "create", "Submitted", "{\"field\":\"one\"}", minutesAgo(60));
+
+    var options = CcdDataMigrationTaskOptions.builder(List.of("TestCase"))
+        .sourceJurisdiction("OTHER")
+        .mode(PRELOAD_EVENTS)
+        .build();
+
+    CcdDataMigrationRunResult result = new CcdDataMigrationTask(jdbc, transactionManager, options).runMigration();
+
+    assertThat(result.caughtUp()).isTrue();
+    assertThat(result.eventsProcessed()).isZero();
+    assertThat(countRows("ccd.case_event")).isZero();
   }
 
   @Test
@@ -176,7 +228,7 @@ class CcdDataMigrationTaskIntegrationTest {
     insertSourceCaseEvent(101, 10, "create", "Submitted", "{\"field\":\"one\"}", minutesAgo(60));
     insertSourceCaseEvent(102, 10, "update", "Updated", "{\"field\":\"two\"}", minutesAgo(60));
 
-    CcdDataMigrationRunResult result = task(CUTOVER, 1, 1).runMigration();
+    CcdDataMigrationRunResult result = task(CUTOVER, 101, 1).runMigration();
 
     assertThat(result.caughtUp()).isFalse();
     assertThat(progressStatus()).isEqualTo("CUTOVER");
@@ -217,7 +269,7 @@ class CcdDataMigrationTaskIntegrationTest {
   @Test
   void failsWhenDecentralisedRuntimeIsEnabled() {
     insertSourceCase(10, 1000000000000010L, 1, "Submitted", "{\"field\":\"one\"}");
-    var options = CcdDataMigrationTaskOptions.builder(List.of("TestCase")).build();
+    var options = optionsBuilder(List.of("TestCase")).build();
 
     assertThatThrownBy(() -> new CcdDataMigrationTask(jdbc, transactionManager, options, () -> true).runMigration())
         .isInstanceOf(CcdDataMigrationException.class)
@@ -232,7 +284,7 @@ class CcdDataMigrationTaskIntegrationTest {
   void migratesSeededDatasetWithinPerfHarnessLimit() {
     int caseCount = Integer.getInteger("ccd.data-migration.perf.cases", 100_000);
     int eventsPerCase = Integer.getInteger("ccd.data-migration.perf.events-per-case", 10);
-    int eventBatchSize = Integer.getInteger("ccd.data-migration.perf.event-batch-size", 10_000);
+    int eventIdWindowSize = Integer.getInteger("ccd.data-migration.perf.event-id-window-size", 10_000);
     final Duration maxElapsed = Duration.ofSeconds(Long.getLong("ccd.data-migration.perf.max-seconds", 900L));
 
     seedSourceDataset(PERF_CASE_TYPE, caseCount, eventsPerCase);
@@ -242,16 +294,18 @@ class CcdDataMigrationTaskIntegrationTest {
         jdbc,
         transactionManager,
         CcdDataMigrationTaskOptions.builder(List.of(PERF_CASE_TYPE))
+            .sourceJurisdiction("TEST")
             .mode(PRELOAD_EVENTS)
-            .eventBatchSize(eventBatchSize)
+            .eventIdWindowSize(eventIdWindowSize)
             .build()
     ).runMigration();
     CcdDataMigrationRunResult cutoverResult = new CcdDataMigrationTask(
         jdbc,
         transactionManager,
         CcdDataMigrationTaskOptions.builder(List.of(PERF_CASE_TYPE))
+            .sourceJurisdiction("TEST")
             .mode(CUTOVER)
-            .eventBatchSize(eventBatchSize)
+            .eventIdWindowSize(eventIdWindowSize)
             .build()
     ).runMigration();
     final Duration elapsed = Duration.between(started, Instant.now());
@@ -270,12 +324,12 @@ class CcdDataMigrationTaskIntegrationTest {
 
   private CcdDataMigrationTask task(
       CcdDataMigrationMode mode,
-      int eventBatchSize,
+      int eventIdWindowSize,
       int maxBatchesPerRun
   ) {
-    var options = CcdDataMigrationTaskOptions.builder(List.of("TestCase"))
+    var options = optionsBuilder(List.of("TestCase"))
         .mode(mode)
-        .eventBatchSize(eventBatchSize)
+        .eventIdWindowSize(eventIdWindowSize)
         .maxBatchesPerRun(maxBatchesPerRun)
         .build();
     return new CcdDataMigrationTask(jdbc, transactionManager, options);
@@ -413,12 +467,26 @@ class CcdDataMigrationTaskIntegrationTest {
   }
 
   private void insertSourceCase(long id, long reference, int version, String state, String data) {
+    insertSourceCase(id, reference, version, state, data, "TEST", "TestCase");
+  }
+
+  private void insertSourceCase(
+      long id,
+      long reference,
+      int version,
+      String state,
+      String data,
+      String jurisdiction,
+      String caseTypeId
+  ) {
     var params = new MapSqlParameterSource()
         .addValue("id", id)
         .addValue("reference", reference)
         .addValue("version", version)
         .addValue("state", state)
-        .addValue("data", data);
+        .addValue("data", data)
+        .addValue("jurisdiction", jurisdiction)
+        .addValue("caseTypeId", caseTypeId);
     jdbc.update(
         """
         insert into source.case_data (
@@ -443,8 +511,8 @@ class CcdDataMigrationTaskIntegrationTest {
           timestamp '2024-01-01 00:00:00',
           null,
           timestamp '2024-01-01 00:00:00',
-          'TEST',
-          'TestCase',
+          :jurisdiction,
+          :caseTypeId,
           :state,
           :data::jsonb,
           '{}'::jsonb,
@@ -684,7 +752,7 @@ class CcdDataMigrationTaskIntegrationTest {
         """,
         new MapSqlParameterSource()
             .addValue("taskName", "ccd-data-migration")
-            .addValue("configHash", CcdDataMigrationTaskOptions.builder(List.of("TestCase"))
+            .addValue("configHash", optionsBuilder(List.of("TestCase"))
                 .build()
                 .migrationConfigHash())
     );
@@ -707,11 +775,16 @@ class CcdDataMigrationTaskIntegrationTest {
         """,
         new MapSqlParameterSource()
             .addValue("taskName", "ccd-data-migration")
-            .addValue("configHash", CcdDataMigrationTaskOptions.builder(List.of("TestCase"))
+            .addValue("configHash", optionsBuilder(List.of("TestCase"))
                 .build()
                 .migrationConfigHash())
             .addValue("cutoverEventHwm", cutoverEventHwm)
     );
+  }
+
+  private CcdDataMigrationTaskOptions.Builder optionsBuilder(List<String> caseTypeIds) {
+    return CcdDataMigrationTaskOptions.builder(caseTypeIds)
+        .sourceJurisdiction("TEST");
   }
 
   private void seedSourceDataset(String caseTypeId, int caseCount, int eventsPerCase) {
@@ -781,7 +854,7 @@ class CcdDataMigrationTaskIntegrationTest {
           proxied_by_last_name
         )
         select
-          9000000000000000::bigint + ((case_number - 1) * :eventsPerCase) + event_number,
+          ((case_number - 1) * :eventsPerCase) + event_number,
           timestamp '2024-01-01 00:00:00' + make_interval(secs => ((case_number - 1) * :eventsPerCase)
               + event_number),
           'PUBLIC'::ccd.securityclassification,
@@ -874,6 +947,14 @@ class CcdDataMigrationTaskIntegrationTest {
         where cd.case_type_id = :caseTypeId
         """,
         Map.of("caseTypeId", "TestCase"),
+        Long.class
+    );
+  }
+
+  private long sourceEventHwm() {
+    return jdbc.queryForObject(
+        "select source_event_hwm from ccd.ccd_data_migration_progress where task_name = :taskName",
+        Map.of("taskName", "ccd-data-migration"),
         Long.class
     );
   }

--- a/sdk/decentralised-runtime/src/test/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTaskIntegrationTest.java
+++ b/sdk/decentralised-runtime/src/test/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTaskIntegrationTest.java
@@ -123,6 +123,27 @@ class CcdDataMigrationTaskIntegrationTest {
   }
 
   @Test
+  void cutoverScopesCaseDataRefreshAndQueueCleanupBySourceJurisdiction() {
+    insertSourceCase(10, 1000000000000010L, 1, "Submitted", "{\"field\":\"one\"}");
+    insertSourceCaseEvent(101, 10, "create", "Submitted", "{\"field\":\"one\"}", minutesAgo(60));
+    task(PRELOAD_EVENTS, 1000, 10).runMigration();
+
+    insertSourceCase(20, 1000000000000020L, 2, "Updated", "{\"field\":\"source-other\"}", "OTHER", "TestCase");
+    insertTargetCase(20, 1000000000000020L, 1, "Submitted", "{\"field\":\"target-other\"}", "OTHER", "TestCase", 5);
+    insertElasticsearchQueueRow(1000000000000020L, 5);
+
+    CcdDataMigrationRunResult result = task(CUTOVER, 1000, 10).runMigration();
+
+    assertThat(result.caughtUp()).isTrue();
+    assertThat(progressStatus()).isEqualTo("COMPLETE");
+    assertThat(targetCaseState(20)).isEqualTo("Submitted");
+    assertThat(targetCaseData(20)).isEqualTo("{\"field\": \"target-other\"}");
+    assertThat(caseRevision(20)).isEqualTo(5);
+    assertThat(countElasticsearchQueueRows("TestCase")).isEqualTo(1);
+    assertThat(caseDataTriggerEnabled("trigger_enqueue_case_revision")).isTrue();
+  }
+
+  @Test
   void completedCutoverRerunValidatesBeforeReEnablingElasticsearchQueueTrigger() {
     insertTargetCase(10, 1000000000000010L, 1, "Submitted", "{\"field\":\"one\"}", 1);
     createCompleteProgress(101);
@@ -136,7 +157,7 @@ class CcdDataMigrationTaskIntegrationTest {
   }
 
   @Test
-  void preloadResumesFromLocalTargetEventHighWaterMark() {
+  void preloadFailsWhenTargetEventsExistWithoutSourceProgress() {
     insertSourceCase(10, 1000000000000010L, 1, "Submitted", "{\"field\":\"one\"}");
     insertSourceCaseEvent(101, 10, "create", "Submitted", "{\"field\":\"one\"}", minutesAgo(60));
     insertSourceCaseEvent(102, 10, "update", "Updated", "{\"field\":\"two\"}", minutesAgo(60));
@@ -144,14 +165,13 @@ class CcdDataMigrationTaskIntegrationTest {
     insertTargetEvent(101, 10, "create", "Submitted", "{\"field\":\"one\"}", 1);
     createProgress();
 
-    CcdDataMigrationRunResult result = task(PRELOAD_EVENTS, 10, 10).runMigration();
-
-    assertThat(result.caughtUp()).isTrue();
-    assertThat(result.eventsProcessed()).isEqualTo(1);
-    assertThat(countRows("ccd.case_event")).isEqualTo(2);
-    assertThat(localEventHwm()).isEqualTo(102);
-    assertThat(caseEventRevision(102)).isEqualTo(2);
-    assertElasticsearchQueueEmpty();
+    assertThatThrownBy(() -> task(PRELOAD_EVENTS, 10, 10).runMigration())
+        .isInstanceOf(CcdDataMigrationException.class)
+        .hasMessageContaining("target already contains migrated events")
+        .hasMessageContaining("source_event_hwm is zero");
+    assertThat(countRows("ccd.case_event")).isEqualTo(1);
+    assertThat(localEventHwm()).isEqualTo(101);
+    assertThat(sourceEventHwm()).isZero();
   }
 
   @Test
@@ -615,7 +635,7 @@ class CcdDataMigrationTaskIntegrationTest {
   }
 
   private void insertTargetCase(long id, long reference, int version, String state, String data, long caseRevision) {
-    insertTargetCase(id, reference, version, state, data, "TestCase", caseRevision);
+    insertTargetCase(id, reference, version, state, data, "TEST", "TestCase", caseRevision);
   }
 
   private void insertTargetCase(
@@ -624,6 +644,19 @@ class CcdDataMigrationTaskIntegrationTest {
       int version,
       String state,
       String data,
+      String caseTypeId,
+      long caseRevision
+  ) {
+    insertTargetCase(id, reference, version, state, data, "TEST", caseTypeId, caseRevision);
+  }
+
+  private void insertTargetCase(
+      long id,
+      long reference,
+      int version,
+      String state,
+      String data,
+      String jurisdiction,
       String caseTypeId,
       long caseRevision
   ) {
@@ -652,7 +685,7 @@ class CcdDataMigrationTaskIntegrationTest {
           timestamp '2024-01-01 00:00:00',
           null,
           timestamp '2024-01-01 00:00:00',
-          'TEST',
+          :jurisdiction,
           :caseTypeId,
           :state,
           :data::jsonb,
@@ -667,6 +700,7 @@ class CcdDataMigrationTaskIntegrationTest {
             .addValue("version", version)
             .addValue("state", state)
             .addValue("data", data)
+            .addValue("jurisdiction", jurisdiction)
             .addValue("caseTypeId", caseTypeId)
             .addValue("caseRevision", caseRevision)
     );
@@ -904,6 +938,16 @@ class CcdDataMigrationTaskIntegrationTest {
         """,
         Map.of("caseTypeId", caseTypeId),
         Long.class
+    );
+  }
+
+  private void insertElasticsearchQueueRow(long reference, long caseRevision) {
+    jdbc.update(
+        """
+        insert into ccd.es_queue(reference, case_revision)
+        values (:reference, :caseRevision)
+        """,
+        Map.of("reference", reference, "caseRevision", caseRevision)
     );
   }
 

--- a/sdk/decentralised-runtime/src/test/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTaskOptionsTest.java
+++ b/sdk/decentralised-runtime/src/test/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTaskOptionsTest.java
@@ -107,6 +107,20 @@ class CcdDataMigrationTaskOptionsTest {
   }
 
   @Test
+  void deprecatedEventBatchSizePropertyAppliesOnlyWhenEventIdWindowSizeIsUnset() {
+    var properties = new CcdDataMigrationProperties();
+    properties.setCaseTypeIds(List.of("TestCase"));
+    properties.setSourceJurisdiction("TEST");
+    properties.setEventBatchSize(123);
+
+    assertThat(properties.toOptions().eventIdWindowSize()).isEqualTo(123);
+
+    properties.setEventIdWindowSize(456);
+
+    assertThat(properties.toOptions().eventIdWindowSize()).isEqualTo(456);
+  }
+
+  @Test
   void rejectsBlankSourceJurisdiction() {
     assertThatThrownBy(() -> CcdDataMigrationTaskOptions.builder(List.of("TestCase"))
         .sourceJurisdiction(" ")

--- a/sdk/decentralised-runtime/src/test/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTaskOptionsTest.java
+++ b/sdk/decentralised-runtime/src/test/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTaskOptionsTest.java
@@ -11,11 +11,12 @@ class CcdDataMigrationTaskOptionsTest {
 
   @Test
   void buildsWithDefaults() {
-    var options = CcdDataMigrationTaskOptions.builder(List.of("TestCase")).build();
+    var options = builder(List.of("TestCase")).build();
 
     assertThat(options.taskName()).isEqualTo("ccd-data-migration");
     assertThat(options.mode()).isEqualTo(CcdDataMigrationMode.PRELOAD_EVENTS);
-    assertThat(options.eventBatchSize()).isEqualTo(10_000);
+    assertThat(options.sourceJurisdiction()).isEqualTo("TEST");
+    assertThat(options.eventIdWindowSize()).isEqualTo(1_000_000);
     assertThat(options.caseRevisionOffset()).isEqualTo(1_000_000_000L);
     assertThat(options.maxBatchesPerRun()).isEqualTo(Integer.MAX_VALUE);
     assertThat(options.maxRunTime()).isNull();
@@ -24,17 +25,17 @@ class CcdDataMigrationTaskOptionsTest {
 
   @Test
   void migrationConfigHashIgnoresRuntimeLimitsAndCaseTypeOrder() {
-    var first = CcdDataMigrationTaskOptions.builder(List.of("CaseB", "CaseA"))
+    var first = builder(List.of("CaseB", "CaseA"))
         .mode(CcdDataMigrationMode.CUTOVER)
-        .eventBatchSize(1)
+        .eventIdWindowSize(1)
         .maxBatchesPerRun(1)
         .maxRunTime(Duration.ofMinutes(10))
         .statementTimeout(Duration.ofSeconds(30))
         .build();
 
-    var second = CcdDataMigrationTaskOptions.builder(List.of("CaseA", "CaseB"))
+    var second = builder(List.of("CaseA", "CaseB"))
         .mode(CcdDataMigrationMode.VALIDATE_ONLY)
-        .eventBatchSize(500)
+        .eventIdWindowSize(500)
         .maxBatchesPerRun(500)
         .maxRunTime(Duration.ofHours(4))
         .statementTimeout(Duration.ofMinutes(15))
@@ -46,12 +47,17 @@ class CcdDataMigrationTaskOptionsTest {
 
   @Test
   void migrationConfigHashChangesForMigrationIdentityChanges() {
-    var original = CcdDataMigrationTaskOptions.builder(List.of("TestCase")).build();
+    var original = builder(List.of("TestCase")).build();
 
-    assertThat(CcdDataMigrationTaskOptions.builder(List.of("OtherCase")).build().migrationConfigHash())
+    assertThat(builder(List.of("OtherCase")).build().migrationConfigHash())
         .isNotEqualTo(original.migrationConfigHash());
-    assertThat(CcdDataMigrationTaskOptions.builder(List.of("TestCase"))
+    assertThat(builder(List.of("TestCase"))
         .caseRevisionOffset(2_000_000_000L)
+        .build()
+        .migrationConfigHash())
+        .isNotEqualTo(original.migrationConfigHash());
+    assertThat(builder(List.of("TestCase"))
+        .sourceJurisdiction("OTHER")
         .build()
         .migrationConfigHash())
         .isNotEqualTo(original.migrationConfigHash());
@@ -59,14 +65,14 @@ class CcdDataMigrationTaskOptionsTest {
 
   @Test
   void rejectsEmptyCaseTypeIds() {
-    assertThatThrownBy(() -> CcdDataMigrationTaskOptions.builder(List.of()).build())
+    assertThatThrownBy(() -> builder(List.of()).build())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("caseTypeIds");
   }
 
   @Test
   void rejectsNonPositiveMaxRunTime() {
-    assertThatThrownBy(() -> CcdDataMigrationTaskOptions.builder(List.of("TestCase"))
+    assertThatThrownBy(() -> builder(List.of("TestCase"))
         .maxRunTime(Duration.ZERO)
         .build())
         .isInstanceOf(IllegalArgumentException.class)
@@ -74,12 +80,44 @@ class CcdDataMigrationTaskOptionsTest {
   }
 
   @Test
+  void rejectsNonPositiveEventIdWindowSize() {
+    assertThatThrownBy(() -> builder(List.of("TestCase"))
+        .eventIdWindowSize(0)
+        .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("eventIdWindowSize");
+  }
+
+  @Test
   void rejectsNonPositiveStatementTimeout() {
-    assertThatThrownBy(() -> CcdDataMigrationTaskOptions.builder(List.of("TestCase"))
+    assertThatThrownBy(() -> builder(List.of("TestCase"))
         .statementTimeout(Duration.ZERO)
         .build())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("statementTimeout");
+  }
+
+  @Test
+  @SuppressWarnings("deprecation")
+  void supportsDeprecatedEventBatchSizeAlias() {
+    assertThat(builder(List.of("TestCase"))
+        .eventBatchSize(123)
+        .build()
+        .eventIdWindowSize()).isEqualTo(123);
+  }
+
+  @Test
+  void rejectsBlankSourceJurisdiction() {
+    assertThatThrownBy(() -> CcdDataMigrationTaskOptions.builder(List.of("TestCase"))
+        .sourceJurisdiction(" ")
+        .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("sourceJurisdiction");
+  }
+
+  private CcdDataMigrationTaskOptions.Builder builder(List<String> caseTypeIds) {
+    return CcdDataMigrationTaskOptions.builder(caseTypeIds)
+        .sourceJurisdiction("TEST");
   }
 
 }

--- a/sdk/decentralised-runtime/src/test/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTaskOptionsTest.java
+++ b/sdk/decentralised-runtime/src/test/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTaskOptionsTest.java
@@ -98,29 +98,6 @@ class CcdDataMigrationTaskOptionsTest {
   }
 
   @Test
-  @SuppressWarnings("deprecation")
-  void supportsDeprecatedEventBatchSizeAlias() {
-    assertThat(builder(List.of("TestCase"))
-        .eventBatchSize(123)
-        .build()
-        .eventIdWindowSize()).isEqualTo(123);
-  }
-
-  @Test
-  void deprecatedEventBatchSizePropertyAppliesOnlyWhenEventIdWindowSizeIsUnset() {
-    var properties = new CcdDataMigrationProperties();
-    properties.setCaseTypeIds(List.of("TestCase"));
-    properties.setSourceJurisdiction("TEST");
-    properties.setEventBatchSize(123);
-
-    assertThat(properties.toOptions().eventIdWindowSize()).isEqualTo(123);
-
-    properties.setEventIdWindowSize(456);
-
-    assertThat(properties.toOptions().eventIdWindowSize()).isEqualTo(456);
-  }
-
-  @Test
   void rejectsBlankSourceJurisdiction() {
     assertThatThrownBy(() -> CcdDataMigrationTaskOptions.builder(List.of("TestCase"))
         .sourceJurisdiction(" ")

--- a/test-projects/e2e/src/test/java/uk/gov/hmcts/divorce/integration/CcdDataMigrationSpringBootTest.java
+++ b/test-projects/e2e/src/test/java/uk/gov/hmcts/divorce/integration/CcdDataMigrationSpringBootTest.java
@@ -18,6 +18,7 @@ import uk.gov.hmcts.ccd.sdk.migration.CcdDataMigrationTask;
     "spring.autoconfigure.exclude=com.azure.spring.cloud.autoconfigure.implementation.jms.ServiceBusJmsAutoConfiguration",
     "ccd.data-migration.enabled=true",
     "ccd.data-migration.case-type-ids[0]=NFD",
+    "ccd.data-migration.source-jurisdiction=DIVORCE",
     "ccd.sdk.decentralised=true"
 })
 class CcdDataMigrationSpringBootTest {


### PR DESCRIPTION
Adds source jurisdiction as mandatory CCD data migration configuration and uses it to bootstrap the first event batch from source case data. This avoids starting an empty migration at event id zero and relying on a global case_event id walk before the first matching case type event is found.