### PR TITLE
Add reindex helper case data index

### DIFF
--- a/sdk/decentralised-runtime/src/main/resources/dataruntime-db/migration/V0023__index_case_data_reindex_modified_date.sql
+++ b/sdk/decentralised-runtime/src/main/resources/dataruntime-db/migration/V0023__index_case_data_reindex_modified_date.sql
@@ -1,0 +1,3 @@
+create index concurrently if not exists idx_case_data_reindex_modified_date
+    on ccd.case_data ((coalesce(last_modified, created_date)))
+    include (reference, case_revision);

--- a/sdk/decentralised-runtime/src/main/resources/dataruntime-db/migration/V0023__index_case_data_reindex_modified_date.sql
+++ b/sdk/decentralised-runtime/src/main/resources/dataruntime-db/migration/V0023__index_case_data_reindex_modified_date.sql
@@ -1,3 +1,3 @@
-create index concurrently if not exists idx_case_data_reindex_modified_date
+create index concurrently idx_case_data_reindex_modified_date
     on ccd.case_data ((coalesce(last_modified, created_date)))
     include (reference, case_revision);


### PR DESCRIPTION
Adds a concurrent expression index on `coalesce(last_modified, created_date)` for `ccd.case_data`.

The reindex helper counts and enqueues cases using that expression, and the enqueue path also needs `reference` and `case_revision`, so the index includes those columns. Existing indexes cover point lookups, history, queues and idempotency, but none cover this modified-date expression.