### PR TITLE
Add case event significant item migration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,16 @@ tasks.register('verifyCcdMigrationFdw', Exec) {
     description = 'Validates and applies the FDW CCD migration scripts after the e2e environment is up'
     dependsOn ':e2e:dumpCCDDefinitions'
     workingDir projectDir
+    ['/opt/homebrew/opt/libpq/bin', '/usr/local/opt/libpq/bin'].find {
+        file("${it}/pg_dump").exists()
+    }.with {
+        if (it != null) {
+            environment 'PG_DUMP_BIN', "${it}/pg_dump"
+            environment 'PSQL_BIN', "${it}/psql"
+            environment 'CREATEDB_BIN', "${it}/createdb"
+            environment 'DROPDB_BIN', "${it}/dropdb"
+        }
+    }
     commandLine 'bash', '-lc', './scripts/test-migrate-ccd-data-fdw.sh'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -43,12 +43,26 @@ tasks.register('publishToAzureArtifacts') { task ->
     }
 }
 
+def configurePostgresClientTools = { task ->
+    ['/opt/homebrew/opt/libpq/bin', '/usr/local/opt/libpq/bin'].find {
+        file("${it}/pg_dump").exists()
+    }.with {
+        if (it != null) {
+            task.environment 'PG_DUMP_BIN', "${it}/pg_dump"
+            task.environment 'PSQL_BIN', "${it}/psql"
+            task.environment 'CREATEDB_BIN', "${it}/createdb"
+            task.environment 'DROPDB_BIN', "${it}/dropdb"
+        }
+    }
+}
+
 tasks.register('verifyCcdMigration', Exec) {
     group = 'verification'
     description = 'Validates the classic and FDW CCD migration scripts after the e2e environment is up'
     dependsOn ':e2e:dumpCCDDefinitions'
     dependsOn 'verifyCcdMigrationFdw'
     workingDir projectDir
+    configurePostgresClientTools(it)
     commandLine 'bash', '-lc', './scripts/test-migrate-ccd-data.sh'
 }
 
@@ -57,16 +71,7 @@ tasks.register('verifyCcdMigrationFdw', Exec) {
     description = 'Validates and applies the FDW CCD migration scripts after the e2e environment is up'
     dependsOn ':e2e:dumpCCDDefinitions'
     workingDir projectDir
-    ['/opt/homebrew/opt/libpq/bin', '/usr/local/opt/libpq/bin'].find {
-        file("${it}/pg_dump").exists()
-    }.with {
-        if (it != null) {
-            environment 'PG_DUMP_BIN', "${it}/pg_dump"
-            environment 'PSQL_BIN', "${it}/psql"
-            environment 'CREATEDB_BIN', "${it}/createdb"
-            environment 'DROPDB_BIN', "${it}/dropdb"
-        }
-    }
+    configurePostgresClientTools(it)
     commandLine 'bash', '-lc', './scripts/test-migrate-ccd-data-fdw.sh'
 }
 

--- a/docs/ccd-data-migration-task.md
+++ b/docs/ccd-data-migration-task.md
@@ -17,8 +17,8 @@ writes for the selected case types have been frozen.
 The task has one implementation with explicit modes:
 
 * `PRELOAD_EVENTS`: scheduled before cutover. Copies immutable source events by event ID high-water
-  mark, copies any linked `case_event_significant_items`, and inserts provisional parent `case_data`
-  rows so the target FK remains valid.
+  mark, then copies linked `case_event_significant_items` with a separate event ID high-water mark,
+  and inserts provisional parent `case_data` rows so the target FK remains valid.
 * `CUTOVER`: explicit operator action during downtime. Captures the cutover event high-water mark,
   copies the final event delta, refreshes target `case_data` from source, sets final case revisions,
   resets sequences, validates, and marks the migration complete.
@@ -36,12 +36,16 @@ The preload path keeps the target tables constraint-valid after every committed 
 * the unique `(case_data_id, case_revision)` index stays in place
 * `case_event.version` and `case_event.case_revision` are calculated before insert
 * `case_event` user triggers are not disabled
-* resume position is stored as a source `case_event.id` window position after each committed batch
+* event resume position is stored as a source `case_event.id` window position after each committed
+  event batch
+* significant-item resume position is stored independently, also by source `case_event.id` window
 
 Preloaded `case_data` is provisional. Its purpose is to satisfy the event FK. Every copied event
 batch inserts missing parent source `case_data` rows for that batch. Significant items are copied in
-the same committed event ID window as their parent events. `CUTOVER` overwrites target `case_data`
-columns from source, then sets
+a separate stage that only joins to already copied target events. This lets an environment with an
+existing event preload backfill the new `case_event_significant_items` table without resetting or
+rewalking the long `case_event` migration progress. `CUTOVER` overwrites target `case_data` columns
+from source, then sets
 `case_data.case_revision = max(case_event.case_revision) + caseRevisionOffset`.
 
 The runtime `case_data` revision trigger is deliberately disabled only inside the cutover refresh
@@ -65,6 +69,7 @@ state:
 * `status`: `PRELOAD`, `CUTOVER`, or `COMPLETE`
 * `cutover_event_hwm`
 * `source_event_hwm`
+* `significant_items_event_hwm`
 * timestamps
 
 The migration configuration hash covers the migration identity. Runtime limits such as

--- a/docs/ccd-data-migration-task.md
+++ b/docs/ccd-data-migration-task.md
@@ -1,19 +1,24 @@
 # CCD data migration task
 
 This page covers the SDK `CcdDataMigrationTask`, a reusable Java migration runner for services that
-need to copy large CCD `case_event` history and final `case_data` rows into their decentralised
-runtime database.
+need to copy large CCD `case_event` history, event significant items and final `case_data` rows into
+their decentralised runtime database.
 
-Use this task after the FDW setup in [`fdw-data-migration.md`](fdw-data-migration.md) has been
-created. The task is designed for repeated event preloads before downtime, followed by an explicit
-operator-run cutover after source writes for the selected case types have been frozen.
+Use this task after the FDW setup in [`fdw-data-migration.md`](fdw-data-migration.md) has created
+the FDW server, user mapping, and at least one of the CCD source foreign tables. The task creates
+any missing `fdw_stage.case_data`, `fdw_stage.case_event`, or
+`fdw_stage.case_event_significant_items` foreign tables from the same existing FDW table options so
+environments that were set up before a table was added can self-heal. The task is designed for
+repeated event preloads before downtime, followed by an explicit operator-run cutover after source
+writes for the selected case types have been frozen.
 
 ## Modes
 
 The task has one implementation with explicit modes:
 
 * `PRELOAD_EVENTS`: scheduled before cutover. Copies immutable source events by event ID high-water
-  mark and inserts provisional parent `case_data` rows so the target FK remains valid.
+  mark, copies any linked `case_event_significant_items`, and inserts provisional parent `case_data`
+  rows so the target FK remains valid.
 * `CUTOVER`: explicit operator action during downtime. Captures the cutover event high-water mark,
   copies the final event delta, refreshes target `case_data` from source, sets final case revisions,
   resets sequences, validates, and marks the migration complete.
@@ -27,14 +32,16 @@ writes for the selected case types and wait for in-flight source transactions to
 The preload path keeps the target tables constraint-valid after every committed batch:
 
 * the `case_event -> case_data` FK stays in place
+* the `case_event_significant_items -> case_event` FK stays in place
 * the unique `(case_data_id, case_revision)` index stays in place
 * `case_event.version` and `case_event.case_revision` are calculated before insert
 * `case_event` user triggers are not disabled
 * resume position is stored as a source `case_event.id` window position after each committed batch
 
 Preloaded `case_data` is provisional. Its purpose is to satisfy the event FK. Every copied event
-batch inserts missing parent source `case_data` rows for that batch. `CUTOVER` overwrites target
-`case_data` columns from source, then sets
+batch inserts missing parent source `case_data` rows for that batch. Significant items are copied in
+the same committed event ID window as their parent events. `CUTOVER` overwrites target `case_data`
+columns from source, then sets
 `case_data.case_revision = max(case_event.case_revision) + caseRevisionOffset`.
 
 The runtime `case_data` revision trigger is deliberately disabled only inside the cutover refresh
@@ -148,7 +155,9 @@ period. Run `CUTOVER` explicitly during the agreed downtime window.
 
 ## Validation
 
-After cutover, the task logs final `case_data` and `case_event` counts for the selected case types.
+After cutover, the task logs final `case_data`, `case_event`, and `case_event_significant_items`
+counts for the selected case types. It also compares source and target significant-item counts up to
+the captured cutover event high-water mark.
 
 ## Performance Harness
 

--- a/docs/ccd-data-migration-task.md
+++ b/docs/ccd-data-migration-task.md
@@ -17,11 +17,11 @@ writes for the selected case types have been frozen.
 The task has one implementation with explicit modes:
 
 * `PRELOAD_EVENTS`: scheduled before cutover. Copies immutable source events by event ID high-water
-  mark, then copies linked `case_event_significant_items` with a separate event ID high-water mark,
-  and inserts provisional parent `case_data` rows so the target FK remains valid.
+  mark and inserts provisional parent `case_data` rows so the target FK remains valid.
 * `CUTOVER`: explicit operator action during downtime. Captures the cutover event high-water mark,
-  copies the final event delta, refreshes target `case_data` from source, sets final case revisions,
-  resets sequences, validates, and marks the migration complete.
+  copies the final event delta, copies linked `case_event_significant_items` in a single set-based
+  query, refreshes target `case_data` from source, sets final case revisions, resets sequences,
+  validates, and marks the migration complete.
 * `VALIDATE_ONLY`: runs final source-vs-target validation without copying data.
 
 Do not switch to `CUTOVER` automatically from a scheduler. The operator must first freeze source
@@ -36,16 +36,13 @@ The preload path keeps the target tables constraint-valid after every committed 
 * the unique `(case_data_id, case_revision)` index stays in place
 * `case_event.version` and `case_event.case_revision` are calculated before insert
 * `case_event` user triggers are not disabled
-* event resume position is stored as a source `case_event.id` window position after each committed
-  event batch
-* significant-item resume position is stored independently, also by source `case_event.id` window
+* resume position is stored as a source `case_event.id` window position after each committed batch
 
 Preloaded `case_data` is provisional. Its purpose is to satisfy the event FK. Every copied event
-batch inserts missing parent source `case_data` rows for that batch. Significant items are copied in
-a separate stage that only joins to already copied target events. This lets an environment with an
-existing event preload backfill the new `case_event_significant_items` table without resetting or
-rewalking the long `case_event` migration progress. `CUTOVER` overwrites target `case_data` columns
-from source, then sets
+batch inserts missing parent source `case_data` rows for that batch. Significant items are copied
+only during `CUTOVER`, using one `insert into ... select` query that reads source significant items
+and joins through already migrated target events up to the captured cutover event high-water mark.
+`CUTOVER` then overwrites target `case_data` columns from source and sets
 `case_data.case_revision = max(case_event.case_revision) + caseRevisionOffset`.
 
 The runtime `case_data` revision trigger is deliberately disabled only inside the cutover refresh
@@ -69,7 +66,6 @@ state:
 * `status`: `PRELOAD`, `CUTOVER`, or `COMPLETE`
 * `cutover_event_hwm`
 * `source_event_hwm`
-* `significant_items_event_hwm`
 * timestamps
 
 The migration configuration hash covers the migration identity. Runtime limits such as

--- a/docs/fdw-data-migration.md
+++ b/docs/fdw-data-migration.md
@@ -16,19 +16,24 @@ flowchart LR
     subgraph CCD["CCD central database"]
       A["public.case_data"]
       B["public.case_event"]
+      G["public.case_event_significant_items"]
     end
 
     subgraph APP["Application database"]
       C["fdw_stage.case_data"]
       D["fdw_stage.case_event"]
+      H["fdw_stage.case_event_significant_items"]
       E["ccd.case_data"]
       F["ccd.case_event"]
+      I["ccd.case_event_significant_items"]
     end
 
     A -->|postgres_fdw| C
     B -->|postgres_fdw| D
+    G -->|postgres_fdw| H
     C -->|insert/update| E
     D -->|insert/update| F
+    H -->|insert/update| I
 ```
 
 ## Prerequisites
@@ -62,8 +67,10 @@ You need:
 
 * a target application database connection string with permission to create extensions, schemas,
   FDW servers, user mappings and foreign tables for setup
-* a source CCD database user with read access to `case_data` and `case_event`
-* a target application database user with write access to `ccd.case_data` and `ccd.case_event`
+* a source CCD database user with read access to `case_data`, `case_event`, and
+  `case_event_significant_items`
+* a target application database user with write access to `ccd.case_data`, `ccd.case_event`, and
+  `ccd.case_event_significant_items`
 * permission for the migration user to run `SET LOCAL session_replication_role = replica`
 * network connectivity from the target database to the source CCD database
 * `psql` available on the machine running the scripts
@@ -119,6 +126,7 @@ The setup script creates:
 * foreign tables:
   * `fdw_stage.case_data`
   * `fdw_stage.case_event`
+  * `fdw_stage.case_event_significant_items`
 
 The foreign tables are created with `fetch_size '10000'` so large reads do not use the
 `postgres_fdw` default of 100 rows per cursor fetch. If the FDW objects were created before this
@@ -128,7 +136,10 @@ option existed, recreate them with `setup-ccd-data-fdw.sh --apply` before runnin
 ## Phase 2: Run the migration
 
 The migration script only reads from the FDW foreign tables. It does not create or write to
-`fdw_stage`.
+`fdw_stage`. The Java `CcdDataMigrationTask` is a little more forgiving: if the FDW server and at
+least one of the expected source foreign tables already exist, it creates any missing
+`fdw_stage.case_data`, `fdw_stage.case_event`, or `fdw_stage.case_event_significant_items` foreign
+tables from the same server, source schema, and fetch size options.
 
 Required environment variables:
 
@@ -163,9 +174,10 @@ The validation checks:
 * target database connectivity
 * `pgcrypto` is installed
 * the migration user can temporarily disable target triggers with `session_replication_role`
-* `fdw_stage.case_data` and `fdw_stage.case_event` exist as foreign tables
+* `fdw_stage.case_data`, `fdw_stage.case_event`, and `fdw_stage.case_event_significant_items` exist
+  as foreign tables
 * source `case_data` count for the selected case types
-* target `case_data` and `case_event` counts
+* target `case_data`, `case_event`, and `case_event_significant_items` counts
 
 Run a full migration:
 
@@ -190,6 +202,7 @@ types, clean the target CCD tables before rerunning:
 truncate table
   ccd.case_event_audit,
   ccd.es_queue,
+  ccd.case_event_significant_items,
   ccd.case_event,
   ccd.case_data
 restart identity cascade;
@@ -206,15 +219,17 @@ The migration script:
 * temporarily disables `case_event` user triggers so delta upserts do not write audit rows
 * upserts `case_data` rows from `fdw_stage.case_data` with target triggers suppressed
 * upserts `case_event` rows from `fdw_stage.case_event` for cases already loaded into `ccd.case_data`
+* upserts `case_event_significant_items` rows linked to copied target events
 * reruns `case_data` upsert to catch parent cases changed while events were copying
 * reruns `case_event` upsert to catch events for cases loaded or updated by the second `case_data` pass
+* reruns `case_event_significant_items` upsert for events caught by the second `case_event` pass
 * recalculates `case_event.version` and `case_event.case_revision`
 * updates `case_data.case_revision` to the max event revision plus `CASE_REVISION_OFFSET`, with
   target triggers suppressed
-* checks for orphaned events
+* checks for orphaned events and significant items
 * restores the event revision unique index, FK and `case_event` user triggers
-* resets `case_event_id_seq`
-* runs final validation for counts, orphan events, duplicate event revisions and case revision alignment
+* resets `case_event_id_seq` and `case_event_significant_items_id_seq`
+* runs final validation for counts, orphan events/items, duplicate event revisions and case revision alignment
 
 If the script exits after dropping the FK and unique index, it attempts to restore them in an exit
 handler before returning the original failure status. If automatic restoration fails, manual

--- a/docs/fdw-data-migration.md
+++ b/docs/fdw-data-migration.md
@@ -141,6 +141,11 @@ least one of the expected source foreign tables already exist, it creates any mi
 `fdw_stage.case_data`, `fdw_stage.case_event`, or `fdw_stage.case_event_significant_items` foreign
 tables from the same server, source schema, and fetch size options.
 
+For services using the Java task, `case_event_significant_items` is copied as a separate resumable
+stage tracked by `ccd.ccd_data_migration_progress.significant_items_event_hwm`. If events have
+already been preloaded, the task can backfill significant items up to the existing event high-water
+mark without resetting `source_event_hwm` or rewalking the long `case_event` copy.
+
 Required environment variables:
 
 ```bash

