### PR TITLE
Add ACR login to Java CI

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -2,6 +2,8 @@ name: Java CI
 
 on:
   push:
+    branches:
+      - master
     paths-ignore:
       - '**/*.md'
       - '*.md'
@@ -14,6 +16,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      id-token: write
     steps:
     - uses: actions/checkout@v7
       with:
@@ -48,6 +51,16 @@ jobs:
       with:
         distribution: 'zulu'
         java-version: 21
+    - name: Az CLI login
+      if: steps.changes.outputs.docs_only != 'true'
+      uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43
+      with:
+        client-id: 82f79201-9a30-4160-b264-7bbed775c7f4
+        tenant-id: 531ff96d-0ae9-462a-8d2d-bec7c0b42082
+        allow-no-subscriptions: true
+    - name: ACR Login
+      if: steps.changes.outputs.docs_only != 'true'
+      run: az acr login --name hmctsprod
     - name: Run SDK checks and e2e test
       if: steps.changes.outputs.docs_only != 'true'
       run: ./gradlew :sdk:check :e2e:check -i --stacktrace
@@ -123,6 +136,9 @@ jobs:
 
   migration-check:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
     - uses: actions/checkout@v7
       with:
@@ -160,6 +176,16 @@ jobs:
       with:
         distribution: 'zulu'
         java-version: 21
+    - name: Az CLI login
+      if: steps.changes.outputs.docs_only != 'true'
+      uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43
+      with:
+        client-id: 82f79201-9a30-4160-b264-7bbed775c7f4
+        tenant-id: 531ff96d-0ae9-462a-8d2d-bec7c0b42082
+        allow-no-subscriptions: true
+    - name: ACR Login
+      if: steps.changes.outputs.docs_only != 'true'
+      run: az acr login --name hmctsprod
     - name: Verify CCD migration script
       if: steps.changes.outputs.docs_only != 'true'
       run: ./gradlew verifyCcdMigration -i


### PR DESCRIPTION
Java CI runs CFTLib-backed Gradle tasks that pull images from hmctsprod.azurecr.io. This adds the OIDC Azure login and ACR login documented by rse-cft-lib before those tasks run.

The push trigger is limited to master because the existing federation config covers master and pull_request subjects.