### PR TITLE
Allow CDAM attachment without document hashes

### DIFF
--- a/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/impl/cdam/CaseDocumentHashScanner.java
+++ b/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/impl/cdam/CaseDocumentHashScanner.java
@@ -80,11 +80,10 @@ public class CaseDocumentHashScanner {
   }
 
   private DocumentHashToken buildDocumentHashToken(String documentId, JsonNode documentHashNode) {
-    if (!isText(documentHashNode)) {
-      throw new CdamAttachException("New document " + documentId + " is missing document_hash");
-    }
-
-    return new DocumentHashToken(documentId, documentHashNode.asText());
+    String hashToken = documentHashNode == null || documentHashNode.isNull()
+        ? null
+        : documentHashNode.textValue();
+    return new DocumentHashToken(documentId, hashToken);
   }
 
   private String documentId(JsonNode node) {

--- a/sdk/decentralised-runtime/src/test/java/uk/gov/hmcts/ccd/sdk/impl/cdam/CaseDocumentHashScannerTest.java
+++ b/sdk/decentralised-runtime/src/test/java/uk/gov/hmcts/ccd/sdk/impl/cdam/CaseDocumentHashScannerTest.java
@@ -207,7 +207,7 @@ class CaseDocumentHashScannerTest {
   }
 
   @Test
-  void failsWhenNewDocumentIsMissingHash() throws Exception {
+  void returnsNullHashTokenWhenNewDocumentHashIsMissing() throws Exception {
     JsonNode submittedData = read("""
         {
           "document": {
@@ -216,9 +216,23 @@ class CaseDocumentHashScannerTest {
         }
         """);
 
-    assertThatThrownBy(() -> scanner.findNewDocumentHashTokens(null, submittedData))
-        .isInstanceOf(CdamAttachException.class)
-        .hasMessageContaining("missing document_hash");
+    assertThat(scanner.findNewDocumentHashTokens(null, submittedData))
+        .containsExactly(new DocumentHashToken("22222222-2222-2222-2222-222222222222", null));
+  }
+
+  @Test
+  void returnsNullHashTokenWhenNewDocumentHashIsExplicitlyNull() throws Exception {
+    JsonNode submittedData = read("""
+        {
+          "document": {
+            "document_url": "http://dm-store/documents/22222222-2222-2222-2222-222222222222",
+            "document_hash": null
+          }
+        }
+        """);
+
+    assertThat(scanner.findNewDocumentHashTokens(null, submittedData))
+        .containsExactly(new DocumentHashToken("22222222-2222-2222-2222-222222222222", null));
   }
 
   @Test

--- a/test-projects/e2e/src/cftlibTest/java/uk/gov/hmcts/divorce/cftlib/TestWithCCD.java
+++ b/test-projects/e2e/src/cftlibTest/java/uk/gov/hmcts/divorce/cftlib/TestWithCCD.java
@@ -3089,6 +3089,36 @@ public class TestWithCCD extends CftlibTest {
     @SneakyThrows
     @Order(215)
     @Test
+    void legacyJsonCallbackAddsDocumentWithNullHashAndSdkAttachesIt() {
+        BaseJsonLegacyController.reset();
+
+        var response = submitJsonLegacyEventForCaseType(
+            JsonLegacyCcdConfig.CASE_TYPE_A,
+            Map.of("note", BaseJsonLegacyController.ACAS_DOCUMENT_WITH_NULL_HASH_NOTE),
+            201
+        );
+
+        assertThat(BaseJsonLegacyController.aboutToSubmitAttempts, equalTo(1));
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> data = (Map<String, Object>) response.get("data");
+        JsonNode responseData = mapper.valueToTree(data);
+        assertThat(responseData.findValues("document_hash"), is(empty()));
+        assertThat(responseData.toString(), containsString(BaseJsonLegacyController.NULL_HASH_CALLBACK_DOCUMENT_ID));
+
+        JsonNode storedData = mapper.readTree(storedData(JsonLegacyCcdConfig.CASE_TYPE_A));
+        assertThat(storedData.findValues("document_hash"), is(empty()));
+        assertThat(storedData.toString(), containsString(BaseJsonLegacyController.NULL_HASH_CALLBACK_DOCUMENT_ID));
+
+        JsonNode cdamDocument = fetchCdamDocument(BaseJsonLegacyController.NULL_HASH_CALLBACK_DOCUMENT_ID);
+        assertThat(cdamDocument.path("metadata").path("case_type_id").asText(),
+            equalTo(JsonLegacyCcdConfig.CASE_TYPE_A));
+        assertThat(cdamDocument.path("metadata").path("jurisdiction").asText(), equalTo("EMPLOYMENT"));
+    }
+
+    @SneakyThrows
+    @Order(216)
+    @Test
     void submittedRetriesAndDuplicateJsonLegacySubmissionDoesNotReRun() {
         for (String caseType : jsonLegacyCaseTypes()) {
             BaseJsonLegacyController.reset();
@@ -3129,7 +3159,7 @@ public class TestWithCCD extends CftlibTest {
     }
 
     @SneakyThrows
-    @Order(216)
+    @Order(217)
     @Test
     void jsonDefinitionAuditHistoryUsesStateLabel() {
         for (String caseType : jsonLegacyCaseTypes()) {

--- a/test-projects/e2e/src/main/java/uk/gov/hmcts/divorce/jsonlegacy/BaseJsonLegacyController.java
+++ b/test-projects/e2e/src/main/java/uk/gov/hmcts/divorce/jsonlegacy/BaseJsonLegacyController.java
@@ -21,8 +21,10 @@ public abstract class BaseJsonLegacyController {
 
   public static final String MARKER = "json-legacy-about-to-submit";
   public static final String ACAS_DOCUMENT_NOTE = "json-legacy-acas-cdam-document";
+  public static final String ACAS_DOCUMENT_WITH_NULL_HASH_NOTE = "json-legacy-acas-cdam-document-null-hash";
   public static final String EVENT_INPUT_DOCUMENT_ID = "11111111-1111-1111-1111-111111111111";
   public static final String CALLBACK_DOCUMENT_ID = "22222222-2222-2222-2222-222222222222";
+  public static final String NULL_HASH_CALLBACK_DOCUMENT_ID = "33333333-3333-3333-3333-333333333333";
   public static final String CALLBACK_DOCUMENT_HASH = documentHashToken(CALLBACK_DOCUMENT_ID, "EMPLOYMENT", "case-type-a");
   public static final String CONFIRMATION_HEADER = "# JSON legacy submitted";
   public static final String CONFIRMATION_BODY = "JSON legacy submitted callback ran";
@@ -54,6 +56,8 @@ public abstract class BaseJsonLegacyController {
     data.put("setInAboutToSubmit", MARKER);
     if (ACAS_DOCUMENT_NOTE.equals(data.get("note"))) {
       addAcasVisibleDocument(data, "callback-acas-document", CALLBACK_DOCUMENT_ID, CALLBACK_DOCUMENT_HASH);
+    } else if (ACAS_DOCUMENT_WITH_NULL_HASH_NOTE.equals(data.get("note"))) {
+      addAcasVisibleDocument(data, "callback-acas-document-null-hash", NULL_HASH_CALLBACK_DOCUMENT_ID, null);
     }
     aboutToSubmitSawAuthorisation = authorisation != null && !authorisation.isBlank();
     aboutToSubmitSawServiceAuthorisation = serviceAuthorisation != null && !serviceAuthorisation.isBlank();

--- a/test-projects/e2e/src/main/java/uk/gov/hmcts/divorce/stubs/RefDataStubController.java
+++ b/test-projects/e2e/src/main/java/uk/gov/hmcts/divorce/stubs/RefDataStubController.java
@@ -81,7 +81,8 @@ public class RefDataStubController {
 
     @GetMapping(value = "/documents/{documentId}", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<Map<String, Object>> documentMetadata(@PathVariable String documentId) {
-        if (!BaseJsonLegacyController.CALLBACK_DOCUMENT_ID.equals(documentId)) {
+        if (!BaseJsonLegacyController.CALLBACK_DOCUMENT_ID.equals(documentId)
+            && !BaseJsonLegacyController.NULL_HASH_CALLBACK_DOCUMENT_ID.equals(documentId)) {
             return ResponseEntity.notFound().build();
         }
 


### PR DESCRIPTION
The decentralised runtime will now tolerate & attach new documents when `document_hash` is absent or null, matching CCD data store behaviour.