--- a/docs/fdw-data-migration.md
+++ b/docs/fdw-data-migration.md
@@ -141,10 +141,9 @@ least one of the expected source foreign tables already exist, it creates any mi
 `fdw_stage.case_data`, `fdw_stage.case_event`, or `fdw_stage.case_event_significant_items` foreign
 tables from the same server, source schema, and fetch size options.
 
-For services using the Java task, `case_event_significant_items` is copied as a separate resumable
-stage tracked by `ccd.ccd_data_migration_progress.significant_items_event_hwm`. If events have
-already been preloaded, the task can backfill significant items up to the existing event high-water
-mark without resetting `source_event_hwm` or rewalking the long `case_event` copy.
+For services using the Java task, `case_event_significant_items` is copied during `CUTOVER` after
+events have caught up. It uses one set-based insert query joined through the migrated target events
+up to the captured cutover event high-water mark, so the preload event walk is not restarted.
 
 Required environment variables:
 

--- a/scripts/migrate-ccd-data-fdw.sh
+++ b/scripts/migrate-ccd-data-fdw.sh
@@ -8,10 +8,12 @@ set -euo pipefail
 # Populates:
 #   ccd.case_data
 #   ccd.case_event
+#   ccd.case_event_significant_items
 #
 # From remote source tables:
 #   FDW_SCHEMA.case_data
 #   FDW_SCHEMA.case_event
+#   FDW_SCHEMA.case_event_significant_items
 #
 # Requires the FDW objects to have already been created by:
 #   ./setup-ccd-data-fdw.sh --apply
@@ -154,14 +156,14 @@ SQL
   fi
 
   missing_table_count="$(psql_dst --quiet -tA <<'SQL'
-select 2 - count(*)
+select 3 - count(*)
 from (
   select c.relname
   from pg_foreign_table ft
   join pg_class c on c.oid = ft.ftrelid
   join pg_namespace n on n.oid = c.relnamespace
   where n.nspname = :'fdw_schema'
-    and c.relname in ('case_data', 'case_event')
+    and c.relname in ('case_data', 'case_event', 'case_event_significant_items')
 ) as fdw_tables;
 SQL
 )"
@@ -188,6 +190,7 @@ and (
 );
 
 select 'source case_event' as table_name, 'unknown - slow query' as count;
+select 'source case_event_significant_items' as table_name, 'unknown - slow query' as count;
 
 select 'target case_data' as table_name, count(*)
 from :dst_schema.case_data
@@ -196,6 +199,12 @@ where case_type_id in (:case_type_ids);
 select 'target case_event' as table_name, count(*)
 from :dst_schema.case_event
 where case_type_id in (:case_type_ids);
+
+select 'target case_event_significant_items' as table_name, count(*)
+from :dst_schema.case_event_significant_items item
+join :dst_schema.case_event ce
+  on ce.id = item.case_event_id
+where ce.case_type_id in (:case_type_ids);
 SQL
 }
 
@@ -386,6 +395,50 @@ commit;
 SQL
 }
 
+load_case_event_significant_items() {
+  log "Loading/upserting case_event_significant_items..."
+
+  psql_dst <<'SQL'
+begin;
+set local session_replication_role = replica;
+
+insert into :dst_schema.case_event_significant_items (
+    id,
+    description,
+    "type",
+    url,
+    case_event_id
+)
+select
+    item.id,
+    item.description,
+    item."type"::text:::"dst_schema".significant_item_type,
+    item.url,
+    item.case_event_id
+from :fdw_schema.case_event_significant_items item
+join :fdw_schema.case_event ce
+  on ce.id = item.case_event_id
+join :dst_schema.case_event target_event
+  on target_event.id = item.case_event_id
+join :dst_schema.case_data cd
+  on cd.id = target_event.case_data_id
+where cd.case_type_id in (:case_type_ids)
+and ce.case_type_id in (:case_type_ids)
+and (
+    nullif(:'delta_since', '') is null
+    or ce.created_date >= nullif(:'delta_since', '')::timestamp
+)
+on conflict (id) do update
+set
+    description = excluded.description,
+    "type" = excluded."type",
+    url = excluded.url,
+    case_event_id = excluded.case_event_id;
+
+commit;
+SQL
+}
+
 recalculate_revisions() {
   log "Recalculating case_event.version and case_event.case_revision locally..."
 
@@ -434,9 +487,9 @@ SQL
 }
 
 validate_no_orphans() {
-  log "Checking for orphaned case_event rows..."
+  log "Checking for orphaned case_event and significant item rows..."
 
-  local orphan_count
+  local orphan_count significant_item_orphan_count
 
   orphan_count="$(psql_dst --quiet -tA <<'SQL'
 select count(*)
@@ -448,8 +501,18 @@ where d.id is null
 SQL
 )"
 
-  if [[ "$orphan_count" != "0" ]]; then
-    log "ERROR: Found ${orphan_count} orphaned case_event rows. Not restoring FK."
+  significant_item_orphan_count="$(psql_dst --quiet -tA <<'SQL'
+select count(*)
+from :dst_schema.case_event_significant_items item
+left join :dst_schema.case_event ce
+  on ce.id = item.case_event_id
+where ce.id is null;
+SQL
+)"
+
+  if [[ "$orphan_count" != "0" || "$significant_item_orphan_count" != "0" ]]; then
+    log "ERROR: Found orphan rows: case_event=${orphan_count}, significant_items=${significant_item_orphan_count}."
+    log "Not restoring FK."
     exit 1
   fi
 }
@@ -486,6 +549,12 @@ select setval(
   (select coalesce(max(id), 1) from :dst_schema.case_event),
   true
 );
+
+select setval(
+  format('%I.case_event_significant_items_id_seq', :'dst_schema')::regclass,
+  (select coalesce(max(id), 1) from :dst_schema.case_event_significant_items),
+  true
+);
 SQL
 }
 
@@ -505,12 +574,26 @@ where case_type_id in (:case_type_ids)
 group by case_type_id
 order by case_type_id;
 
+select 'target case_event_significant_items by case_type' as check_name, ce.case_type_id, count(*)
+from :dst_schema.case_event_significant_items item
+join :dst_schema.case_event ce
+  on ce.id = item.case_event_id
+where ce.case_type_id in (:case_type_ids)
+group by ce.case_type_id
+order by ce.case_type_id;
+
 select 'orphan case_event rows' as check_name, count(*)
 from :dst_schema.case_event e
 left join :dst_schema.case_data d
   on d.id = e.case_data_id
 where d.id is null
   and e.case_type_id in (:case_type_ids);
+
+select 'orphan case_event_significant_items rows' as check_name, count(*)
+from :dst_schema.case_event_significant_items item
+left join :dst_schema.case_event ce
+  on ce.id = item.case_event_id
+where ce.id is null;
 
 select 'duplicate event revisions' as check_name, count(*)
 from (
@@ -598,11 +681,13 @@ main() {
   prepare_target
   load_case_data
   load_case_events
+  load_case_event_significant_items
 
   # Important: catch parent cases created while events were being copied.
   load_case_data
   # Then catch events for cases loaded or updated by the second case_data pass.
   load_case_events
+  load_case_event_significant_items
 
   recalculate_revisions
   validate_no_orphans

--- a/scripts/migrate-ccd-data.sh
+++ b/scripts/migrate-ccd-data.sh
@@ -211,6 +211,44 @@ EOF
     psql "$DST_DSN" --set=ON_ERROR_STOP=on --no-psqlrc --quiet -c "$insert_sql"
 }
 
+copy_case_event_significant_items() {
+  log "Copying case_event_significant_items rows linked to migrated events..."
+  local select_sql
+  local insert_sql
+  select_sql=$(cat <<EOF
+COPY (
+  SELECT
+      item.id,
+      item.description,
+      item."type",
+      item.url,
+      item.case_event_id
+  FROM public.case_event_significant_items item
+       JOIN public.case_event ce ON ce.id = item.case_event_id
+       JOIN public.case_data cd ON cd.id = ce.case_data_id
+  WHERE cd.case_type_id = '${CASE_TYPE}'
+  ORDER BY item.id ASC
+) TO STDOUT WITH (FORMAT CSV);
+EOF
+)
+  insert_sql=$(cat <<'EOF'
+BEGIN;
+SET LOCAL session_replication_role = replica;
+COPY ccd.case_event_significant_items (
+    id,
+    description,
+    "type",
+    url,
+    case_event_id
+) FROM STDIN WITH (FORMAT CSV);
+COMMIT;
+EOF
+)
+
+  psql "$SRC_DSN" --set=ON_ERROR_STOP=on --no-psqlrc --tuples-only --quiet -c "$select_sql" | \
+    psql "$DST_DSN" --set=ON_ERROR_STOP=on --no-psqlrc --quiet -c "$insert_sql"
+}
+
 align_case_revisions() {
   log "Aligning case_data.case_revision with migrated event counts plus offset..."
   # We have seen CCD cases where case versions and event counts drift; ensure revisions match event history
@@ -243,22 +281,31 @@ reset_sequences() {
   # duplicate-key error once decentralised writes resume.
   psql "$DST_DSN" --set=ON_ERROR_STOP=on --no-psqlrc --tuples-only --quiet <<'SQL' >/dev/null
 SELECT setval('ccd.case_event_id_seq', COALESCE((SELECT MAX(id) FROM ccd.case_event), 1), true);
+SELECT setval(
+  'ccd.case_event_significant_items_id_seq',
+  COALESCE((SELECT MAX(id) FROM ccd.case_event_significant_items), 1),
+  true
+);
 SQL
 }
 
 report_counts() {
-  local src_cases src_events dst_cases dst_events
+  local src_cases src_events src_significant_items dst_cases dst_events dst_significant_items
   src_cases=$(psql "$SRC_DSN" --set=ON_ERROR_STOP=on --no-psqlrc --quiet -tA \
     -c "SELECT COUNT(*) FROM public.case_data WHERE case_type_id = '${CASE_TYPE}'")
   src_events=$(psql "$SRC_DSN" --set=ON_ERROR_STOP=on --no-psqlrc --quiet -tA \
     -c "SELECT COUNT(*) FROM public.case_event ce JOIN public.case_data cd ON cd.id = ce.case_data_id WHERE cd.case_type_id = '${CASE_TYPE}'")
+  src_significant_items=$(psql "$SRC_DSN" --set=ON_ERROR_STOP=on --no-psqlrc --quiet -tA \
+    -c "SELECT COUNT(*) FROM public.case_event_significant_items item JOIN public.case_event ce ON ce.id = item.case_event_id JOIN public.case_data cd ON cd.id = ce.case_data_id WHERE cd.case_type_id = '${CASE_TYPE}'")
   dst_cases=$(psql "$DST_DSN" --set=ON_ERROR_STOP=on --no-psqlrc --quiet -tA \
     -c "SELECT COUNT(*) FROM ccd.case_data WHERE case_type_id = '${CASE_TYPE}'")
   dst_events=$(psql "$DST_DSN" --set=ON_ERROR_STOP=on --no-psqlrc --quiet -tA \
     -c "SELECT COUNT(*) FROM ccd.case_event ce JOIN ccd.case_data cd ON cd.id = ce.case_data_id WHERE cd.case_type_id = '${CASE_TYPE}'")
+  dst_significant_items=$(psql "$DST_DSN" --set=ON_ERROR_STOP=on --no-psqlrc --quiet -tA \
+    -c "SELECT COUNT(*) FROM ccd.case_event_significant_items item JOIN ccd.case_event ce ON ce.id = item.case_event_id JOIN ccd.case_data cd ON cd.id = ce.case_data_id WHERE cd.case_type_id = '${CASE_TYPE}'")
 
-  log "Source counts: case_data=${src_cases}, case_event=${src_events}"
-  log "Target counts: case_data=${dst_cases}, case_event=${dst_events}"
+  log "Source counts: case_data=${src_cases}, case_event=${src_events}, case_event_significant_items=${src_significant_items}"
+  log "Target counts: case_data=${dst_cases}, case_event=${dst_events}, case_event_significant_items=${dst_significant_items}"
 }
 
 main() {
@@ -278,6 +325,7 @@ main() {
   log "Validation succeeded. Proceeding with migration..."
   copy_case_data
   copy_case_event
+  copy_case_event_significant_items
   align_case_revisions
   reset_sequences
   report_counts

--- a/scripts/migration-test/lib.sh
+++ b/scripts/migration-test/lib.sh
@@ -92,6 +92,7 @@ clear_target_data() {
   echo "Ensuring target database is empty"
   psql_dst <<'SQL'
 set client_min_messages to warning;
+delete from ccd.case_event_significant_items;
 delete from ccd.case_event;
 delete from ccd.case_data;
 SQL
@@ -145,7 +146,7 @@ SQL
 }
 
 assert_migrated_counts_match_source() {
-  local src_cases src_events dst_cases dst_events
+  local src_cases src_events src_significant_items dst_cases dst_events dst_significant_items
 
   echo "Validating migrated record counts"
   src_cases="$(psql_src --quiet -tA <<'SQL'
@@ -157,6 +158,16 @@ SQL
   src_events="$(psql_src --quiet -tA <<'SQL'
 select count(*)
 from case_event ce
+join case_data cd
+  on cd.id = ce.case_data_id
+where cd.case_type_id = :'case_type';
+SQL
+)"
+  src_significant_items="$(psql_src --quiet -tA <<'SQL'
+select count(*)
+from case_event_significant_items item
+join case_event ce
+  on ce.id = item.case_event_id
 join case_data cd
   on cd.id = ce.case_data_id
 where cd.case_type_id = :'case_type';
@@ -176,9 +187,22 @@ join ccd.case_data cd
 where cd.case_type_id = :'case_type';
 SQL
 )"
+  dst_significant_items="$(psql_dst --quiet -tA <<'SQL'
+select count(*)
+from ccd.case_event_significant_items item
+join ccd.case_event ce
+  on ce.id = item.case_event_id
+join ccd.case_data cd
+  on cd.id = ce.case_data_id
+where cd.case_type_id = :'case_type';
+SQL
+)"
 
-  if [[ "$src_cases" != "$dst_cases" || "$src_events" != "$dst_events" ]]; then
-    echo "Count mismatch after migration: source=${src_cases}/${src_events} target=${dst_cases}/${dst_events}" >&2
+  if [[ "$src_cases" != "$dst_cases"
+      || "$src_events" != "$dst_events"
+      || "$src_significant_items" != "$dst_significant_items" ]]; then
+    echo "Count mismatch after migration: source=${src_cases}/${src_events}/${src_significant_items}" \
+      "target=${dst_cases}/${dst_events}/${dst_significant_items}" >&2
     exit 1
   fi
 }
@@ -196,6 +220,18 @@ SQL
 
   if [[ "$copied_count" != "0" ]]; then
     echo "Out-of-scope parent event was migrated despite misleading event case_type_id" >&2
+    exit 1
+  fi
+
+  copied_count="$(psql_dst --quiet -tA <<'SQL'
+select count(*)
+from ccd.case_event_significant_items
+where id = 8199;
+SQL
+)"
+
+  if [[ "$copied_count" != "0" ]]; then
+    echo "Out-of-scope parent significant item was migrated despite misleading event case_type_id" >&2
     exit 1
   fi
 }
