### PR TITLE
Add shutterServiceExclude to keep roles out of a shutter

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,6 +449,15 @@ Individual roles can be shuttered with:
   configBuilder.shutterService(UserRole.SOLICITOR);
 ```
 
+Roles can be excluded from a shutter with `shutterServiceExclude`, so they keep their normal permissions instead of being set to DELETE. The exclusion applies whether the shutter was requested for the whole service (`shutterService()`) or for individual roles (`shutterService(UserRole.SOLICITOR)`), and takes precedence over both:
+
+```java
+  configBuilder.shutterService();
+  configBuilder.shutterServiceExclude(UserRole.CASEWORKER_WA_TASK_CONFIGURATION);
+```
+
+This is typically used to keep `caseworker-wa-task-configuration` out of a shutter, as dropping that role to DELETE can cause issues for Work Allocation / Task Management.
+
 ## Unwrapped types
 
 In some cases you might want to use a Java class for a property but not have it mapped to a complex type. Jackson provides an annotation `@JsonUnwrapped` that will flatten properties in a child class to the parent class. The CCD config generator treats the `@JsonUnwrapped` annotation as a sign that the class should be flattened into fields rather than a complex type.

--- a/sdk/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/ConfigBuilderImpl.java
+++ b/sdk/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/ConfigBuilderImpl.java
@@ -135,6 +135,11 @@ public class ConfigBuilderImpl<T, S, R extends HasRole> implements Decentralised
   }
 
   @Override
+  public void shutterServiceExclude(R... roles) {
+    config.shutterServiceExcludedRoles.addAll(Set.of(roles));
+  }
+
+  @Override
   public void omitHistoryForRoles(R... roles) {
     omitHistoryForRoles.addAll(Set.of(roles));
   }

--- a/sdk/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/ResolvedCCDConfig.java
+++ b/sdk/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/ResolvedCCDConfig.java
@@ -41,6 +41,7 @@ public class ResolvedCCDConfig<T, S, R extends HasRole> {
 
   Set<String> rolesWithNoHistory;
   Set<R> shutterServiceForRoles = new HashSet<>();
+  Set<R> shutterServiceExcludedRoles = new HashSet<>();
   String caseType = "";
   String callbackHost = "";
   String caseName = "";

--- a/sdk/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/api/ConfigBuilder.java
+++ b/sdk/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/api/ConfigBuilder.java
@@ -30,6 +30,19 @@ public interface ConfigBuilder<T, S, R extends HasRole> {
 
   void shutterService(R... roles);
 
+  /**
+   * Exclude roles from a shutter so they retain their normal case-type permissions rather than
+   * being set to DELETE. The exclusion applies whether the shutter was requested for the whole
+   * service via {@link #shutterService()} or for individual roles via {@link #shutterService(R...)},
+   * and takes precedence over both.
+   *
+   * <p>Typically used to keep {@code caseworker-wa-task-configuration} out of a shutter, as
+   * dropping that role to DELETE can cause issues for Work Allocation / Task Management.
+   *
+   * @param roles roles to exclude from the shutter
+   */
+  void shutterServiceExclude(R... roles);
+
   void omitHistoryForRoles(R... roles);
 
   /**

--- a/sdk/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/api/ConfigBuilder.java
+++ b/sdk/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/api/ConfigBuilder.java
@@ -41,7 +41,9 @@ public interface ConfigBuilder<T, S, R extends HasRole> {
    *
    * @param roles roles to exclude from the shutter
    */
-  void shutterServiceExclude(R... roles);
+  default void shutterServiceExclude(R... roles) {
+    // Default no-op for backward compatibility; implementations may override.
+  }
 
   void omitHistoryForRoles(R... roles);
 

--- a/sdk/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/AuthorisationCaseTypeGenerator.java
+++ b/sdk/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/AuthorisationCaseTypeGenerator.java
@@ -21,7 +21,9 @@ class AuthorisationCaseTypeGenerator<T, S, R extends HasRole> implements ConfigG
         if (enumConstant instanceof HasRole r) {
           // Add non case roles.
           if (!r.getRole().matches("\\[.+\\]")) {
-            boolean shuttered = config.isShutterService() || config.getShutterServiceForRoles().contains(r);
+            boolean shuttered =
+                (config.isShutterService() || config.getShutterServiceForRoles().contains(r))
+                    && !config.getShutterServiceExcludedRoles().contains(r);
             Map<String, Object> entry = JsonUtils.caseRow(config.getCaseType());
             entry.put("UserRole", r.getRole());
             entry.put("CRUD", shuttered ? "D" : r.getCaseTypePermissions());

--- a/sdk/ccd-config-generator/src/test/java/uk/gov/hmcts/ccd/sdk/E2EConfigGenerationTests.java
+++ b/sdk/ccd-config-generator/src/test/java/uk/gov/hmcts/ccd/sdk/E2EConfigGenerationTests.java
@@ -56,6 +56,14 @@ public class E2EConfigGenerationTests {
         CcdConfigComparator.assertEquivalent(expected, actual);
     }
 
+    @SneakyThrows
+    @Test
+    public void shuttersAllRolesExceptExcludedRole() {
+        File expected = resourceFile("Shuttered/AuthorisationCaseType.json");
+        File actual = new File(tmp.getRoot(), "Shuttered/AuthorisationCaseType.json");
+        CcdConfigComparator.assertEquals(expected, actual, JSONCompareMode.NON_EXTENSIBLE);
+    }
+
     @Test
     public void generatesDerivedConfig() {
         Map<String, File> actual = CcdConfigComparator.dirToMap(new File(tmp.getRoot(), "derived"));

--- a/sdk/ccd-config-generator/src/test/java/uk/gov/hmcts/ccd/sdk/generator/AuthorisationCaseTypeGeneratorTest.java
+++ b/sdk/ccd-config-generator/src/test/java/uk/gov/hmcts/ccd/sdk/generator/AuthorisationCaseTypeGeneratorTest.java
@@ -1,0 +1,91 @@
+package uk.gov.hmcts.ccd.sdk.generator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableSet;
+import java.io.File;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.SneakyThrows;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import uk.gov.hmcts.ccd.sdk.ConfigBuilderImpl;
+import uk.gov.hmcts.ccd.sdk.ResolvedCCDConfig;
+import uk.gov.hmcts.reform.fpl.enums.State;
+import uk.gov.hmcts.reform.fpl.enums.UserRole;
+import uk.gov.hmcts.reform.fpl.model.CaseData;
+
+public class AuthorisationCaseTypeGeneratorTest {
+
+    private static final String CASE_TYPE = "TEST_CASE_TYPE";
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Rule
+    public TemporaryFolder tmp = new TemporaryFolder();
+
+    @Test
+    public void fullShutterSetsAllRolesToDelete() {
+        ConfigBuilderImpl<CaseData, State, UserRole> builder = newBuilder();
+        builder.shutterService();
+
+        Map<String, String> crudByRole = generateCrudByRole(builder);
+
+        assertThat(crudByRole.values()).containsOnly("D");
+    }
+
+    @Test
+    public void excludedRolesKeepTheirPermissionsWhenServiceIsShuttered() {
+        ConfigBuilderImpl<CaseData, State, UserRole> builder = newBuilder();
+        builder.shutterService();
+        builder.shutterServiceExclude(UserRole.SYSTEM_UPDATE);
+
+        Map<String, String> crudByRole = generateCrudByRole(builder);
+
+        // The excluded role retains its normal case-type permissions.
+        assertThat(crudByRole.get(UserRole.SYSTEM_UPDATE.getRole()))
+            .isEqualTo(UserRole.SYSTEM_UPDATE.getCaseTypePermissions());
+        // Every other non-case role is still shuttered to DELETE.
+        assertThat(crudByRole.get(UserRole.LOCAL_AUTHORITY.getRole())).isEqualTo("D");
+        assertThat(crudByRole.get(UserRole.CASE_ACCESS_APPROVER.getRole())).isEqualTo("D");
+    }
+
+    @Test
+    public void excludeOverridesRoleSpecificShutter() {
+        ConfigBuilderImpl<CaseData, State, UserRole> builder = newBuilder();
+        builder.shutterService(UserRole.SYSTEM_UPDATE);
+        builder.shutterServiceExclude(UserRole.SYSTEM_UPDATE);
+
+        Map<String, String> crudByRole = generateCrudByRole(builder);
+
+        assertThat(crudByRole.get(UserRole.SYSTEM_UPDATE.getRole()))
+            .isEqualTo(UserRole.SYSTEM_UPDATE.getCaseTypePermissions());
+    }
+
+    private ConfigBuilderImpl<CaseData, State, UserRole> newBuilder() {
+        ResolvedCCDConfig<CaseData, State, UserRole> config = new ResolvedCCDConfig<>(
+            CaseData.class, State.class, UserRole.class, Map.of(),
+            ImmutableSet.copyOf(State.values()));
+        ConfigBuilderImpl<CaseData, State, UserRole> builder = new ConfigBuilderImpl<>(config);
+        builder.caseType(CASE_TYPE, "Test", "Test case type");
+        return builder;
+    }
+
+    @SneakyThrows
+    private Map<String, String> generateCrudByRole(ConfigBuilderImpl<CaseData, State, UserRole> builder) {
+        ResolvedCCDConfig<CaseData, State, UserRole> config = builder.build();
+        new AuthorisationCaseTypeGenerator<CaseData, State, UserRole>().write(tmp.getRoot(), config);
+
+        File output = new File(tmp.getRoot(), "AuthorisationCaseType.json");
+        List<Map<String, Object>> rows =
+            MAPPER.readValue(output, new TypeReference<List<Map<String, Object>>>() {});
+
+        return rows.stream().collect(Collectors.toMap(
+            row -> (String) row.get("UserRole"),
+            row -> (String) row.get("CRUD"),
+            (a, b) -> b));
+    }
+}

--- a/sdk/ccd-config-generator/src/test/java/uk/gov/hmcts/reform/ShutteredCaseData.java
+++ b/sdk/ccd-config-generator/src/test/java/uk/gov/hmcts/reform/ShutteredCaseData.java
@@ -1,0 +1,9 @@
+package uk.gov.hmcts.reform;
+
+import uk.gov.hmcts.ccd.sdk.api.CCD;
+
+public class ShutteredCaseData {
+
+  @CCD(label = "A field")
+  private String aField;
+}

--- a/sdk/ccd-config-generator/src/test/java/uk/gov/hmcts/reform/ShutteredCaseType.java
+++ b/sdk/ccd-config-generator/src/test/java/uk/gov/hmcts/reform/ShutteredCaseType.java
@@ -1,0 +1,24 @@
+package uk.gov.hmcts.reform;
+
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.ccd.sdk.api.CCDConfig;
+import uk.gov.hmcts.ccd.sdk.api.ConfigBuilder;
+import uk.gov.hmcts.reform.fpl.enums.State;
+import uk.gov.hmcts.reform.fpl.enums.UserRole;
+
+/**
+ * A shuttered case type used to exercise {@link ConfigBuilder#shutterService()} and
+ * {@link ConfigBuilder#shutterServiceExclude(uk.gov.hmcts.ccd.sdk.api.HasRole...)}.
+ * The whole service is shuttered but the system-update role is excluded, so it retains
+ * its normal permissions while every other role is set to DELETE.
+ */
+@Component
+public class ShutteredCaseType implements CCDConfig<ShutteredCaseData, State, UserRole> {
+
+  @Override
+  public void configure(ConfigBuilder<ShutteredCaseData, State, UserRole> builder) {
+    builder.caseType("Shuttered", "Shuttered", "Shuttered case type");
+    builder.shutterService();
+    builder.shutterServiceExclude(UserRole.SYSTEM_UPDATE);
+  }
+}

--- a/sdk/ccd-config-generator/src/test/resources/Shuttered/AuthorisationCaseType.json
+++ b/sdk/ccd-config-generator/src/test/resources/Shuttered/AuthorisationCaseType.json
@@ -1,0 +1,50 @@
+[
+  {
+    "CRUD" : "D",
+    "CaseTypeID" : "Shuttered",
+    "LiveFrom" : "01/01/2017",
+    "UserRole" : "caseworker-approver"
+  },
+  {
+    "CRUD" : "D",
+    "CaseTypeID" : "Shuttered",
+    "LiveFrom" : "01/01/2017",
+    "UserRole" : "caseworker-caa"
+  },
+  {
+    "CRUD" : "D",
+    "CaseTypeID" : "Shuttered",
+    "LiveFrom" : "01/01/2017",
+    "UserRole" : "caseworker-publiclaw-bulkscan"
+  },
+  {
+    "CRUD" : "D",
+    "CaseTypeID" : "Shuttered",
+    "LiveFrom" : "01/01/2017",
+    "UserRole" : "caseworker-publiclaw-bulkscansystemupdate"
+  },
+  {
+    "CRUD" : "D",
+    "CaseTypeID" : "Shuttered",
+    "LiveFrom" : "01/01/2017",
+    "UserRole" : "caseworker-publiclaw-cafcass"
+  },
+  {
+    "CRUD" : "D",
+    "CaseTypeID" : "Shuttered",
+    "LiveFrom" : "01/01/2017",
+    "UserRole" : "caseworker-publiclaw-courtadmin"
+  },
+  {
+    "CRUD" : "D",
+    "CaseTypeID" : "Shuttered",
+    "LiveFrom" : "01/01/2017",
+    "UserRole" : "caseworker-publiclaw-solicitor"
+  },
+  {
+    "CRUD" : "CRU",
+    "CaseTypeID" : "Shuttered",
+    "LiveFrom" : "01/01/2017",
+    "UserRole" : "caseworker-publiclaw-systemupdate"
+  }
+]


### PR DESCRIPTION
## What

Adds `configBuilder.shutterServiceExclude(R... roles)` to the CCD config generator SDK.

## Why

`shutterService()` forces every non-case role's `AuthorisationCaseType` CRUD to `D` (DELETE-only). There is currently no way to shutter a service while keeping a specific role at its normal permissions.

This is a known operational problem for `caseworker-wa-task-configuration`: dropping that role to `D` when shuttering EXUI by jurisdiction can cause issues for Work Allocation / Task Management. Today the only mitigations are to avoid the no-arg `shutterService()` or to notify Task Management before the release — the tooling offers no automatic protection.

## How

- `shutterServiceExclude(R...)` records excluded roles on `ResolvedCCDConfig`.
- `AuthorisationCaseTypeGenerator` now only shutters a role when it is *not* in the excluded set. The exclusion takes precedence over both `shutterService()` and the role-specific `shutterService(R...)`.

```java
configBuilder.shutterService();
configBuilder.shutterServiceExclude(UserRole.CASEWORKER_WA_TASK_CONFIGURATION);
```

## Tests

New `AuthorisationCaseTypeGeneratorTest` covering:
- full shutter sets all roles to `D`
- an excluded role keeps its permissions while others remain shuttered
- exclude overrides a role-specific shutter

README shuttering section updated.