@@ -261,7 +297,7 @@ SQL
 }
 
 assert_no_orphans_or_duplicate_revisions() {
-  local orphan_count duplicate_count
+  local orphan_count significant_item_orphan_count duplicate_count
 
   echo "Validating no orphan events or duplicate event revisions"
   orphan_count="$(psql_dst --quiet -tA <<'SQL'
@@ -270,6 +306,14 @@ from ccd.case_event ce
 left join ccd.case_data cd
   on cd.id = ce.case_data_id
 where cd.id is null;
+SQL
+)"
+  significant_item_orphan_count="$(psql_dst --quiet -tA <<'SQL'
+select count(*)
+from ccd.case_event_significant_items item
+left join ccd.case_event ce
+  on ce.id = item.case_event_id
+where ce.id is null;
 SQL
 )"
   duplicate_count="$(psql_dst --quiet -tA <<'SQL'
@@ -286,24 +330,36 @@ from (
 SQL
 )"
 
-  if [[ "$orphan_count" != "0" || "$duplicate_count" != "0" ]]; then
-    echo "Invalid event state: orphans=${orphan_count}, duplicate revisions=${duplicate_count}" >&2
+  if [[ "$orphan_count" != "0" || "$significant_item_orphan_count" != "0" || "$duplicate_count" != "0" ]]; then
+    echo "Invalid event state: orphans=${orphan_count}, significant_item_orphans=${significant_item_orphan_count}," \
+      "duplicate revisions=${duplicate_count}" >&2
     exit 1
   fi
 }
 
 assert_case_event_sequence_is_safe() {
-  local sequence_is_safe
+  local sequence_is_safe significant_item_sequence_is_safe
 
   echo "Validating case_event_id_seq is above migrated event ids"
   sequence_is_safe="$(psql_dst --quiet -tA <<'SQL'
-select last_value >= (select max(id) from ccd.case_event)
+select last_value >= (select coalesce(max(id), 1) from ccd.case_event)
 from ccd.case_event_id_seq;
 SQL
 )"
 
   if [[ "$sequence_is_safe" != "t" ]]; then
     echo "case_event_id_seq was not reset above migrated event ids" >&2
+    exit 1
+  fi
+
+  significant_item_sequence_is_safe="$(psql_dst --quiet -tA <<'SQL'
+select last_value >= (select coalesce(max(id), 1) from ccd.case_event_significant_items)
+from ccd.case_event_significant_items_id_seq;
+SQL
+)"
+
+  if [[ "$significant_item_sequence_is_safe" != "t" ]]; then
+    echo "case_event_significant_items_id_seq was not reset above migrated significant item ids" >&2
     exit 1
   fi
 }

--- a/scripts/migration-test/seed-delta-source.sql
+++ b/scripts/migration-test/seed-delta-source.sql
@@ -86,3 +86,23 @@ insert into case_event (
     'summary',
     'description'
 );
+
+insert into case_event_significant_items (
+    id,
+    description,
+    "type",
+    url,
+    case_event_id
+) values (
+    8105,
+    'Delta document',
+    'DOCUMENT',
+    'http://dm-store/documents/8105',
+    9105
+), (
+    8106,
+    'New case document',
+    'DOCUMENT',
+    'http://dm-store/documents/8106',
+    9106
+);

--- a/scripts/migration-test/seed-source.sql
+++ b/scripts/migration-test/seed-source.sql
@@ -1,5 +1,6 @@
 set client_min_messages to warning;
 
+delete from case_event_significant_items where case_event_id in (9101, 9102, 9103, 9104, 9199);
 delete from case_event where case_data_id in (5601, 5602, 5603, 5604);
 delete from case_data where id in (5601, 5602, 5603, 5604);
 
@@ -159,4 +160,30 @@ insert into case_event (
     'PUBLIC',
     'summary',
     'description'
+);
+
+insert into case_event_significant_items (
+    id,
+    description,
+    "type",
+    url,
+    case_event_id
+) values (
+    8101,
+    'Main document',
+    'DOCUMENT',
+    'http://dm-store/documents/8101',
+    9102
+), (
+    8102,
+    'Extra document',
+    'DOCUMENT',
+    'http://dm-store/documents/8102',
+    9104
+), (
+    8199,
+    'Out of scope document',
+    'DOCUMENT',
+    'http://dm-store/documents/8199',
+    9199
 );

--- a/scripts/setup-ccd-data-fdw.sh
+++ b/scripts/setup-ccd-data-fdw.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 #   - postgres_fdw and pgcrypto extensions
 #   - FDW staging schema
 #   - FDW server and user mapping
-#   - foreign tables for source case_data and case_event
+#   - foreign tables for source case_data, case_event and case_event_significant_items
 #
 # This script is intended to be run once by the team with database privileges.
 # ------------------------------------------------------------------------------
@@ -153,6 +153,7 @@ setup_fdw() {
   psql_dst <<'SQL'
 create schema if not exists :"fdw_schema";
 
+drop foreign table if exists :"fdw_schema".case_event_significant_items;
 drop foreign table if exists :"fdw_schema".case_event;
 drop foreign table if exists :"fdw_schema".case_data;
 
@@ -223,6 +224,20 @@ options (
   table_name 'case_event',
   fetch_size '10000'
 );
+
+create foreign table :"fdw_schema".case_event_significant_items (
+  id bigint,
+  description varchar(64),
+  "type" text,
+  url text,
+  case_event_id bigint
+)
+server :"fdw_server"
+options (
+  schema_name :'src_schema',
+  table_name 'case_event_significant_items',
+  fetch_size '10000'
+);
 SQL
 }
 
@@ -232,7 +247,11 @@ grant_fdw_access() {
   psql_dst <<'SQL'
 grant usage on foreign server :"fdw_server" to :local_user_sql;
 grant usage on schema :"fdw_schema" to :local_user_sql;
-grant select on :"fdw_schema".case_data, :"fdw_schema".case_event to :local_user_sql;
+grant select on
+  :"fdw_schema".case_data,
+  :"fdw_schema".case_event,
+  :"fdw_schema".case_event_significant_items
+to :local_user_sql;
 SQL
 }
 
@@ -242,6 +261,8 @@ validate_fdw_tables() {
   psql_dst <<'SQL'
 select 'fdw case_data table' as check_name, to_regclass(:'fdw_schema' || '.case_data') as relation;
 select 'fdw case_event table' as check_name, to_regclass(:'fdw_schema' || '.case_event') as relation;
+select 'fdw case_event_significant_items table' as check_name,
+  to_regclass(:'fdw_schema' || '.case_event_significant_items') as relation;
 
 select 'source case_data reachable' as check_name, exists(
   select 1
@@ -252,6 +273,12 @@ select 'source case_data reachable' as check_name, exists(
 select 'source case_event reachable' as check_name, exists(
   select 1
   from :"fdw_schema".case_event
+  limit 1
+) as reachable;
+
+select 'source case_event_significant_items reachable' as check_name, exists(
+  select 1
+  from :"fdw_schema".case_event_significant_items
   limit 1
 ) as reachable;
 SQL

--- a/scripts/test-migrate-ccd-data-fdw.sh
+++ b/scripts/test-migrate-ccd-data-fdw.sh
@@ -91,7 +91,7 @@ join pg_class c
 join pg_namespace n
   on n.oid = c.relnamespace
 where n.nspname = '${FDW_SCHEMA}'
-  and c.relname in ('case_data', 'case_event');
+  and c.relname in ('case_data', 'case_event', 'case_event_significant_items');
 SQL
 )"
   source_case_count="$(psql_dst --quiet -tA <<SQL
@@ -101,7 +101,7 @@ where case_type_id = :'case_type';
 SQL
 )"
 
-  if [[ "$extension_count" != "2" || "$foreign_server_count" != "1" || "$foreign_table_count" != "2" || "$source_case_count" != "2" ]]; then
+  if [[ "$extension_count" != "2" || "$foreign_server_count" != "1" || "$foreign_table_count" != "3" || "$source_case_count" != "2" ]]; then
     echo "FDW setup validation failed:" \
       "extensions=${extension_count}, server=${foreign_server_count}," \
       "tables=${foreign_table_count}, source_cases=${source_case_count}" >&2
@@ -110,7 +110,7 @@ SQL
 }
 
 assert_delta_rows_migrated() {
-  local delta_event_count delta_case_count
+  local delta_event_count delta_case_count delta_significant_item_count
 
   echo "Validating delta rows were migrated"
   delta_event_count="$(psql_dst --quiet -tA <<'SQL'
@@ -125,9 +125,16 @@ from ccd.case_data
 where id = 5604;
 SQL
 )"
+  delta_significant_item_count="$(psql_dst --quiet -tA <<'SQL'
+select count(*)
+from ccd.case_event_significant_items
+where id in (8105, 8106);
+SQL
+)"
 
-  if [[ "$delta_event_count" != "2" || "$delta_case_count" != "1" ]]; then
-    echo "Delta migration failed: delta_cases=${delta_case_count}, delta_events=${delta_event_count}" >&2
+  if [[ "$delta_event_count" != "2" || "$delta_case_count" != "1" || "$delta_significant_item_count" != "2" ]]; then
+    echo "Delta migration failed: delta_cases=${delta_case_count}, delta_events=${delta_event_count}," \
+      "delta_significant_items=${delta_significant_item_count}" >&2
     exit 1
   fi
 }

--- a/sdk/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/api/callback/AboutToStartOrSubmitResponse.java
+++ b/sdk/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/api/callback/AboutToStartOrSubmitResponse.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import lombok.Builder;
 import lombok.Data;
 import uk.gov.hmcts.ccd.sdk.api.EventMetadata;
+import uk.gov.hmcts.reform.ccd.client.model.SignificantItem;
 
 @Builder
 @Data
@@ -31,4 +32,6 @@ public class AboutToStartOrSubmitResponse<T, S> {
   @JsonIgnore
   private EventMetadata eventMetadata;
 
+  @JsonProperty("significant_item")
+  private SignificantItem significantItem;
 }

--- a/sdk/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/api/callback/SubmitResponse.java
+++ b/sdk/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/api/callback/SubmitResponse.java
@@ -1,11 +1,13 @@
 package uk.gov.hmcts.ccd.sdk.api.callback;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 import lombok.Builder;
 import lombok.Data;
 import uk.gov.hmcts.ccd.sdk.api.EventMetadata;
 import uk.gov.hmcts.reform.ccd.client.model.Classification;
+import uk.gov.hmcts.reform.ccd.client.model.SignificantItem;
 
 /**
  * Response returned from decentralised submit handlers.
@@ -34,4 +36,7 @@ public class SubmitResponse<State> {
 
   @JsonIgnore
   private EventMetadata eventMetadata;
+
+  @JsonProperty("significant_item")
+  private SignificantItem significantItem;
 }

--- a/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/impl/AuditEventService.java
+++ b/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/impl/AuditEventService.java
@@ -3,10 +3,14 @@ package uk.gov.hmcts.ccd.sdk.impl;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -100,6 +104,8 @@ class AuditEventService {
       UUID idempotencyKey,
       Optional<uk.gov.hmcts.reform.ccd.client.model.SignificantItem> significantItem
   ) {
+    significantItem.ifPresent(this::validateSignificantItem);
+
     final String oldState = event.getCaseDetailsBefore() != null
         ? event.getCaseDetailsBefore().getState()
         : null;
@@ -220,6 +226,23 @@ class AuditEventService {
       );
     }
     return inserted.id();
+  }
+
+  private void validateSignificantItem(uk.gov.hmcts.reform.ccd.client.model.SignificantItem item) {
+    if (item.getType() == null || item.getType().isBlank()
+        || item.getDescription() == null || item.getDescription().isBlank()
+        || item.getUrl() == null || item.getUrl().isBlank()) {
+      return;
+    }
+
+    try {
+      new URI(item.getUrl()).toURL();
+    } catch (IllegalArgumentException | MalformedURLException | URISyntaxException e) {
+      throw new CallbackValidationException(
+          List.of("Significant item URL is not valid"),
+          Collections.emptyList()
+      );
+    }
   }
 
   private void saveSignificantItem(long caseEventId, uk.gov.hmcts.reform.ccd.client.model.SignificantItem item) {

--- a/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/impl/AuditEventService.java
+++ b/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/impl/AuditEventService.java
@@ -23,6 +23,7 @@ import org.springframework.web.server.ResponseStatusException;
 import uk.gov.hmcts.ccd.data.casedetails.SecurityClassification;
 import uk.gov.hmcts.ccd.decentralised.dto.DecentralisedAuditEvent;
 import uk.gov.hmcts.ccd.decentralised.dto.DecentralisedCaseEvent;
+import uk.gov.hmcts.ccd.domain.model.callbacks.SignificantItem;
 import uk.gov.hmcts.ccd.domain.model.std.AuditEvent;
 import uk.gov.hmcts.ccd.sdk.ResolvedConfigRegistry;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
@@ -40,9 +41,19 @@ class AuditEventService {
   public List<DecentralisedAuditEvent> loadHistory(long caseRef) {
     final String sql = """
         select ce.*,
-               cd.reference as "case_reference"
+               cd.reference as "case_reference",
+               significant_item.description as significant_item_description,
+               significant_item."type"::text as significant_item_type,
+               significant_item.url as significant_item_url
         from ccd.case_event ce
              join ccd.case_data cd on cd.id = ce.case_data_id
+             left join lateral (
+               select item.description, item."type", item.url
+               from ccd.case_event_significant_items item
+               where item.case_event_id = ce.id
+               order by item.id desc
+               limit 1
+             ) significant_item on true
         where cd.reference = :caseRef
         order by id desc
         """;
@@ -53,9 +64,19 @@ class AuditEventService {
   public DecentralisedAuditEvent loadHistoryEvent(long caseRef, long eventId) {
     final String sql = """
         select ce.*,
-               cd.reference as "case_reference"
+               cd.reference as "case_reference",
+               significant_item.description as significant_item_description,
+               significant_item."type"::text as significant_item_type,
+               significant_item.url as significant_item_url
         from ccd.case_event ce
              join ccd.case_data cd on cd.id = ce.case_data_id
+             left join lateral (
+               select item.description, item."type", item.url
+               from ccd.case_event_significant_items item
+               where item.case_event_id = ce.id
+               order by item.id desc
+               limit 1
+             ) significant_item on true
         where cd.reference = :caseRef and ce.id = :eventId
         """;
 
@@ -76,7 +97,8 @@ class AuditEventService {
       DecentralisedCaseEvent event,
       IdamService.User user,
       uk.gov.hmcts.ccd.domain.model.definition.CaseDetails currentView,
-      UUID idempotencyKey
+      UUID idempotencyKey,
+      Optional<uk.gov.hmcts.reform.ccd.client.model.SignificantItem> significantItem
   ) {
     final String oldState = event.getCaseDetailsBefore() != null
         ? event.getCaseDetailsBefore().getState()
@@ -174,6 +196,7 @@ class AuditEventService {
         .addValue("proxied_by_last_name", proxiedByLastName);
 
     var inserted = ndb.queryForObject(sql, params, this::mapInsertedAuditEvent);
+    significantItem.ifPresent(item -> saveSignificantItem(inserted.id(), item));
 
     if (this.publisher.isPresent()) {
       log.info(
@@ -197,6 +220,34 @@ class AuditEventService {
       );
     }
     return inserted.id();
+  }
+
+  private void saveSignificantItem(long caseEventId, uk.gov.hmcts.reform.ccd.client.model.SignificantItem item) {
+    if (item.getType() == null || item.getType().isBlank()
+        || item.getDescription() == null || item.getDescription().isBlank()) {
+      return;
+    }
+
+    ndb.update(
+        """
+        insert into ccd.case_event_significant_items (
+          description,
+          "type",
+          url,
+          case_event_id
+        ) values (
+          :description,
+          :type::ccd.significant_item_type,
+          :url,
+          :caseEventId
+        )
+        """,
+        new MapSqlParameterSource()
+            .addValue("description", item.getDescription())
+            .addValue("type", item.getType())
+            .addValue("url", item.getUrl())
+            .addValue("caseEventId", caseEventId)
+    );
   }
 
   private CaseDetails toCaseDetails(uk.gov.hmcts.ccd.domain.model.definition.CaseDetails data) {
@@ -223,6 +274,7 @@ class AuditEventService {
     auditEvent.setProxiedByFirstName(rs.getString("proxied_by_first_name"));
     auditEvent.setProxiedByLastName(rs.getString("proxied_by_last_name"));
     auditEvent.setSecurityClassification(SecurityClassification.valueOf(rs.getString("security_classification")));
+    auditEvent.setSignificantItem(mapSignificantItem(rs));
 
     auditEvent.setData(defaultMapper.readValue(rs.getString("data"), DATA_TYPE));
     auditEvent.setDataClassification(Map.of());
@@ -232,6 +284,19 @@ class AuditEventService {
     decentralisedEvent.setCaseReference(rs.getLong("case_reference"));
     decentralisedEvent.setEvent(auditEvent);
     return decentralisedEvent;
+  }
+
+  private SignificantItem mapSignificantItem(ResultSet rs) throws SQLException {
+    String type = rs.getString("significant_item_type");
+    if (type == null) {
+      return null;
+    }
+
+    var item = new SignificantItem();
+    item.setType(type);
+    item.setDescription(rs.getString("significant_item_description"));
+    item.setUrl(rs.getString("significant_item_url"));
+    return item;
   }
 
   private InsertedAuditEvent mapInsertedAuditEvent(ResultSet rs, int rowNum) throws SQLException {

--- a/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/impl/CaseSubmissionHandler.java
+++ b/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/impl/CaseSubmissionHandler.java
@@ -6,6 +6,7 @@ import java.util.function.Supplier;
 import uk.gov.hmcts.ccd.decentralised.dto.DecentralisedCaseEvent;
 import uk.gov.hmcts.ccd.sdk.api.EventMetadata;
 import uk.gov.hmcts.ccd.sdk.api.callback.SubmitResponse;
+import uk.gov.hmcts.reform.ccd.client.model.SignificantItem;
 
 /**
  * Defines a single submission flow. Implementations decide how to apply an event
@@ -41,6 +42,10 @@ interface CaseSubmissionHandler {
        * Optional replacement values for the case event audit metadata.
        */
       Optional<EventMetadata> eventMetadata,
+      /*
+       * Optional CCD significant item to associate with the created audit event.
+       */
+      Optional<SignificantItem> significantItem,
       /*
        * Deferred response builder executed post-transaction by {@link CaseSubmissionService}.
        */

--- a/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/impl/CaseSubmissionService.java
+++ b/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/impl/CaseSubmissionService.java
@@ -82,7 +82,13 @@ public class CaseSubmissionService {
     // Bookkeeping: update case_data metadata and optionally the legacy json blob
     upsertCase(event, handlerResult.dataUpdate());
     DecentralisedCaseDetails savedCaseDetails = caseProjectionService.load(event.getCaseDetails().getReference());
-    auditEventService.saveAuditRecord(event, user, savedCaseDetails.getCaseDetails(), idempotencyKey);
+    auditEventService.saveAuditRecord(
+        event,
+        user,
+        savedCaseDetails.getCaseDetails(),
+        idempotencyKey,
+        handlerResult.significantItem()
+    );
 
     var outcome = new SubmissionOutcome(savedCaseDetails, handlerResult.responseSupplier());
     return new TransactionResult(Optional.empty(), Optional.of(outcome));

--- a/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/impl/DecentralisedSubmissionHandler.java
+++ b/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/impl/DecentralisedSubmissionHandler.java
@@ -42,6 +42,7 @@ class DecentralisedSubmissionHandler implements CaseSubmissionHandler {
         state,
         securityClassification,
         Optional.ofNullable(outcome.getEventMetadata()),
+        Optional.ofNullable(outcome.getSignificantItem()),
         () -> outcome);
   }
 

--- a/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/impl/LegacyCallbackSubmissionHandler.java
+++ b/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/impl/LegacyCallbackSubmissionHandler.java
@@ -23,6 +23,7 @@ import uk.gov.hmcts.ccd.sdk.runtime.CcdCallbackExecutor;
 import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.ccd.client.model.Classification;
+import uk.gov.hmcts.reform.ccd.client.model.SignificantItem;
 import uk.gov.hmcts.reform.ccd.client.model.SubmittedCallbackResponse;
 
 /**
@@ -78,6 +79,7 @@ class LegacyCallbackSubmissionHandler implements CaseSubmissionHandler {
         state,
         securityClassification,
         Optional.ofNullable(outcome.eventMetadata()),
+        Optional.ofNullable(outcome.significantItem()),
         () -> {
           var builder = SubmitResponse.builder()
               .errors(errors)
@@ -104,11 +106,13 @@ class LegacyCallbackSubmissionHandler implements CaseSubmissionHandler {
 
     var response = new DecentralisedSubmitEventResponse();
     EventMetadata eventMetadata = null;
+    SignificantItem significantItem = null;
 
     if (eventConfig.getAboutToSubmitCallback() != null) {
       CallbackRequest request = buildCallbackRequest(event);
       AboutToStartOrSubmitResponse callbackResponse = executor.aboutToSubmit(request);
       eventMetadata = callbackResponse.getEventMetadata();
+      significantItem = callbackResponse.getSignificantItem();
 
       Map<String, JsonNode> normalisedData = callbackResponse.getData() == null
           ? Map.of()
@@ -129,7 +133,7 @@ class LegacyCallbackSubmissionHandler implements CaseSubmissionHandler {
     }
 
     boolean hasSubmitted = eventConfig.getSubmittedCallback() != null;
-    return new LegacySubmitOutcome(response, eventMetadata, hasSubmitted);
+    return new LegacySubmitOutcome(response, eventMetadata, significantItem, hasSubmitted);
   }
 
   private Optional<SubmittedCallbackResponse> runSubmittedCallback(DecentralisedCaseEvent event) {
@@ -178,6 +182,7 @@ class LegacyCallbackSubmissionHandler implements CaseSubmissionHandler {
 
   private record LegacySubmitOutcome(DecentralisedSubmitEventResponse response,
                                      EventMetadata eventMetadata,
+                                     SignificantItem significantItem,
                                      boolean runSubmittedCallback) {}
 
   @SneakyThrows

--- a/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/impl/json/JsonCallbackBridge.java
+++ b/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/impl/json/JsonCallbackBridge.java
@@ -44,6 +44,7 @@ import uk.gov.hmcts.ccd.sdk.api.callback.AboutToStartOrSubmitResponse;
 import uk.gov.hmcts.ccd.sdk.api.callback.AboutToSubmit;
 import uk.gov.hmcts.ccd.sdk.api.callback.Submitted;
 import uk.gov.hmcts.ccd.sdk.config.CcdCaseDataMapperConfiguration;
+import uk.gov.hmcts.reform.ccd.client.model.SignificantItem;
 import uk.gov.hmcts.reform.ccd.client.model.SubmittedCallbackResponse;
 
 @Component
@@ -133,7 +134,12 @@ public class JsonCallbackBridge {
         .dataClassification((Map<String, Object>) callbackResponse.get("data_classification"))
         .securityClassification((String) callbackResponse.get("security_classification"))
         .errorMessageOverride((String) callbackResponse.get("error_message_override"))
+        .significantItem(significantItem(callbackResponse.get("significant_item")))
         .build();
+  }
+
+  private SignificantItem significantItem(Object value) {
+    return value == null ? null : mapper.convertValue(value, SignificantItem.class);
   }
 
   private Object invoke(String callbackUrl,

--- a/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTask.java
+++ b/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTask.java
@@ -150,65 +150,107 @@ public class CcdDataMigrationTask implements Runnable {
 
     prepareElasticsearchQueueForMigration();
     long targetEventHwm = sourceEventHighWaterMark();
-    CopyTotals totals = copyEventBatches(targetEventHwm);
+    CopyTotals eventTotals = copyEventBatches(targetEventHwm);
     long sourceEventHwm = sourceEventProgressHighWaterMark();
-    boolean caughtUp = sourceEventHwm >= targetEventHwm;
+    CopyTotals significantItemTotals = copySignificantItemBatches(sourceEventHwm);
+    long significantItemsEventHwm = significantItemsEventProgressHighWaterMark();
+    boolean caughtUp = sourceEventHwm >= targetEventHwm && significantItemsEventHwm >= sourceEventHwm;
+    boolean stoppedByTimeLimit = eventTotals.stoppedByTimeLimit() || significantItemTotals.stoppedByTimeLimit();
     log.info(
         "Completed CCD data migration preload taskName={} targetEventHwm={} batches={} cases={} events={} "
-            + "caughtUp={} stoppedByTimeLimit={}",
+            + "significantItemBatches={} significantItems={} significantItemsEventHwm={} caughtUp={} "
+            + "stoppedByTimeLimit={}",
         options.taskName(),
         targetEventHwm,
-        totals.batches(),
+        eventTotals.batches(),
         0,
-        totals.events(),
+        eventTotals.events(),
+        significantItemTotals.batches(),
+        significantItemTotals.events(),
+        significantItemsEventHwm,
         caughtUp,
-        totals.stoppedByTimeLimit()
+        stoppedByTimeLimit
     );
     return new CcdDataMigrationRunResult(
         true,
-        totals.batches(),
+        eventTotals.batches() + significantItemTotals.batches(),
         0,
-        totals.events(),
+        eventTotals.events(),
         caughtUp,
-        totals.stoppedByTimeLimit()
+        stoppedByTimeLimit
     );
   }
 
   private CcdDataMigrationRunResult cutover() {
     Progress progress = getOrCreateProgress();
     if (STATUS_COMPLETE.equals(progress.status())) {
+      CopyTotals significantItemTotals = copySignificantItemBatches(progress.requiredCutoverEventHwm());
+      long significantItemsEventHwm = significantItemsEventProgressHighWaterMark();
+      if (significantItemTotals.stoppedByTimeLimit()
+          || significantItemsEventHwm < progress.requiredCutoverEventHwm()) {
+        log.info(
+            "CCD data migration completed cutover paused before significant item catchup taskName={} "
+                + "cutoverEventHwm={} significantItemsEventHwm={} significantItemBatches={} significantItems={} "
+                + "stoppedByTimeLimit={}",
+            options.taskName(),
+            progress.requiredCutoverEventHwm(),
+            significantItemsEventHwm,
+            significantItemTotals.batches(),
+            significantItemTotals.events(),
+            significantItemTotals.stoppedByTimeLimit()
+        );
+        return new CcdDataMigrationRunResult(
+            true,
+            significantItemTotals.batches(),
+            0,
+            0,
+            false,
+            significantItemTotals.stoppedByTimeLimit()
+        );
+      }
       transaction.execute(status -> {
+        applyMigrationStatementTimeout();
+        resetSequences();
         validateFinal(progress.requiredCutoverEventHwm());
         enableElasticsearchQueueTrigger();
         return null;
       });
-      return new CcdDataMigrationRunResult(true, 0, 0, 0, true, false);
+      return new CcdDataMigrationRunResult(true, significantItemTotals.batches(), 0, 0, true, false);
     }
 
     prepareElasticsearchQueueForMigration();
     long cutoverEventHwm = progress.cutoverEventHwm() == null
         ? captureCutoverEventHighWaterMark()
         : progress.cutoverEventHwm();
-    CopyTotals totals = copyEventBatches(cutoverEventHwm);
+    CopyTotals eventTotals = copyEventBatches(cutoverEventHwm);
     long sourceEventHwm = sourceEventProgressHighWaterMark();
-    if (totals.stoppedByTimeLimit() || sourceEventHwm < cutoverEventHwm) {
+    CopyTotals significantItemTotals = copySignificantItemBatches(sourceEventHwm);
+    long significantItemsEventHwm = significantItemsEventProgressHighWaterMark();
+    if (eventTotals.stoppedByTimeLimit()
+        || significantItemTotals.stoppedByTimeLimit()
+        || sourceEventHwm < cutoverEventHwm
+        || significantItemsEventHwm < sourceEventHwm) {
       log.info(
           "CCD data migration cutover paused before final refresh taskName={} cutoverEventHwm={} sourceEventHwm={} "
-              + "batches={} events={} stoppedByTimeLimit={}",
+              + "significantItemsEventHwm={} batches={} events={} significantItemBatches={} significantItems={} "
+              + "stoppedByTimeLimit={}",
           options.taskName(),
           cutoverEventHwm,
           sourceEventHwm,
-          totals.batches(),
-          totals.events(),
-          totals.stoppedByTimeLimit()
+          significantItemsEventHwm,
+          eventTotals.batches(),
+          eventTotals.events(),
+          significantItemTotals.batches(),
+          significantItemTotals.events(),
+          eventTotals.stoppedByTimeLimit() || significantItemTotals.stoppedByTimeLimit()
       );
       return new CcdDataMigrationRunResult(
           true,
-          totals.batches(),
+          eventTotals.batches() + significantItemTotals.batches(),
           0,
-          totals.events(),
+          eventTotals.events(),
           false,
-          totals.stoppedByTimeLimit()
+          eventTotals.stoppedByTimeLimit() || significantItemTotals.stoppedByTimeLimit()
       );
     }
     final int refreshedCases = refreshCutoverCaseData();
@@ -217,21 +259,23 @@ public class CcdDataMigrationTask implements Runnable {
 
     log.info(
         "Completed CCD data migration cutover taskName={} cutoverEventHwm={} batches={} refreshedCases={} events={} "
-            + "stoppedByTimeLimit={}",
+            + "significantItemBatches={} significantItems={} stoppedByTimeLimit={}",
         options.taskName(),
         cutoverEventHwm,
-        totals.batches(),
+        eventTotals.batches(),
         refreshedCases,
-        totals.events(),
-        totals.stoppedByTimeLimit()
+        eventTotals.events(),
+        significantItemTotals.batches(),
+        significantItemTotals.events(),
+        eventTotals.stoppedByTimeLimit() || significantItemTotals.stoppedByTimeLimit()
     );
     return new CcdDataMigrationRunResult(
         true,
-        totals.batches(),
+        eventTotals.batches() + significantItemTotals.batches(),
         refreshedCases,
-        totals.events(),
-        !totals.stoppedByTimeLimit(),
-        totals.stoppedByTimeLimit()
+        eventTotals.events(),
+        !(eventTotals.stoppedByTimeLimit() || significantItemTotals.stoppedByTimeLimit()),
+        eventTotals.stoppedByTimeLimit() || significantItemTotals.stoppedByTimeLimit()
     );
   }
 
@@ -257,19 +301,16 @@ public class CcdDataMigrationTask implements Runnable {
 
       long batchEndEventHwm = nextFixedEventWindowEnd(sourceEventHwm, targetEventHwm);
       long batchStartEventId = sourceEventHwm + 1L;
-      final int[] copiedSignificantItems = new int[1];
       int events = transaction.execute(status -> {
         applyMigrationStatementTimeout();
         int copiedEvents = copyNextEventBatch(batchStartEventId, batchEndEventHwm);
-        copiedSignificantItems[0] = copySignificantItemsForEventBatch(batchStartEventId, batchEndEventHwm);
         updateSourceEventProgressHighWaterMark(batchEndEventHwm);
         return copiedEvents;
       });
       totals = totals.plus(events);
       log.info(
           "CCD data migration progress taskName={} mode={} sourceEventHwm={} targetEventHwm={} "
-              + "batchStartEventId={} batchEndEventHwm={} batchEvents={} batchSignificantItems={} "
-              + "totalBatches={} totalEvents={}",
+              + "batchStartEventId={} batchEndEventHwm={} batchEvents={} totalBatches={} totalEvents={}",
           options.taskName(),
           options.mode(),
           sourceEventHwm,
@@ -277,7 +318,6 @@ public class CcdDataMigrationTask implements Runnable {
           batchStartEventId,
           batchEndEventHwm,
           events,
-          copiedSignificantItems[0],
           totals.batches(),
           totals.events()
       );
@@ -285,6 +325,54 @@ public class CcdDataMigrationTask implements Runnable {
       if (isTimeLimitReached(stopAt)) {
         log.info("Stopping CCD data migration taskName={} after event id window because time limit was reached",
             options.taskName());
+        totals = totals.markStoppedByTimeLimit();
+        break;
+      }
+    }
+    return totals;
+  }
+
+  private CopyTotals copySignificantItemBatches(long targetEventHwm) {
+    var totals = new CopyTotals();
+    LocalDateTime stopAt = calculateStopAt();
+
+    for (int i = 0; i < options.maxBatchesPerRun(); i++) {
+      long significantItemsEventHwm = significantItemsEventProgressHighWaterMark();
+      if (significantItemsEventHwm >= targetEventHwm) {
+        totals = totals.markCaughtUp();
+        break;
+      }
+
+      long batchEndEventHwm = nextFixedEventWindowEnd(significantItemsEventHwm, targetEventHwm);
+      long batchStartEventId = significantItemsEventHwm + 1L;
+      int significantItems = transaction.execute(status -> {
+        applyMigrationStatementTimeout();
+        int copiedSignificantItems = copySignificantItemsForEventBatch(batchStartEventId, batchEndEventHwm);
+        updateSignificantItemsEventProgressHighWaterMark(batchEndEventHwm);
+        return copiedSignificantItems;
+      });
+      totals = totals.plus(significantItems);
+      log.info(
+          "CCD data migration significant item progress taskName={} mode={} significantItemsEventHwm={} "
+              + "targetEventHwm={} batchStartEventId={} batchEndEventHwm={} batchSignificantItems={} "
+              + "totalBatches={} totalSignificantItems={}",
+          options.taskName(),
+          options.mode(),
+          significantItemsEventHwm,
+          targetEventHwm,
+          batchStartEventId,
+          batchEndEventHwm,
+          significantItems,
+          totals.batches(),
+          totals.events()
+      );
+
+      if (isTimeLimitReached(stopAt)) {
+        log.info(
+            "Stopping CCD data migration taskName={} after significant item event id window because time limit was "
+                + "reached",
+            options.taskName()
+        );
         totals = totals.markStoppedByTimeLimit();
         break;
       }
@@ -603,6 +691,34 @@ public class CcdDataMigrationTask implements Runnable {
     );
   }
 
+  private long significantItemsEventProgressHighWaterMark() {
+    Long hwm = db.queryForObject(
+        """
+        select significant_items_event_hwm
+        from ccd.ccd_data_migration_progress
+        where task_name = :taskName
+        """,
+        Map.of("taskName", options.taskName()),
+        Long.class
+    );
+    return hwm == null ? 0 : hwm;
+  }
+
+  private void updateSignificantItemsEventProgressHighWaterMark(long significantItemsEventHwm) {
+    db.update(
+        """
+        update ccd.ccd_data_migration_progress
+        set significant_items_event_hwm = :significantItemsEventHwm,
+            updated_at = now() at time zone 'UTC'
+        where task_name = :taskName
+        """,
+        Map.of(
+            "taskName", options.taskName(),
+            "significantItemsEventHwm", significantItemsEventHwm
+        )
+    );
+  }
+
   private long effectiveSourceEventHighWaterMark(long targetEventHwm) {
     long progressEventHwm = sourceEventProgressHighWaterMark();
     if (progressEventHwm > 0) {
@@ -843,6 +959,7 @@ public class CcdDataMigrationTask implements Runnable {
             'status',
             'cutover_event_hwm',
             'source_event_hwm',
+            'significant_items_event_hwm',
             'created_at',
             'updated_at'
           )
@@ -850,7 +967,7 @@ public class CcdDataMigrationTask implements Runnable {
         Map.of("schema", TARGET_SCHEMA),
         Integer.class
     );
-    if (columnCount == null || columnCount != 7) {
+    if (columnCount == null || columnCount != 8) {
       throw new CcdDataMigrationException(
           "CCD data migration progress table is missing or incomplete. "
               + "Run the decentralised-runtime Flyway migrations before starting the task."
@@ -881,7 +998,8 @@ public class CcdDataMigrationTask implements Runnable {
         select config_hash,
                status,
                cutover_event_hwm,
-               source_event_hwm
+               source_event_hwm,
+               significant_items_event_hwm
         from ccd.ccd_data_migration_progress
         where task_name = :taskName
         """,
@@ -917,7 +1035,8 @@ public class CcdDataMigrationTask implements Runnable {
         rs.getString("config_hash"),
         rs.getString("status"),
         cutoverEventHwm,
-        rs.getLong("source_event_hwm")
+        rs.getLong("source_event_hwm"),
+        rs.getLong("significant_items_event_hwm")
     );
   }
 
@@ -1228,7 +1347,13 @@ public class CcdDataMigrationTask implements Runnable {
     }
   }
 
-  private record Progress(String configHash, String status, Long cutoverEventHwm, long sourceEventHwm) {
+  private record Progress(
+      String configHash,
+      String status,
+      Long cutoverEventHwm,
+      long sourceEventHwm,
+      long significantItemsEventHwm
+  ) {
     long requiredCutoverEventHwm() {
       if (cutoverEventHwm == null) {
         throw new CcdDataMigrationException("cutover_event_hwm is not set for completed migration");

--- a/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTask.java
+++ b/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTask.java
@@ -150,132 +150,96 @@ public class CcdDataMigrationTask implements Runnable {
 
     prepareElasticsearchQueueForMigration();
     long targetEventHwm = sourceEventHighWaterMark();
-    CopyTotals eventTotals = copyEventBatches(targetEventHwm);
+    CopyTotals totals = copyEventBatches(targetEventHwm);
     long sourceEventHwm = sourceEventProgressHighWaterMark();
-    CopyTotals significantItemTotals = copySignificantItemBatches(sourceEventHwm);
-    long significantItemsEventHwm = significantItemsEventProgressHighWaterMark();
-    boolean caughtUp = sourceEventHwm >= targetEventHwm && significantItemsEventHwm >= sourceEventHwm;
-    boolean stoppedByTimeLimit = eventTotals.stoppedByTimeLimit() || significantItemTotals.stoppedByTimeLimit();
+    boolean caughtUp = sourceEventHwm >= targetEventHwm;
     log.info(
         "Completed CCD data migration preload taskName={} targetEventHwm={} batches={} cases={} events={} "
-            + "significantItemBatches={} significantItems={} significantItemsEventHwm={} caughtUp={} "
-            + "stoppedByTimeLimit={}",
+            + "caughtUp={} stoppedByTimeLimit={}",
         options.taskName(),
         targetEventHwm,
-        eventTotals.batches(),
+        totals.batches(),
         0,
-        eventTotals.events(),
-        significantItemTotals.batches(),
-        significantItemTotals.events(),
-        significantItemsEventHwm,
+        totals.events(),
         caughtUp,
-        stoppedByTimeLimit
+        totals.stoppedByTimeLimit()
     );
     return new CcdDataMigrationRunResult(
         true,
-        eventTotals.batches() + significantItemTotals.batches(),
+        totals.batches(),
         0,
-        eventTotals.events(),
+        totals.events(),
         caughtUp,
-        stoppedByTimeLimit
+        totals.stoppedByTimeLimit()
     );
   }
 
   private CcdDataMigrationRunResult cutover() {
     Progress progress = getOrCreateProgress();
     if (STATUS_COMPLETE.equals(progress.status())) {
-      CopyTotals significantItemTotals = copySignificantItemBatches(progress.requiredCutoverEventHwm());
-      long significantItemsEventHwm = significantItemsEventProgressHighWaterMark();
-      if (significantItemTotals.stoppedByTimeLimit()
-          || significantItemsEventHwm < progress.requiredCutoverEventHwm()) {
-        log.info(
-            "CCD data migration completed cutover paused before significant item catchup taskName={} "
-                + "cutoverEventHwm={} significantItemsEventHwm={} significantItemBatches={} significantItems={} "
-                + "stoppedByTimeLimit={}",
-            options.taskName(),
-            progress.requiredCutoverEventHwm(),
-            significantItemsEventHwm,
-            significantItemTotals.batches(),
-            significantItemTotals.events(),
-            significantItemTotals.stoppedByTimeLimit()
-        );
-        return new CcdDataMigrationRunResult(
-            true,
-            significantItemTotals.batches(),
-            0,
-            0,
-            false,
-            significantItemTotals.stoppedByTimeLimit()
-        );
-      }
       transaction.execute(status -> {
         applyMigrationStatementTimeout();
+        copySignificantItemsForCutover(progress.requiredCutoverEventHwm());
         resetSequences();
         validateFinal(progress.requiredCutoverEventHwm());
         enableElasticsearchQueueTrigger();
         return null;
       });
-      return new CcdDataMigrationRunResult(true, significantItemTotals.batches(), 0, 0, true, false);
+      return new CcdDataMigrationRunResult(true, 0, 0, 0, true, false);
     }
 
     prepareElasticsearchQueueForMigration();
     long cutoverEventHwm = progress.cutoverEventHwm() == null
         ? captureCutoverEventHighWaterMark()
         : progress.cutoverEventHwm();
-    CopyTotals eventTotals = copyEventBatches(cutoverEventHwm);
+    CopyTotals totals = copyEventBatches(cutoverEventHwm);
     long sourceEventHwm = sourceEventProgressHighWaterMark();
-    CopyTotals significantItemTotals = copySignificantItemBatches(sourceEventHwm);
-    long significantItemsEventHwm = significantItemsEventProgressHighWaterMark();
-    if (eventTotals.stoppedByTimeLimit()
-        || significantItemTotals.stoppedByTimeLimit()
-        || sourceEventHwm < cutoverEventHwm
-        || significantItemsEventHwm < sourceEventHwm) {
+    if (totals.stoppedByTimeLimit() || sourceEventHwm < cutoverEventHwm) {
       log.info(
           "CCD data migration cutover paused before final refresh taskName={} cutoverEventHwm={} sourceEventHwm={} "
-              + "significantItemsEventHwm={} batches={} events={} significantItemBatches={} significantItems={} "
-              + "stoppedByTimeLimit={}",
+              + "batches={} events={} stoppedByTimeLimit={}",
           options.taskName(),
           cutoverEventHwm,
           sourceEventHwm,
-          significantItemsEventHwm,
-          eventTotals.batches(),
-          eventTotals.events(),
-          significantItemTotals.batches(),
-          significantItemTotals.events(),
-          eventTotals.stoppedByTimeLimit() || significantItemTotals.stoppedByTimeLimit()
+          totals.batches(),
+          totals.events(),
+          totals.stoppedByTimeLimit()
       );
       return new CcdDataMigrationRunResult(
           true,
-          eventTotals.batches() + significantItemTotals.batches(),
+          totals.batches(),
           0,
-          eventTotals.events(),
+          totals.events(),
           false,
-          eventTotals.stoppedByTimeLimit() || significantItemTotals.stoppedByTimeLimit()
+          totals.stoppedByTimeLimit()
       );
     }
+    int significantItems = transaction.execute(status -> {
+      applyMigrationStatementTimeout();
+      return copySignificantItemsForCutover(cutoverEventHwm);
+    });
     final int refreshedCases = refreshCutoverCaseData();
     resetSequences();
     completeCutover(cutoverEventHwm);
 
     log.info(
         "Completed CCD data migration cutover taskName={} cutoverEventHwm={} batches={} refreshedCases={} events={} "
-            + "significantItemBatches={} significantItems={} stoppedByTimeLimit={}",
+            + "significantItems={} stoppedByTimeLimit={}",
         options.taskName(),
         cutoverEventHwm,
-        eventTotals.batches(),
+        totals.batches(),
         refreshedCases,
-        eventTotals.events(),
-        significantItemTotals.batches(),
-        significantItemTotals.events(),
-        eventTotals.stoppedByTimeLimit() || significantItemTotals.stoppedByTimeLimit()
+        totals.events(),
+        significantItems,
+        totals.stoppedByTimeLimit()
     );
     return new CcdDataMigrationRunResult(
         true,
-        eventTotals.batches() + significantItemTotals.batches(),
+        totals.batches(),
         refreshedCases,
-        eventTotals.events(),
-        !(eventTotals.stoppedByTimeLimit() || significantItemTotals.stoppedByTimeLimit()),
-        eventTotals.stoppedByTimeLimit() || significantItemTotals.stoppedByTimeLimit()
+        totals.events(),
+        !totals.stoppedByTimeLimit(),
+        totals.stoppedByTimeLimit()
     );
   }
 
@@ -325,54 +289,6 @@ public class CcdDataMigrationTask implements Runnable {
       if (isTimeLimitReached(stopAt)) {
         log.info("Stopping CCD data migration taskName={} after event id window because time limit was reached",
             options.taskName());
-        totals = totals.markStoppedByTimeLimit();
-        break;
-      }
-    }
-    return totals;
-  }
-
-  private CopyTotals copySignificantItemBatches(long targetEventHwm) {
-    var totals = new CopyTotals();
-    LocalDateTime stopAt = calculateStopAt();
-
-    for (int i = 0; i < options.maxBatchesPerRun(); i++) {
-      long significantItemsEventHwm = significantItemsEventProgressHighWaterMark();
-      if (significantItemsEventHwm >= targetEventHwm) {
-        totals = totals.markCaughtUp();
-        break;
-      }
-
-      long batchEndEventHwm = nextFixedEventWindowEnd(significantItemsEventHwm, targetEventHwm);
-      long batchStartEventId = significantItemsEventHwm + 1L;
-      int significantItems = transaction.execute(status -> {
-        applyMigrationStatementTimeout();
-        int copiedSignificantItems = copySignificantItemsForEventBatch(batchStartEventId, batchEndEventHwm);
-        updateSignificantItemsEventProgressHighWaterMark(batchEndEventHwm);
-        return copiedSignificantItems;
-      });
-      totals = totals.plus(significantItems);
-      log.info(
-          "CCD data migration significant item progress taskName={} mode={} significantItemsEventHwm={} "
-              + "targetEventHwm={} batchStartEventId={} batchEndEventHwm={} batchSignificantItems={} "
-              + "totalBatches={} totalSignificantItems={}",
-          options.taskName(),
-          options.mode(),
-          significantItemsEventHwm,
-          targetEventHwm,
-          batchStartEventId,
-          batchEndEventHwm,
-          significantItems,
-          totals.batches(),
-          totals.events()
-      );
-
-      if (isTimeLimitReached(stopAt)) {
-        log.info(
-            "Stopping CCD data migration taskName={} after significant item event id window because time limit was "
-                + "reached",
-            options.taskName()
-        );
         totals = totals.markStoppedByTimeLimit();
         break;
       }
@@ -507,7 +423,7 @@ public class CcdDataMigrationTask implements Runnable {
     );
   }
 
-  private int copySignificantItemsForEventBatch(long batchStartEventId, long batchEndEventHwm) {
+  private int copySignificantItemsForCutover(long cutoverEventHwm) {
     return db.update(
         """
         insert into ccd.case_event_significant_items (
@@ -530,15 +446,14 @@ public class CcdDataMigrationTask implements Runnable {
         where cd.jurisdiction = :sourceJurisdiction
           and cd.case_type_id in (:caseTypeIds)
           and ce.case_type_id in (:caseTypeIds)
-          and ce.id >= :batchStartEventId
-          and ce.id <= :batchEndEventHwm
+          and ce.id <= :cutoverEventHwm
         on conflict (id) do update
         set description = excluded.description,
             "type" = excluded."type",
             url = excluded.url,
             case_event_id = excluded.case_event_id
         """,
-        eventBatchParams(batchStartEventId, batchEndEventHwm)
+        baseParams().addValue("cutoverEventHwm", cutoverEventHwm)
     );
   }
 
@@ -687,34 +602,6 @@ public class CcdDataMigrationTask implements Runnable {
         Map.of(
             "taskName", options.taskName(),
             "sourceEventHwm", sourceEventHwm
-        )
-    );
-  }
-
-  private long significantItemsEventProgressHighWaterMark() {
-    Long hwm = db.queryForObject(
-        """
-        select significant_items_event_hwm
-        from ccd.ccd_data_migration_progress
-        where task_name = :taskName
-        """,
-        Map.of("taskName", options.taskName()),
-        Long.class
-    );
-    return hwm == null ? 0 : hwm;
-  }
-
-  private void updateSignificantItemsEventProgressHighWaterMark(long significantItemsEventHwm) {
-    db.update(
-        """
-        update ccd.ccd_data_migration_progress
-        set significant_items_event_hwm = :significantItemsEventHwm,
-            updated_at = now() at time zone 'UTC'
-        where task_name = :taskName
-        """,
-        Map.of(
-            "taskName", options.taskName(),
-            "significantItemsEventHwm", significantItemsEventHwm
         )
     );
   }
@@ -959,7 +846,6 @@ public class CcdDataMigrationTask implements Runnable {
             'status',
             'cutover_event_hwm',
             'source_event_hwm',
-            'significant_items_event_hwm',
             'created_at',
             'updated_at'
           )
@@ -967,7 +853,7 @@ public class CcdDataMigrationTask implements Runnable {
         Map.of("schema", TARGET_SCHEMA),
         Integer.class
     );
-    if (columnCount == null || columnCount != 8) {
+    if (columnCount == null || columnCount != 7) {
       throw new CcdDataMigrationException(
           "CCD data migration progress table is missing or incomplete. "
               + "Run the decentralised-runtime Flyway migrations before starting the task."
@@ -998,8 +884,7 @@ public class CcdDataMigrationTask implements Runnable {
         select config_hash,
                status,
                cutover_event_hwm,
-               source_event_hwm,
-               significant_items_event_hwm
+               source_event_hwm
         from ccd.ccd_data_migration_progress
         where task_name = :taskName
         """,
@@ -1035,8 +920,7 @@ public class CcdDataMigrationTask implements Runnable {
         rs.getString("config_hash"),
         rs.getString("status"),
         cutoverEventHwm,
-        rs.getLong("source_event_hwm"),
-        rs.getLong("significant_items_event_hwm")
+        rs.getLong("source_event_hwm")
     );
   }
 
@@ -1347,13 +1231,7 @@ public class CcdDataMigrationTask implements Runnable {
     }
   }
 
-  private record Progress(
-      String configHash,
-      String status,
-      Long cutoverEventHwm,
-      long sourceEventHwm,
-      long significantItemsEventHwm
-  ) {
+  private record Progress(String configHash, String status, Long cutoverEventHwm, long sourceEventHwm) {
     long requiredCutoverEventHwm() {
       if (cutoverEventHwm == null) {
         throw new CcdDataMigrationException("cutover_event_hwm is not set for completed migration");

--- a/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTask.java
+++ b/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTask.java
@@ -257,16 +257,19 @@ public class CcdDataMigrationTask implements Runnable {
 
       long batchEndEventHwm = nextFixedEventWindowEnd(sourceEventHwm, targetEventHwm);
       long batchStartEventId = sourceEventHwm + 1L;
+      final int[] copiedSignificantItems = new int[1];
       int events = transaction.execute(status -> {
         applyMigrationStatementTimeout();
         int copiedEvents = copyNextEventBatch(batchStartEventId, batchEndEventHwm);
+        copiedSignificantItems[0] = copySignificantItemsForEventBatch(batchStartEventId, batchEndEventHwm);
         updateSourceEventProgressHighWaterMark(batchEndEventHwm);
         return copiedEvents;
       });
       totals = totals.plus(events);
       log.info(
           "CCD data migration progress taskName={} mode={} sourceEventHwm={} targetEventHwm={} "
-              + "batchStartEventId={} batchEndEventHwm={} batchEvents={} totalBatches={} totalEvents={}",
+              + "batchStartEventId={} batchEndEventHwm={} batchEvents={} batchSignificantItems={} "
+              + "totalBatches={} totalEvents={}",
           options.taskName(),
           options.mode(),
           sourceEventHwm,
@@ -274,6 +277,7 @@ public class CcdDataMigrationTask implements Runnable {
           batchStartEventId,
           batchEndEventHwm,
           events,
+          copiedSignificantItems[0],
           totals.batches(),
           totals.events()
       );
@@ -410,6 +414,41 @@ public class CcdDataMigrationTask implements Runnable {
           coalesce(local_revisions.case_revision, 0) + calculated_revision
         from numbered_events
         left join local_revisions on local_revisions.case_data_id = numbered_events.case_data_id
+        """,
+        eventBatchParams(batchStartEventId, batchEndEventHwm)
+    );
+  }
+
+  private int copySignificantItemsForEventBatch(long batchStartEventId, long batchEndEventHwm) {
+    return db.update(
+        """
+        insert into ccd.case_event_significant_items (
+          id,
+          description,
+          "type",
+          url,
+          case_event_id
+        )
+        select
+          item.id,
+          item.description,
+          item."type"::ccd.significant_item_type,
+          item.url,
+          item.case_event_id
+        from fdw_stage.case_event_significant_items item
+        join fdw_stage.case_event ce on ce.id = item.case_event_id
+        join fdw_stage.case_data cd on cd.id = ce.case_data_id
+        join ccd.case_event target_event on target_event.id = item.case_event_id
+        where cd.jurisdiction = :sourceJurisdiction
+          and cd.case_type_id in (:caseTypeIds)
+          and ce.case_type_id in (:caseTypeIds)
+          and ce.id >= :batchStartEventId
+          and ce.id <= :batchEndEventHwm
+        on conflict (id) do update
+        set description = excluded.description,
+            "type" = excluded."type",
+            url = excluded.url,
+            case_event_id = excluded.case_event_id
         """,
         eventBatchParams(batchStartEventId, batchEndEventHwm)
     );
@@ -634,6 +673,12 @@ public class CcdDataMigrationTask implements Runnable {
   private void validateFinal(long eventHwm) {
     log.info("CCD data migration final counts taskName={} caseData={}", options.taskName(), queryCounts("case_data"));
     log.info("CCD data migration final counts taskName={} caseEvent={}", options.taskName(), queryCounts("case_event"));
+    log.info(
+        "CCD data migration final counts taskName={} caseEventSignificantItems={}",
+        options.taskName(),
+        queryCounts("case_event_significant_items")
+    );
+    validateSignificantItemCounts(eventHwm);
     long esQueueRows = countElasticsearchQueueRows();
     log.info("CCD data migration final counts taskName={} esQueue={}", options.taskName(), esQueueRows);
     if (esQueueRows > 0) {
@@ -663,9 +708,60 @@ public class CcdDataMigrationTask implements Runnable {
           group by ce.case_type_id
           order by ce.case_type_id
           """;
+      case "case_event_significant_items" -> """
+          select ce.case_type_id, count(*) as count
+          from ccd.case_event_significant_items item
+          join ccd.case_event ce on ce.id = item.case_event_id
+          join ccd.case_data cd on cd.id = ce.case_data_id
+          where cd.jurisdiction = :sourceJurisdiction
+            and cd.case_type_id in (:caseTypeIds)
+            and ce.case_type_id in (:caseTypeIds)
+          group by ce.case_type_id
+          order by ce.case_type_id
+          """;
       default -> throw new IllegalArgumentException("Unsupported table name: " + tableName);
     };
     return db.queryForList(sql, baseParams());
+  }
+
+  private void validateSignificantItemCounts(long eventHwm) {
+    MapSqlParameterSource params = baseParams().addValue("eventHwm", eventHwm);
+    Long sourceCount = db.queryForObject(
+        """
+        select count(*)
+        from fdw_stage.case_event_significant_items item
+        join fdw_stage.case_event ce on ce.id = item.case_event_id
+        join fdw_stage.case_data cd on cd.id = ce.case_data_id
+        where cd.jurisdiction = :sourceJurisdiction
+          and cd.case_type_id in (:caseTypeIds)
+          and ce.case_type_id in (:caseTypeIds)
+          and ce.id <= :eventHwm
+        """,
+        params,
+        Long.class
+    );
+    Long targetCount = db.queryForObject(
+        """
+        select count(*)
+        from ccd.case_event_significant_items item
+        join ccd.case_event ce on ce.id = item.case_event_id
+        join ccd.case_data cd on cd.id = ce.case_data_id
+        where cd.jurisdiction = :sourceJurisdiction
+          and cd.case_type_id in (:caseTypeIds)
+          and ce.case_type_id in (:caseTypeIds)
+          and ce.id <= :eventHwm
+        """,
+        params,
+        Long.class
+    );
+
+    long sourceRows = sourceCount == null ? 0 : sourceCount;
+    long targetRows = targetCount == null ? 0 : targetCount;
+    if (sourceRows != targetRows) {
+      throw new CcdDataMigrationException(
+          "CCD data migration significant item count mismatch source=" + sourceRows + " target=" + targetRows
+      );
+    }
   }
 
   private void resetSequences() {
@@ -673,6 +769,13 @@ public class CcdDataMigrationTask implements Runnable {
         select setval(
           'ccd.case_event_id_seq'::regclass,
           (select coalesce(max(id), 1) from ccd.case_event),
+          true
+        )
+        """);
+    db.getJdbcTemplate().execute("""
+        select setval(
+          'ccd.case_event_significant_items_id_seq'::regclass,
+          (select coalesce(max(id), 1) from ccd.case_event_significant_items),
           true
         )
         """);
@@ -828,16 +931,18 @@ public class CcdDataMigrationTask implements Runnable {
       throw new CcdDataMigrationException("pgcrypto extension is missing. Run the FDW setup first: " + DOCS_URL);
     }
 
+    ensureFdwTables();
+
     Integer missingTables = db.queryForObject(
         """
-        select 2 - count(*)
+        select 3 - count(*)
         from (
           select c.relname
           from pg_foreign_table ft
           join pg_class c on c.oid = ft.ftrelid
           join pg_namespace n on n.oid = c.relnamespace
           where n.nspname = :fdwSchema
-            and c.relname in ('case_data', 'case_event')
+            and c.relname in ('case_data', 'case_event', 'case_event_significant_items')
         ) fdw_tables
         """,
         Map.of("fdwSchema", FDW_SCHEMA),
@@ -848,6 +953,129 @@ public class CcdDataMigrationTask implements Runnable {
           "FDW foreign tables are missing in schema " + FDW_SCHEMA + ". Run the FDW setup first: " + DOCS_URL
       );
     }
+  }
+
+  private void ensureFdwTables() {
+    db.getJdbcTemplate().execute("""
+        do $$
+        declare
+          fdw_server text;
+          source_schema text;
+          fetch_size text;
+        begin
+          if to_regclass('fdw_stage.case_data') is not null
+              and to_regclass('fdw_stage.case_event') is not null
+              and to_regclass('fdw_stage.case_event_significant_items') is not null then
+            return;
+          end if;
+
+          select s.srvname,
+                 coalesce((
+                   select split_part(option, '=', 2)
+                   from unnest(ft.ftoptions) option
+                   where split_part(option, '=', 1) = 'schema_name'
+                 ), 'public'),
+                 (
+                   select split_part(option, '=', 2)
+                   from unnest(ft.ftoptions) option
+                   where split_part(option, '=', 1) = 'fetch_size'
+                 )
+          into fdw_server, source_schema, fetch_size
+          from pg_foreign_table ft
+          join pg_class c on c.oid = ft.ftrelid
+          join pg_namespace n on n.oid = c.relnamespace
+          join pg_foreign_server s on s.oid = ft.ftserver
+          where n.nspname = 'fdw_stage'
+            and c.relname in ('case_data', 'case_event', 'case_event_significant_items')
+          order by case c.relname
+            when 'case_event' then 1
+            when 'case_data' then 2
+            else 3
+          end
+          limit 1;
+
+          if fdw_server is null then
+            return;
+          end if;
+          fetch_size := coalesce(fetch_size, '10000');
+
+          if to_regclass('fdw_stage.case_data') is null then
+            execute format(
+              'create foreign table fdw_stage.case_data (
+                reference bigint,
+                version integer,
+                created_date timestamp without time zone,
+                security_classification ccd.securityclassification,
+                last_state_modified_date timestamp without time zone,
+                resolved_ttl date,
+                last_modified timestamp without time zone,
+                jurisdiction varchar(255),
+                case_type_id varchar(255),
+                state varchar(255),
+                data jsonb,
+                supplementary_data jsonb,
+                id bigint
+              ) server %I options (schema_name %L, table_name %L, fetch_size %L)',
+              fdw_server,
+              source_schema,
+              'case_data',
+              fetch_size
+            );
+          end if;
+
+          if to_regclass('fdw_stage.case_event') is null then
+            execute format(
+              'create foreign table fdw_stage.case_event (
+                id bigint,
+                created_date timestamp without time zone,
+                security_classification ccd.securityclassification,
+                case_data_id bigint,
+                case_type_version integer,
+                event_id varchar(70),
+                summary varchar(1024),
+                description varchar(65536),
+                user_id varchar(64),
+                case_type_id varchar(255),
+                state_id varchar(255),
+                data jsonb,
+                user_first_name varchar(255),
+                user_last_name varchar(255),
+                event_name varchar(30),
+                state_name varchar(255),
+                proxied_by varchar(64),
+                proxied_by_first_name varchar(255),
+                proxied_by_last_name varchar(255)
+              ) server %I options (schema_name %L, table_name %L, fetch_size %L)',
+              fdw_server,
+              source_schema,
+              'case_event',
+              fetch_size
+            );
+          end if;
+
+          if to_regclass('fdw_stage.case_event_significant_items') is null then
+            execute format(
+              'create foreign table fdw_stage.case_event_significant_items (
+                id bigint,
+                description varchar(64),
+                "type" text,
+                url text,
+                case_event_id bigint
+              ) server %I options (schema_name %L, table_name %L, fetch_size %L)',
+              fdw_server,
+              source_schema,
+              'case_event_significant_items',
+              fetch_size
+            );
+          end if;
+
+          grant select on
+            fdw_stage.case_data,
+            fdw_stage.case_event,
+            fdw_stage.case_event_significant_items
+          to current_user;
+        end $$;
+        """);
   }
 
   private void validateDecentralisedRuntimeDisabled() {

--- a/sdk/decentralised-runtime/src/main/resources/dataruntime-db/migration/V0022__case_event_significant_items.sql
+++ b/sdk/decentralised-runtime/src/main/resources/dataruntime-db/migration/V0022__case_event_significant_items.sql
@@ -1,18 +1,12 @@
 create type ccd.significant_item_type as enum ('DOCUMENT');
 
 create table ccd.case_event_significant_items (
-    id serial primary key,
-    description varchar(64) not null,
+    id bigserial primary key,
+    case_event_id bigint not null references ccd.case_event(id) on delete cascade,
     "type" ccd.significant_item_type not null,
-    url text,
-    case_event_id bigint not null
+    description varchar(64) not null,
+    url text
 );
-
-alter table ccd.case_event_significant_items
-    add constraint fk_case_event_items_case_event_id
-    foreign key (case_event_id)
-    references ccd.case_event(id)
-    on delete cascade;
 
 create index idx_case_event_significant_items_case_event_id
     on ccd.case_event_significant_items(case_event_id);

--- a/sdk/decentralised-runtime/src/main/resources/dataruntime-db/migration/V0022__case_event_significant_items.sql
+++ b/sdk/decentralised-runtime/src/main/resources/dataruntime-db/migration/V0022__case_event_significant_items.sql
@@ -1,0 +1,18 @@
+create type ccd.significant_item_type as enum ('DOCUMENT');
+
+create table ccd.case_event_significant_items (
+    id serial primary key,
+    description varchar(64) not null,
+    "type" ccd.significant_item_type not null,
+    url text,
+    case_event_id bigint not null
+);
+
+alter table ccd.case_event_significant_items
+    add constraint fk_case_event_items_case_event_id
+    foreign key (case_event_id)
+    references ccd.case_event(id)
+    on delete cascade;
+
+create index idx_case_event_significant_items_case_event_id
+    on ccd.case_event_significant_items(case_event_id);

--- a/sdk/decentralised-runtime/src/main/resources/dataruntime-db/migration/V0023__data_migration_significant_items_event_hwm.sql
+++ b/sdk/decentralised-runtime/src/main/resources/dataruntime-db/migration/V0023__data_migration_significant_items_event_hwm.sql
@@ -1,2 +1,0 @@
-alter table ccd.ccd_data_migration_progress
-add column significant_items_event_hwm bigint not null default 0;

--- a/sdk/decentralised-runtime/src/main/resources/dataruntime-db/migration/V0023__data_migration_significant_items_event_hwm.sql
+++ b/sdk/decentralised-runtime/src/main/resources/dataruntime-db/migration/V0023__data_migration_significant_items_event_hwm.sql
@@ -1,0 +1,2 @@
+alter table ccd.ccd_data_migration_progress
+add column significant_items_event_hwm bigint not null default 0;

--- a/sdk/decentralised-runtime/src/test/java/uk/gov/hmcts/ccd/sdk/impl/AuditEventServiceTest.java
+++ b/sdk/decentralised-runtime/src/test/java/uk/gov/hmcts/ccd/sdk/impl/AuditEventServiceTest.java
@@ -5,10 +5,12 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Optional;
+import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.http.HttpStatus;
@@ -16,6 +18,7 @@ import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.web.server.ResponseStatusException;
 import uk.gov.hmcts.ccd.sdk.ResolvedConfigRegistry;
+import uk.gov.hmcts.reform.ccd.client.model.SignificantItem;
 
 class AuditEventServiceTest {
 
@@ -39,5 +42,28 @@ class AuditEventServiceTest {
           org.assertj.core.api.Assertions.assertThat(rse.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
           org.assertj.core.api.Assertions.assertThat(rse.getReason()).isEqualTo("History event not found");
         });
+  }
+
+  @Test
+  void saveAuditRecordRejectsInvalidSignificantItemUrlBeforePersistingEvent() {
+    var significantItem = SignificantItem.builder()
+        .type("DOCUMENT")
+        .description("Generated document")
+        .url("not a url")
+        .build();
+
+    assertThatThrownBy(() -> service.saveAuditRecord(
+        null,
+        null,
+        null,
+        UUID.randomUUID(),
+        Optional.of(significantItem)
+    ))
+        .isInstanceOf(CallbackValidationException.class)
+        .satisfies(ex -> org.assertj.core.api.Assertions.assertThat(
+            ((CallbackValidationException) ex).getErrors()
+        ).containsExactly("Significant item URL is not valid"));
+
+    verifyNoInteractions(ndb);
   }
 }

--- a/sdk/decentralised-runtime/src/test/java/uk/gov/hmcts/ccd/sdk/impl/json/JsonCallbackBridgeTest.java
+++ b/sdk/decentralised-runtime/src/test/java/uk/gov/hmcts/ccd/sdk/impl/json/JsonCallbackBridgeTest.java
@@ -90,6 +90,26 @@ class JsonCallbackBridgeTest {
   }
 
   @Test
+  void mapsSignificantItemFromLocalCallbackResponse() {
+    JsonCallbackBridge bridge = bridgeWith(
+        new MockEnvironment().withProperty("decentralisation.local-callback-placeholder", "ET_COS_URL"),
+        new LocalCallbackController()
+    );
+    CaseDetails<Object, Object> caseDetails = CaseDetails.builder()
+        .data(Map.of())
+        .build();
+
+    AboutToStartOrSubmitResponse response = bridge.aboutToSubmit(
+        "${ET_COS_URL}/callbacks/significant-item",
+        "local"
+    ).handle(caseDetails, null);
+
+    assertThat(response.getSignificantItem().getType()).isEqualTo("DOCUMENT");
+    assertThat(response.getSignificantItem().getDescription()).isEqualTo("Generated document");
+    assertThat(response.getSignificantItem().getUrl()).isEqualTo("http://dm-store/documents/123");
+  }
+
+  @Test
   void failsFastWhenCallbackIsNeitherLocalNorAbsoluteExternalUrl() {
     JsonCallbackBridge bridge = bridgeWith(new MockEnvironment());
 
@@ -135,6 +155,18 @@ class JsonCallbackBridgeTest {
       return new NocCallbackResponse(new NocCaseData(
           new ChangeOrganisationRequestField(new OrganisationToAdd(null))
       ));
+    }
+
+    @PostMapping("/significant-item")
+    Map<String, Object> significantItem(@RequestBody Map<String, Object> request) {
+      return Map.of(
+          "data", Map.of(),
+          "significant_item", Map.of(
+              "type", "DOCUMENT",
+              "description", "Generated document",
+              "url", "http://dm-store/documents/123"
+          )
+      );
     }
   }
 

--- a/sdk/decentralised-runtime/src/test/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTaskIntegrationTest.java
+++ b/sdk/decentralised-runtime/src/test/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTaskIntegrationTest.java
@@ -108,6 +108,47 @@ class CcdDataMigrationTaskIntegrationTest {
   }
 
   @Test
+  void copiesSignificantItemsWithPreloadAndCutoverEventWindows() {
+    insertSourceCase(10, 1000000000000010L, 1, "Submitted", "{\"field\":\"one\"}");
+    insertSourceCaseEvent(101, 10, "create", "Submitted", "{\"field\":\"one\"}", minutesAgo(60));
+    insertSourceCaseEvent(102, 10, "update", "Updated", "{\"field\":\"two\"}", minutesAgo(30));
+    insertSourceSignificantItem(5001, 101, "First document", "http://dm-store/documents/first");
+    insertSourceSignificantItem(5002, 102, "Second document", "http://dm-store/documents/second");
+
+    CcdDataMigrationRunResult preloadResult = task(PRELOAD_EVENTS, 101, 1).runMigration();
+
+    assertThat(preloadResult.caughtUp()).isFalse();
+    assertThat(countRows("ccd.case_event_significant_items")).isEqualTo(1);
+    assertThat(significantItemDescription(5001)).isEqualTo("First document");
+    assertThat(sourceEventHwm()).isEqualTo(101);
+
+    CcdDataMigrationRunResult cutoverResult = task(CUTOVER, 1000, 10).runMigration();
+
+    assertThat(cutoverResult.caughtUp()).isTrue();
+    assertThat(progressStatus()).isEqualTo("COMPLETE");
+    assertThat(countRows("ccd.case_event_significant_items")).isEqualTo(2);
+    assertThat(significantItemDescription(5002)).isEqualTo("Second document");
+    assertThat(caseEventSignificantItemsSequenceLastValue()).isGreaterThanOrEqualTo(5002);
+  }
+
+  @Test
+  void createsMissingFdwTablesFromExistingFdwConfiguration() {
+    jdbc.getJdbcTemplate().execute("drop foreign table fdw_stage.case_event");
+    insertSourceCase(10, 1000000000000010L, 1, "Submitted", "{\"field\":\"one\"}");
+    insertSourceCaseEvent(101, 10, "create", "Submitted", "{\"field\":\"one\"}", minutesAgo(60));
+    insertSourceSignificantItem(5001, 101, "First document", "http://dm-store/documents/first");
+
+    CcdDataMigrationRunResult result = task(PRELOAD_EVENTS, 1000, 10).runMigration();
+
+    assertThat(result.caughtUp()).isTrue();
+    assertThat(countRows("ccd.case_event")).isEqualTo(1);
+    assertThat(countRows("ccd.case_event_significant_items")).isEqualTo(1);
+    assertThat(fdwTableExists("case_data")).isTrue();
+    assertThat(fdwTableExists("case_event")).isTrue();
+    assertThat(fdwTableExists("case_event_significant_items")).isTrue();
+  }
+
+  @Test
   void cutoverDeletesOnlyMigratedCaseTypeElasticsearchQueueRows() {
     insertSourceCase(10, 1000000000000010L, 1, "Submitted", "{\"field\":\"one\"}");
     insertSourceCaseEvent(101, 10, "create", "Submitted", "{\"field\":\"one\"}", minutesAgo(60));
@@ -398,6 +439,15 @@ class CcdDataMigrationTaskIntegrationTest {
           proxied_by_last_name varchar(255)
         )
         """);
+    jdbc.getJdbcTemplate().execute("""
+        create table source.case_event_significant_items (
+          id bigint primary key,
+          description varchar(64) not null,
+          "type" text not null,
+          url text,
+          case_event_id bigint not null
+        )
+        """);
   }
 
   private void createFdwTables() {
@@ -458,6 +508,31 @@ class CcdDataMigrationTaskIntegrationTest {
         server ccd_migration_test_server
         options (schema_name 'source', table_name 'case_event', fetch_size '10000')
         """);
+  }
+
+  private void insertSourceSignificantItem(long id, long caseEventId, String description, String url) {
+    jdbc.update(
+        """
+        insert into source.case_event_significant_items (
+          id,
+          description,
+          "type",
+          url,
+          case_event_id
+        ) values (
+          :id,
+          :description,
+          'DOCUMENT',
+          :url,
+          :caseEventId
+        )
+        """,
+        new MapSqlParameterSource()
+            .addValue("id", id)
+            .addValue("description", description)
+            .addValue("url", url)
+            .addValue("caseEventId", caseEventId)
+    );
   }
 
   private void restoreTargetSchemaState() {
@@ -1016,6 +1091,19 @@ class CcdDataMigrationTaskIntegrationTest {
     return jdbc.getJdbcTemplate().queryForObject("select last_value from ccd.case_event_id_seq", Long.class);
   }
 
+  private long caseEventSignificantItemsSequenceLastValue() {
+    return jdbc.getJdbcTemplate()
+        .queryForObject("select last_value from ccd.case_event_significant_items_id_seq", Long.class);
+  }
+
+  private String significantItemDescription(long id) {
+    return jdbc.queryForObject(
+        "select description from ccd.case_event_significant_items where id = :id",
+        Map.of("id", id),
+        String.class
+    );
+  }
+
   private boolean caseEventCaseDataForeignKeyExists() {
     return Boolean.TRUE.equals(jdbc.queryForObject(
         """
@@ -1059,6 +1147,23 @@ class CcdDataMigrationTaskIntegrationTest {
         )
         """,
         Map.of(),
+        Boolean.class
+    ));
+  }
+
+  private boolean fdwTableExists(String tableName) {
+    return Boolean.TRUE.equals(jdbc.queryForObject(
+        """
+        select exists (
+          select 1
+          from pg_foreign_table ft
+          join pg_class c on c.oid = ft.ftrelid
+          join pg_namespace n on n.oid = c.relnamespace
+          where n.nspname = 'fdw_stage'
+            and c.relname = :tableName
+        )
+        """,
+        Map.of("tableName", tableName),
         Boolean.class
     ));
   }

--- a/sdk/decentralised-runtime/src/test/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTaskIntegrationTest.java
+++ b/sdk/decentralised-runtime/src/test/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTaskIntegrationTest.java
@@ -121,6 +121,7 @@ class CcdDataMigrationTaskIntegrationTest {
     assertThat(countRows("ccd.case_event_significant_items")).isEqualTo(1);
     assertThat(significantItemDescription(5001)).isEqualTo("First document");
     assertThat(sourceEventHwm()).isEqualTo(101);
+    assertThat(significantItemsEventHwm()).isEqualTo(101);
 
     CcdDataMigrationRunResult cutoverResult = task(CUTOVER, 1000, 10).runMigration();
 
@@ -128,7 +129,51 @@ class CcdDataMigrationTaskIntegrationTest {
     assertThat(progressStatus()).isEqualTo("COMPLETE");
     assertThat(countRows("ccd.case_event_significant_items")).isEqualTo(2);
     assertThat(significantItemDescription(5002)).isEqualTo("Second document");
+    assertThat(significantItemsEventHwm()).isEqualTo(102);
     assertThat(caseEventSignificantItemsSequenceLastValue()).isGreaterThanOrEqualTo(5002);
+  }
+
+  @Test
+  void preloadsSignificantItemsWithoutRewalkingCompletedEventProgress() {
+    insertSourceCase(10, 1000000000000010L, 1, "Submitted", "{\"field\":\"one\"}");
+    insertSourceCaseEvent(101, 10, "create", "Submitted", "{\"field\":\"one\"}", minutesAgo(60));
+    insertSourceCaseEvent(102, 10, "update", "Updated", "{\"field\":\"two\"}", minutesAgo(30));
+    insertSourceSignificantItem(5001, 101, "First document", "http://dm-store/documents/first");
+    insertSourceSignificantItem(5002, 102, "Second document", "http://dm-store/documents/second");
+    insertTargetCase(10, 1000000000000010L, 1, "Submitted", "{\"field\":\"one\"}", 0);
+    insertTargetEvent(101, 10, "create", "Submitted", "{\"field\":\"one\"}", 1);
+    insertTargetEvent(102, 10, "update", "Updated", "{\"field\":\"two\"}", 2);
+    createProgressWithSourceEventHwm(102);
+
+    CcdDataMigrationRunResult result = task(PRELOAD_EVENTS, 1000, 10).runMigration();
+
+    assertThat(result.caughtUp()).isTrue();
+    assertThat(result.eventsProcessed()).isZero();
+    assertThat(sourceEventHwm()).isEqualTo(102);
+    assertThat(significantItemsEventHwm()).isEqualTo(102);
+    assertThat(countRows("ccd.case_event")).isEqualTo(2);
+    assertThat(countRows("ccd.case_event_significant_items")).isEqualTo(2);
+  }
+
+  @Test
+  void completedCutoverBackfillsSignificantItemsWithoutRewalkingEvents() {
+    insertSourceCase(10, 1000000000000010L, 1, "Submitted", "{\"field\":\"one\"}");
+    insertSourceCaseEvent(101, 10, "create", "Submitted", "{\"field\":\"one\"}", minutesAgo(60));
+    insertSourceSignificantItem(5001, 101, "First document", "http://dm-store/documents/first");
+    insertTargetCase(10, 1000000000000010L, 1, "Submitted", "{\"field\":\"one\"}", CASE_REVISION_OFFSET + 1);
+    insertTargetEvent(101, 10, "create", "Submitted", "{\"field\":\"one\"}", 1);
+    createCompleteProgress(101);
+    jdbc.getJdbcTemplate().execute("delete from ccd.es_queue");
+
+    CcdDataMigrationRunResult result = task(CUTOVER, 1000, 10).runMigration();
+
+    assertThat(result.caughtUp()).isTrue();
+    assertThat(result.eventsProcessed()).isZero();
+    assertThat(sourceEventHwm()).isZero();
+    assertThat(significantItemsEventHwm()).isEqualTo(101);
+    assertThat(countRows("ccd.case_event")).isEqualTo(1);
+    assertThat(countRows("ccd.case_event_significant_items")).isEqualTo(1);
+    assertThat(significantItemDescription(5001)).isEqualTo("First document");
   }
 
   @Test
@@ -190,7 +235,7 @@ class CcdDataMigrationTaskIntegrationTest {
     createCompleteProgress(101);
     jdbc.getJdbcTemplate().execute("alter table ccd.case_data disable trigger trigger_enqueue_case_revision");
 
-    assertThatThrownBy(() -> task(CUTOVER, 10, 10).runMigration())
+    assertThatThrownBy(() -> task(CUTOVER, 101, 10).runMigration())
         .isInstanceOf(CcdDataMigrationException.class)
         .hasMessageContaining("CCD data migration left 1 Elasticsearch queue rows");
 
@@ -868,6 +913,28 @@ class CcdDataMigrationTaskIntegrationTest {
     );
   }
 
+  private void createProgressWithSourceEventHwm(long sourceEventHwm) {
+    jdbc.update(
+        """
+        insert into ccd.ccd_data_migration_progress (
+          task_name,
+          config_hash,
+          source_event_hwm
+        ) values (
+          :taskName,
+          :configHash,
+          :sourceEventHwm
+        )
+        """,
+        new MapSqlParameterSource()
+            .addValue("taskName", "ccd-data-migration")
+            .addValue("configHash", optionsBuilder(List.of("TestCase"))
+                .build()
+                .migrationConfigHash())
+            .addValue("sourceEventHwm", sourceEventHwm)
+    );
+  }
+
   private void createCompleteProgress(long cutoverEventHwm) {
     jdbc.update(
         """
@@ -1074,6 +1141,14 @@ class CcdDataMigrationTaskIntegrationTest {
   private long sourceEventHwm() {
     return jdbc.queryForObject(
         "select source_event_hwm from ccd.ccd_data_migration_progress where task_name = :taskName",
+        Map.of("taskName", "ccd-data-migration"),
+        Long.class
+    );
+  }
+
+  private long significantItemsEventHwm() {
+    return jdbc.queryForObject(
+        "select significant_items_event_hwm from ccd.ccd_data_migration_progress where task_name = :taskName",
         Map.of("taskName", "ccd-data-migration"),
         Long.class
     );

--- a/sdk/decentralised-runtime/src/test/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTaskIntegrationTest.java
+++ b/sdk/decentralised-runtime/src/test/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTaskIntegrationTest.java
@@ -108,7 +108,7 @@ class CcdDataMigrationTaskIntegrationTest {
   }
 
   @Test
-  void copiesSignificantItemsWithPreloadAndCutoverEventWindows() {
+  void copiesSignificantItemsInSingleCutoverQuery() {
     insertSourceCase(10, 1000000000000010L, 1, "Submitted", "{\"field\":\"one\"}");
     insertSourceCaseEvent(101, 10, "create", "Submitted", "{\"field\":\"one\"}", minutesAgo(60));
     insertSourceCaseEvent(102, 10, "update", "Updated", "{\"field\":\"two\"}", minutesAgo(30));
@@ -118,45 +118,21 @@ class CcdDataMigrationTaskIntegrationTest {
     CcdDataMigrationRunResult preloadResult = task(PRELOAD_EVENTS, 101, 1).runMigration();
 
     assertThat(preloadResult.caughtUp()).isFalse();
-    assertThat(countRows("ccd.case_event_significant_items")).isEqualTo(1);
-    assertThat(significantItemDescription(5001)).isEqualTo("First document");
+    assertThat(countRows("ccd.case_event_significant_items")).isZero();
     assertThat(sourceEventHwm()).isEqualTo(101);
-    assertThat(significantItemsEventHwm()).isEqualTo(101);
 
     CcdDataMigrationRunResult cutoverResult = task(CUTOVER, 1000, 10).runMigration();
 
     assertThat(cutoverResult.caughtUp()).isTrue();
     assertThat(progressStatus()).isEqualTo("COMPLETE");
     assertThat(countRows("ccd.case_event_significant_items")).isEqualTo(2);
+    assertThat(significantItemDescription(5001)).isEqualTo("First document");
     assertThat(significantItemDescription(5002)).isEqualTo("Second document");
-    assertThat(significantItemsEventHwm()).isEqualTo(102);
     assertThat(caseEventSignificantItemsSequenceLastValue()).isGreaterThanOrEqualTo(5002);
   }
 
   @Test
-  void preloadsSignificantItemsWithoutRewalkingCompletedEventProgress() {
-    insertSourceCase(10, 1000000000000010L, 1, "Submitted", "{\"field\":\"one\"}");
-    insertSourceCaseEvent(101, 10, "create", "Submitted", "{\"field\":\"one\"}", minutesAgo(60));
-    insertSourceCaseEvent(102, 10, "update", "Updated", "{\"field\":\"two\"}", minutesAgo(30));
-    insertSourceSignificantItem(5001, 101, "First document", "http://dm-store/documents/first");
-    insertSourceSignificantItem(5002, 102, "Second document", "http://dm-store/documents/second");
-    insertTargetCase(10, 1000000000000010L, 1, "Submitted", "{\"field\":\"one\"}", 0);
-    insertTargetEvent(101, 10, "create", "Submitted", "{\"field\":\"one\"}", 1);
-    insertTargetEvent(102, 10, "update", "Updated", "{\"field\":\"two\"}", 2);
-    createProgressWithSourceEventHwm(102);
-
-    CcdDataMigrationRunResult result = task(PRELOAD_EVENTS, 1000, 10).runMigration();
-
-    assertThat(result.caughtUp()).isTrue();
-    assertThat(result.eventsProcessed()).isZero();
-    assertThat(sourceEventHwm()).isEqualTo(102);
-    assertThat(significantItemsEventHwm()).isEqualTo(102);
-    assertThat(countRows("ccd.case_event")).isEqualTo(2);
-    assertThat(countRows("ccd.case_event_significant_items")).isEqualTo(2);
-  }
-
-  @Test
-  void completedCutoverBackfillsSignificantItemsWithoutRewalkingEvents() {
+  void completedCutoverRerunCopiesSignificantItemsBeforeValidation() {
     insertSourceCase(10, 1000000000000010L, 1, "Submitted", "{\"field\":\"one\"}");
     insertSourceCaseEvent(101, 10, "create", "Submitted", "{\"field\":\"one\"}", minutesAgo(60));
     insertSourceSignificantItem(5001, 101, "First document", "http://dm-store/documents/first");
@@ -170,7 +146,6 @@ class CcdDataMigrationTaskIntegrationTest {
     assertThat(result.caughtUp()).isTrue();
     assertThat(result.eventsProcessed()).isZero();
     assertThat(sourceEventHwm()).isZero();
-    assertThat(significantItemsEventHwm()).isEqualTo(101);
     assertThat(countRows("ccd.case_event")).isEqualTo(1);
     assertThat(countRows("ccd.case_event_significant_items")).isEqualTo(1);
     assertThat(significantItemDescription(5001)).isEqualTo("First document");
@@ -187,7 +162,7 @@ class CcdDataMigrationTaskIntegrationTest {
 
     assertThat(result.caughtUp()).isTrue();
     assertThat(countRows("ccd.case_event")).isEqualTo(1);
-    assertThat(countRows("ccd.case_event_significant_items")).isEqualTo(1);
+    assertThat(countRows("ccd.case_event_significant_items")).isZero();
     assertThat(fdwTableExists("case_data")).isTrue();
     assertThat(fdwTableExists("case_event")).isTrue();
     assertThat(fdwTableExists("case_event_significant_items")).isTrue();
@@ -913,28 +888,6 @@ class CcdDataMigrationTaskIntegrationTest {
     );
   }
 
-  private void createProgressWithSourceEventHwm(long sourceEventHwm) {
-    jdbc.update(
-        """
-        insert into ccd.ccd_data_migration_progress (
-          task_name,
-          config_hash,
-          source_event_hwm
-        ) values (
-          :taskName,
-          :configHash,
-          :sourceEventHwm
-        )
-        """,
-        new MapSqlParameterSource()
-            .addValue("taskName", "ccd-data-migration")
-            .addValue("configHash", optionsBuilder(List.of("TestCase"))
-                .build()
-                .migrationConfigHash())
-            .addValue("sourceEventHwm", sourceEventHwm)
-    );
-  }
-
   private void createCompleteProgress(long cutoverEventHwm) {
     jdbc.update(
         """
@@ -1141,14 +1094,6 @@ class CcdDataMigrationTaskIntegrationTest {
   private long sourceEventHwm() {
     return jdbc.queryForObject(
         "select source_event_hwm from ccd.ccd_data_migration_progress where task_name = :taskName",
-        Map.of("taskName", "ccd-data-migration"),
-        Long.class
-    );
-  }
-
-  private long significantItemsEventHwm() {
-    return jdbc.queryForObject(
-        "select significant_items_event_hwm from ccd.ccd_data_migration_progress where task_name = :taskName",
         Map.of("taskName", "ccd-data-migration"),
         Long.class
     );

--- a/test-projects/e2e/src/cftlibTest/java/uk/gov/hmcts/divorce/cftlib/TestWithCCD.java
+++ b/test-projects/e2e/src/cftlibTest/java/uk/gov/hmcts/divorce/cftlib/TestWithCCD.java
@@ -93,6 +93,7 @@ import uk.gov.hmcts.divorce.simplecase.model.SimpleCaseState;
 import uk.gov.hmcts.divorce.sow014.nfd.CaseworkerMaintainCaseLink;
 import uk.gov.hmcts.divorce.sow014.nfd.CaseworkerOverrideEventMetadata;
 import uk.gov.hmcts.divorce.sow014.nfd.CaseworkerPopulateSearchCriteria;
+import uk.gov.hmcts.divorce.sow014.nfd.CaseworkerSignificantItem;
 import uk.gov.hmcts.divorce.sow014.nfd.DecentralisedCaseworkerAddNote;
 import uk.gov.hmcts.divorce.sow014.nfd.DecentralisedCaseworkerAddNoteFailure;
 import uk.gov.hmcts.divorce.sow014.nfd.DecentralisedOverrideEventMetadata;
@@ -975,6 +976,34 @@ public class TestWithCCD extends CftlibTest {
 
     @SneakyThrows
     @Order(16)
+    @Test
+    public void callbackSignificantItemIsReturnedInEventHistory() {
+        String user = "TEST_CASE_WORKER_USER@mailinator.com";
+        var start = ccdApi.startEvent(
+            getAuthorisation(user),
+            getServiceAuth(),
+            String.valueOf(caseRef),
+            CaseworkerSignificantItem.EVENT_ID);
+
+        var request = prepareEventRequestWithToken(
+            user,
+            CaseworkerSignificantItem.EVENT_ID,
+            Map.of("note", "Significant item test"),
+            start.getToken());
+
+        var response = HttpClientBuilder.create().build().execute(request);
+        assertThat(response.getStatusLine().getStatusCode(), equalTo(201));
+
+        var submittedEvent = getLatestAuditEvent(user, caseRef, CaseworkerSignificantItem.EVENT_ID);
+        var significantItem = significantItemFrom(submittedEvent);
+
+        assertThat(significantItem.get("type"), equalTo("DOCUMENT"));
+        assertThat(significantItem.get("description"), equalTo(CaseworkerSignificantItem.DESCRIPTION));
+        assertThat(significantItem.get("url"), equalTo(CaseworkerSignificantItem.URL));
+    }
+
+    @SneakyThrows
+    @Order(17)
     @Test
     public void testSubmittedCallback() {
         var token = ccdApi.startEvent(
@@ -2030,6 +2059,17 @@ public class TestWithCCD extends CftlibTest {
                 .findFirst()
                 .orElseThrow();
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> significantItemFrom(Map<String, Object> event) {
+        Map<String, Object> significantItem = (Map<String, Object>) event.get("significant_item");
+        if (significantItem == null) {
+            significantItem = (Map<String, Object>) event.get("significantItem");
+        }
+        assertThat("Significant item should be present in event history: " + event,
+            significantItem, is(notNullValue()));
+        return significantItem;
     }
 
     private void assertLatestEventMetadata(String eventId, String expectedSummary, String expectedDescription) {

--- a/test-projects/e2e/src/main/java/uk/gov/hmcts/divorce/sow014/nfd/CaseworkerSignificantItem.java
+++ b/test-projects/e2e/src/main/java/uk/gov/hmcts/divorce/sow014/nfd/CaseworkerSignificantItem.java
@@ -1,0 +1,56 @@
+package uk.gov.hmcts.divorce.sow014.nfd;
+
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.CASE_WORKER;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.JUDGE;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.LEGAL_ADVISOR;
+import static uk.gov.hmcts.divorce.divorcecase.model.UserRole.SUPER_USER;
+import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE;
+import static uk.gov.hmcts.divorce.divorcecase.model.access.Permissions.CREATE_READ_UPDATE_DELETE;
+
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.ccd.sdk.api.CCDConfig;
+import uk.gov.hmcts.ccd.sdk.api.CaseDetails;
+import uk.gov.hmcts.ccd.sdk.api.ConfigBuilder;
+import uk.gov.hmcts.ccd.sdk.api.callback.AboutToStartOrSubmitResponse;
+import uk.gov.hmcts.divorce.common.ccd.PageBuilder;
+import uk.gov.hmcts.divorce.divorcecase.model.CaseData;
+import uk.gov.hmcts.divorce.divorcecase.model.State;
+import uk.gov.hmcts.divorce.divorcecase.model.UserRole;
+import uk.gov.hmcts.reform.ccd.client.model.SignificantItem;
+
+@Component
+public class CaseworkerSignificantItem implements CCDConfig<CaseData, State, UserRole> {
+
+    public static final String EVENT_ID = "caseworker-significant-item";
+    public static final String DESCRIPTION = "Generated document";
+    public static final String URL = "http://dm-store/documents/123";
+
+    @Override
+    public void configure(final ConfigBuilder<CaseData, State, UserRole> configBuilder) {
+        new PageBuilder(configBuilder
+            .event(EVENT_ID)
+            .forAllStates()
+            .name("Significant item")
+            .description("Returns a significant item")
+            .aboutToSubmitCallback(this::aboutToSubmit)
+            .grant(CREATE_READ_UPDATE, CASE_WORKER, JUDGE)
+            .grant(CREATE_READ_UPDATE_DELETE, SUPER_USER)
+            .grantHistoryOnly(LEGAL_ADVISOR, JUDGE))
+            .page("significantItem")
+            .optional(CaseData::getNote);
+    }
+
+    private AboutToStartOrSubmitResponse<CaseData, State> aboutToSubmit(
+        final CaseDetails<CaseData, State> details,
+        final CaseDetails<CaseData, State> beforeDetails
+    ) {
+        return AboutToStartOrSubmitResponse.<CaseData, State>builder()
+            .data(details.getData())
+            .significantItem(SignificantItem.builder()
+                .type("DOCUMENT")
+                .description(DESCRIPTION)
+                .url(URL)
+                .build())
+            .build();
+    }
+}


### PR DESCRIPTION
## Summary
- add the decentralised runtime table for CCD case event significant items
- copy significant items through the Java migration task and FDW scripts, including catchup/delta validation
- persist and expose callback significant_item values in decentralised event history
- make the local FDW verifier use compatible libpq client binaries when available

## Validation
- ./gradlew verifyCcdMigrationFdw
- ./gradlew -p sdk :ccd-config-generator:check :decentralised-runtime:check
- git diff --check