### PR TITLE
Allow CCD data migration cutover toggling

### DIFF
--- a/docs/ccd-data-migration-task.md
+++ b/docs/ccd-data-migration-task.md
@@ -69,7 +69,7 @@ state:
 * timestamps
 
 The migration configuration hash covers the migration identity. Runtime limits such as
-`eventIdWindowSize`, `maxBatchesPerRun`, `maxRunTime`, and `mode` can change between invocations.
+`eventIdWindowSize`, `significantItemIdWindowSize`, `maxBatchesPerRun`, `maxRunTime`, and `mode` can change between invocations.
 If the migration identity changes after a task has already created a progress row, the task fails
 fast rather than resuming under different source filters. Operators must either keep the same
 identity configuration or explicitly reset/use a new `task-name` after confirming the target state.
@@ -89,6 +89,7 @@ ccd:
       - ET_Scotland
     source-jurisdiction: EMPLOYMENT
     event-id-window-size: 1000000
+    significant-item-id-window-size: 100000
     max-batches-per-run: 100
     max-run-time: 4h
     case-revision-offset: 1000000000

--- a/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationProperties.java
+++ b/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationProperties.java
@@ -15,6 +15,7 @@ public class CcdDataMigrationProperties {
   private CcdDataMigrationMode mode = CcdDataMigrationMode.PRELOAD_EVENTS;
   private List<String> caseTypeIds = new ArrayList<>();
   private int eventIdWindowSize = 1_000_000;
+  private int significantItemIdWindowSize = 100_000;
   private long caseRevisionOffset = 1_000_000_000L;
   private int maxBatchesPerRun = Integer.MAX_VALUE;
   private Duration maxRunTime;
@@ -33,6 +34,7 @@ public class CcdDataMigrationProperties {
         .taskName(taskName)
         .mode(mode)
         .eventIdWindowSize(eventIdWindowSize)
+        .significantItemIdWindowSize(significantItemIdWindowSize)
         .caseRevisionOffset(caseRevisionOffset)
         .maxBatchesPerRun(maxBatchesPerRun)
         .maxRunTime(maxRunTime)

--- a/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTask.java
+++ b/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTask.java
@@ -141,7 +141,9 @@ public class CcdDataMigrationTask implements Runnable {
 
   private CcdDataMigrationRunResult preloadEvents() {
     Progress progress = getOrCreateProgress();
-    if (!STATUS_PRELOAD.equals(progress.status())) {
+    if (STATUS_COMPLETE.equals(progress.status())) {
+      reopenPreload();
+    } else if (!STATUS_PRELOAD.equals(progress.status())) {
       throw new CcdDataMigrationException(
           "PRELOAD_EVENTS cannot run when migration status is " + progress.status()
               + " taskName=" + options.taskName()
@@ -177,19 +179,11 @@ public class CcdDataMigrationTask implements Runnable {
   private CcdDataMigrationRunResult cutover() {
     Progress progress = getOrCreateProgress();
     if (STATUS_COMPLETE.equals(progress.status())) {
-      transaction.execute(status -> {
-        applyMigrationStatementTimeout();
-        copySignificantItemsForCutover(progress.requiredCutoverEventHwm());
-        resetSequences();
-        validateFinal(progress.requiredCutoverEventHwm());
-        enableElasticsearchQueueTrigger();
-        return null;
-      });
-      return new CcdDataMigrationRunResult(true, 0, 0, 0, true, false);
+      prepareCompleteProgressForNextCutover(progress.requiredCutoverEventHwm());
     }
 
     prepareElasticsearchQueueForMigration();
-    long cutoverEventHwm = progress.cutoverEventHwm() == null
+    long cutoverEventHwm = progress.cutoverEventHwm() == null || STATUS_COMPLETE.equals(progress.status())
         ? captureCutoverEventHighWaterMark()
         : progress.cutoverEventHwm();
     CopyTotals totals = copyEventBatches(cutoverEventHwm);
@@ -424,7 +418,13 @@ public class CcdDataMigrationTask implements Runnable {
   }
 
   private int copySignificantItemsForCutover(long cutoverEventHwm) {
-    return db.update(
+    long significantItemsEventHwm = significantItemsProgressHighWaterMark();
+    if (significantItemsEventHwm >= cutoverEventHwm) {
+      validateSignificantItemCounts(cutoverEventHwm);
+      return 0;
+    }
+
+    int copiedItems = db.update(
         """
         insert into ccd.case_event_significant_items (
           id,
@@ -446,6 +446,7 @@ public class CcdDataMigrationTask implements Runnable {
         where cd.jurisdiction = :sourceJurisdiction
           and cd.case_type_id in (:caseTypeIds)
           and ce.case_type_id in (:caseTypeIds)
+          and ce.id > :significantItemsEventHwm
           and ce.id <= :cutoverEventHwm
         on conflict (id) do update
         set description = excluded.description,
@@ -454,7 +455,11 @@ public class CcdDataMigrationTask implements Runnable {
             case_event_id = excluded.case_event_id
         """,
         baseParams().addValue("cutoverEventHwm", cutoverEventHwm)
+            .addValue("significantItemsEventHwm", significantItemsEventHwm)
     );
+    validateSignificantItemCounts(cutoverEventHwm);
+    updateSignificantItemsProgressHighWaterMark(cutoverEventHwm);
+    return copiedItems;
   }
 
   private int refreshCutoverCaseData() {
@@ -606,6 +611,34 @@ public class CcdDataMigrationTask implements Runnable {
     );
   }
 
+  private long significantItemsProgressHighWaterMark() {
+    Long hwm = db.queryForObject(
+        """
+        select significant_items_event_hwm
+        from ccd.ccd_data_migration_progress
+        where task_name = :taskName
+        """,
+        Map.of("taskName", options.taskName()),
+        Long.class
+    );
+    return hwm == null ? 0 : hwm;
+  }
+
+  private void updateSignificantItemsProgressHighWaterMark(long significantItemsEventHwm) {
+    db.update(
+        """
+        update ccd.ccd_data_migration_progress
+        set significant_items_event_hwm = greatest(significant_items_event_hwm, :significantItemsEventHwm),
+            updated_at = now() at time zone 'UTC'
+        where task_name = :taskName
+        """,
+        Map.of(
+            "taskName", options.taskName(),
+            "significantItemsEventHwm", significantItemsEventHwm
+        )
+    );
+  }
+
   private long effectiveSourceEventHighWaterMark(long targetEventHwm) {
     long progressEventHwm = sourceEventProgressHighWaterMark();
     if (progressEventHwm > 0) {
@@ -649,6 +682,34 @@ public class CcdDataMigrationTask implements Runnable {
         )
     );
     return hwm;
+  }
+
+  private void reopenPreload() {
+    db.update(
+        """
+        update ccd.ccd_data_migration_progress
+        set status = :status,
+            cutover_event_hwm = null,
+            updated_at = now() at time zone 'UTC'
+        where task_name = :taskName
+        """,
+        Map.of("taskName", options.taskName(), "status", STATUS_PRELOAD)
+    );
+  }
+
+  private void prepareCompleteProgressForNextCutover(long completedCutoverEventHwm) {
+    db.update(
+        """
+        update ccd.ccd_data_migration_progress
+        set source_event_hwm = greatest(source_event_hwm, :completedCutoverEventHwm),
+            updated_at = now() at time zone 'UTC'
+        where task_name = :taskName
+        """,
+        Map.of(
+            "taskName", options.taskName(),
+            "completedCutoverEventHwm", completedCutoverEventHwm
+        )
+    );
   }
 
   private void markComplete() {
@@ -884,7 +945,8 @@ public class CcdDataMigrationTask implements Runnable {
         select config_hash,
                status,
                cutover_event_hwm,
-               source_event_hwm
+               source_event_hwm,
+               significant_items_event_hwm
         from ccd.ccd_data_migration_progress
         where task_name = :taskName
         """,
@@ -920,7 +982,8 @@ public class CcdDataMigrationTask implements Runnable {
         rs.getString("config_hash"),
         rs.getString("status"),
         cutoverEventHwm,
-        rs.getLong("source_event_hwm")
+        rs.getLong("source_event_hwm"),
+        rs.getLong("significant_items_event_hwm")
     );
   }
 
@@ -1231,7 +1294,13 @@ public class CcdDataMigrationTask implements Runnable {
     }
   }
 
-  private record Progress(String configHash, String status, Long cutoverEventHwm, long sourceEventHwm) {
+  private record Progress(
+      String configHash,
+      String status,
+      Long cutoverEventHwm,
+      long sourceEventHwm,
+      long significantItemsEventHwm
+  ) {
     long requiredCutoverEventHwm() {
       if (cutoverEventHwm == null) {
         throw new CcdDataMigrationException("cutover_event_hwm is not set for completed migration");

--- a/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTask.java
+++ b/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTask.java
@@ -445,14 +445,9 @@ public class CcdDataMigrationTask implements Runnable {
         join ccd.case_event target_event on target_event.id = item.case_event_id
         where cd.jurisdiction = :sourceJurisdiction
           and cd.case_type_id in (:caseTypeIds)
-          and ce.case_type_id in (:caseTypeIds)
           and ce.id > :significantItemsEventHwm
           and ce.id <= :cutoverEventHwm
-        on conflict (id) do update
-        set description = excluded.description,
-            "type" = excluded."type",
-            url = excluded.url,
-            case_event_id = excluded.case_event_id
+        on conflict (id) do nothing
         """,
         baseParams().addValue("cutoverEventHwm", cutoverEventHwm)
             .addValue("significantItemsEventHwm", significantItemsEventHwm)
@@ -768,20 +763,18 @@ public class CcdDataMigrationTask implements Runnable {
           join ccd.case_data cd on cd.id = ce.case_data_id
           where cd.jurisdiction = :sourceJurisdiction
             and cd.case_type_id in (:caseTypeIds)
-            and ce.case_type_id in (:caseTypeIds)
           group by ce.case_type_id
           order by ce.case_type_id
           """;
       case "case_event_significant_items" -> """
-          select ce.case_type_id, count(*) as count
+          select cd.case_type_id, count(*) as count
           from ccd.case_event_significant_items item
           join ccd.case_event ce on ce.id = item.case_event_id
           join ccd.case_data cd on cd.id = ce.case_data_id
           where cd.jurisdiction = :sourceJurisdiction
             and cd.case_type_id in (:caseTypeIds)
-            and ce.case_type_id in (:caseTypeIds)
-          group by ce.case_type_id
-          order by ce.case_type_id
+          group by cd.case_type_id
+          order by cd.case_type_id
           """;
       default -> throw new IllegalArgumentException("Unsupported table name: " + tableName);
     };
@@ -798,7 +791,6 @@ public class CcdDataMigrationTask implements Runnable {
         join fdw_stage.case_data cd on cd.id = ce.case_data_id
         where cd.jurisdiction = :sourceJurisdiction
           and cd.case_type_id in (:caseTypeIds)
-          and ce.case_type_id in (:caseTypeIds)
           and ce.id <= :eventHwm
         """,
         params,
@@ -812,7 +804,6 @@ public class CcdDataMigrationTask implements Runnable {
         join ccd.case_data cd on cd.id = ce.case_data_id
         where cd.jurisdiction = :sourceJurisdiction
           and cd.case_type_id in (:caseTypeIds)
-          and ce.case_type_id in (:caseTypeIds)
           and ce.id <= :eventHwm
         """,
         params,

--- a/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTask.java
+++ b/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTask.java
@@ -418,8 +418,9 @@ public class CcdDataMigrationTask implements Runnable {
   }
 
   private int copySignificantItemsForCutover(long cutoverEventHwm) {
-    long significantItemsEventHwm = significantItemsProgressHighWaterMark();
-    if (significantItemsEventHwm >= cutoverEventHwm) {
+    long significantItemsHwm = significantItemsProgressHighWaterMark();
+    long targetSignificantItemsHwm = sourceSignificantItemsHighWaterMark(cutoverEventHwm);
+    if (significantItemsHwm >= targetSignificantItemsHwm) {
       validateSignificantItemCounts(cutoverEventHwm);
       return 0;
     }
@@ -445,15 +446,17 @@ public class CcdDataMigrationTask implements Runnable {
         join ccd.case_event target_event on target_event.id = item.case_event_id
         where cd.jurisdiction = :sourceJurisdiction
           and cd.case_type_id in (:caseTypeIds)
-          and ce.id > :significantItemsEventHwm
           and ce.id <= :cutoverEventHwm
+          and item.id > :significantItemsHwm
+          and item.id <= :targetSignificantItemsHwm
         on conflict (id) do nothing
         """,
         baseParams().addValue("cutoverEventHwm", cutoverEventHwm)
-            .addValue("significantItemsEventHwm", significantItemsEventHwm)
+            .addValue("significantItemsHwm", significantItemsHwm)
+            .addValue("targetSignificantItemsHwm", targetSignificantItemsHwm)
     );
     validateSignificantItemCounts(cutoverEventHwm);
-    updateSignificantItemsProgressHighWaterMark(cutoverEventHwm);
+    updateSignificantItemsProgressHighWaterMark(targetSignificantItemsHwm);
     return copiedItems;
   }
 
@@ -609,7 +612,7 @@ public class CcdDataMigrationTask implements Runnable {
   private long significantItemsProgressHighWaterMark() {
     Long hwm = db.queryForObject(
         """
-        select significant_items_event_hwm
+        select significant_items_hwm
         from ccd.ccd_data_migration_progress
         where task_name = :taskName
         """,
@@ -619,17 +622,34 @@ public class CcdDataMigrationTask implements Runnable {
     return hwm == null ? 0 : hwm;
   }
 
-  private void updateSignificantItemsProgressHighWaterMark(long significantItemsEventHwm) {
+  private long sourceSignificantItemsHighWaterMark(long cutoverEventHwm) {
+    Long hwm = withMigrationStatementTimeout(() -> db.queryForObject(
+        """
+        select coalesce(max(item.id), 0)
+        from fdw_stage.case_event_significant_items item
+        join fdw_stage.case_event ce on ce.id = item.case_event_id
+        join fdw_stage.case_data cd on cd.id = ce.case_data_id
+        where cd.jurisdiction = :sourceJurisdiction
+          and cd.case_type_id in (:caseTypeIds)
+          and ce.id <= :cutoverEventHwm
+        """,
+        baseParams().addValue("cutoverEventHwm", cutoverEventHwm),
+        Long.class
+    ));
+    return hwm == null ? 0 : hwm;
+  }
+
+  private void updateSignificantItemsProgressHighWaterMark(long significantItemsHwm) {
     db.update(
         """
         update ccd.ccd_data_migration_progress
-        set significant_items_event_hwm = greatest(significant_items_event_hwm, :significantItemsEventHwm),
+        set significant_items_hwm = greatest(significant_items_hwm, :significantItemsHwm),
             updated_at = now() at time zone 'UTC'
         where task_name = :taskName
         """,
         Map.of(
             "taskName", options.taskName(),
-            "significantItemsEventHwm", significantItemsEventHwm
+            "significantItemsHwm", significantItemsHwm
         )
     );
   }
@@ -937,7 +957,7 @@ public class CcdDataMigrationTask implements Runnable {
                status,
                cutover_event_hwm,
                source_event_hwm,
-               significant_items_event_hwm
+               significant_items_hwm
         from ccd.ccd_data_migration_progress
         where task_name = :taskName
         """,
@@ -974,7 +994,7 @@ public class CcdDataMigrationTask implements Runnable {
         rs.getString("status"),
         cutoverEventHwm,
         rs.getLong("source_event_hwm"),
-        rs.getLong("significant_items_event_hwm")
+        rs.getLong("significant_items_hwm")
     );
   }
 
@@ -1290,7 +1310,7 @@ public class CcdDataMigrationTask implements Runnable {
       String status,
       Long cutoverEventHwm,
       long sourceEventHwm,
-      long significantItemsEventHwm
+      long significantItemsHwm
   ) {
     long requiredCutoverEventHwm() {
       if (cutoverEventHwm == null) {

--- a/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTask.java
+++ b/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTask.java
@@ -106,11 +106,12 @@ public class CcdDataMigrationTask implements Runnable {
   public final CcdDataMigrationRunResult runMigration() {
     log.info(
         "Starting CCD data migration task taskName={} mode={} caseTypeIds={} eventIdWindowSize={} "
-            + "maxBatchesPerRun={} maxRunTime={}",
+            + "significantItemIdWindowSize={} maxBatchesPerRun={} maxRunTime={}",
         options.taskName(),
         options.mode(),
         options.caseTypeIds(),
         options.eventIdWindowSize(),
+        options.significantItemIdWindowSize(),
         options.maxBatchesPerRun(),
         options.maxRunTime()
     );
@@ -152,7 +153,7 @@ public class CcdDataMigrationTask implements Runnable {
 
     prepareElasticsearchQueueForMigration();
     long targetEventHwm = sourceEventHighWaterMark();
-    CopyTotals totals = copyEventBatches(targetEventHwm);
+    CopyTotals totals = copyEventBatches(targetEventHwm, calculateStopAt());
     long sourceEventHwm = sourceEventProgressHighWaterMark();
     boolean caughtUp = sourceEventHwm >= targetEventHwm;
     log.info(
@@ -186,7 +187,8 @@ public class CcdDataMigrationTask implements Runnable {
     long cutoverEventHwm = progress.cutoverEventHwm() == null || STATUS_COMPLETE.equals(progress.status())
         ? captureCutoverEventHighWaterMark()
         : progress.cutoverEventHwm();
-    CopyTotals totals = copyEventBatches(cutoverEventHwm);
+    LocalDateTime stopAt = calculateStopAt();
+    CopyTotals totals = copyEventBatches(cutoverEventHwm, stopAt);
     long sourceEventHwm = sourceEventProgressHighWaterMark();
     if (totals.stoppedByTimeLimit() || sourceEventHwm < cutoverEventHwm) {
       log.info(
@@ -208,23 +210,40 @@ public class CcdDataMigrationTask implements Runnable {
           totals.stoppedByTimeLimit()
       );
     }
-    int significantItems = transaction.execute(status -> {
-      applyMigrationStatementTimeout();
-      return copySignificantItemsForCutover(cutoverEventHwm);
-    });
+    SignificantItemCopyTotals significantItemTotals = copySignificantItemBatches(cutoverEventHwm, stopAt);
+    if (!significantItemTotals.caughtUp()) {
+      log.info(
+          "CCD data migration cutover paused before final refresh taskName={} cutoverEventHwm={} "
+              + "significantItemBatches={} significantItems={} stoppedByTimeLimit={}",
+          options.taskName(),
+          cutoverEventHwm,
+          significantItemTotals.batches(),
+          significantItemTotals.items(),
+          significantItemTotals.stoppedByTimeLimit()
+      );
+      return new CcdDataMigrationRunResult(
+          true,
+          totals.batches(),
+          0,
+          totals.events(),
+          false,
+          significantItemTotals.stoppedByTimeLimit()
+      );
+    }
     final int refreshedCases = refreshCutoverCaseData();
     resetSequences();
     completeCutover(cutoverEventHwm);
 
     log.info(
         "Completed CCD data migration cutover taskName={} cutoverEventHwm={} batches={} refreshedCases={} events={} "
-            + "significantItems={} stoppedByTimeLimit={}",
+            + "significantItems={} significantItemBatches={} stoppedByTimeLimit={}",
         options.taskName(),
         cutoverEventHwm,
         totals.batches(),
         refreshedCases,
         totals.events(),
-        significantItems,
+        significantItemTotals.items(),
+        significantItemTotals.batches(),
         totals.stoppedByTimeLimit()
     );
     return new CcdDataMigrationRunResult(
@@ -246,9 +265,8 @@ public class CcdDataMigrationTask implements Runnable {
     return new CcdDataMigrationRunResult(true, 0, 0, 0, true, false);
   }
 
-  private CopyTotals copyEventBatches(long targetEventHwm) {
+  private CopyTotals copyEventBatches(long targetEventHwm, LocalDateTime stopAt) {
     var totals = new CopyTotals();
-    LocalDateTime stopAt = calculateStopAt();
 
     for (int i = 0; i < options.maxBatchesPerRun(); i++) {
       long sourceEventHwm = effectiveSourceEventHighWaterMark(targetEventHwm);
@@ -417,15 +435,56 @@ public class CcdDataMigrationTask implements Runnable {
     );
   }
 
-  private int copySignificantItemsForCutover(long cutoverEventHwm) {
-    long significantItemsHwm = significantItemsProgressHighWaterMark();
+  private SignificantItemCopyTotals copySignificantItemBatches(long cutoverEventHwm, LocalDateTime stopAt) {
     long targetSignificantItemsHwm = sourceSignificantItemsHighWaterMark(cutoverEventHwm);
-    if (significantItemsHwm >= targetSignificantItemsHwm) {
-      validateSignificantItemCounts(cutoverEventHwm);
-      return 0;
-    }
+    var totals = new SignificantItemCopyTotals();
 
-    int copiedItems = db.update(
+    for (int i = 0; i < options.maxBatchesPerRun(); i++) {
+      long significantItemsHwm = significantItemsProgressHighWaterMark();
+      if (significantItemsHwm >= targetSignificantItemsHwm) {
+        validateSignificantItemCounts(cutoverEventHwm);
+        return totals.markCaughtUp();
+      }
+      if (isTimeLimitReached(stopAt)) {
+        return totals.markStoppedByTimeLimit();
+      }
+
+      long batchEndItemHwm = nextFixedSignificantItemWindowEnd(significantItemsHwm, targetSignificantItemsHwm);
+      int copiedItems = transaction.execute(status -> {
+        applyMigrationStatementTimeout();
+        int copied = copySignificantItemBatch(cutoverEventHwm, significantItemsHwm, batchEndItemHwm);
+        updateSignificantItemsProgressHighWaterMark(batchEndItemHwm);
+        return copied;
+      });
+      totals = totals.plus(copiedItems);
+      log.info(
+          "CCD data migration significant item progress taskName={} cutoverEventHwm={} "
+              + "batchStartItemId={} batchEndItemHwm={} batchItems={} totalBatches={} totalItems={}",
+          options.taskName(),
+          cutoverEventHwm,
+          significantItemsHwm + 1L,
+          batchEndItemHwm,
+          copiedItems,
+          totals.batches(),
+          totals.items()
+      );
+      if (isTimeLimitReached(stopAt)) {
+        return totals.markStoppedByTimeLimit();
+      }
+    }
+    if (significantItemsProgressHighWaterMark() >= targetSignificantItemsHwm) {
+      validateSignificantItemCounts(cutoverEventHwm);
+      return totals.markCaughtUp();
+    }
+    return totals;
+  }
+
+  private int copySignificantItemBatch(
+      long cutoverEventHwm,
+      long significantItemsHwm,
+      long targetSignificantItemsHwm
+  ) {
+    return db.update(
         """
         insert into ccd.case_event_significant_items (
           id,
@@ -455,9 +514,6 @@ public class CcdDataMigrationTask implements Runnable {
             .addValue("significantItemsHwm", significantItemsHwm)
             .addValue("targetSignificantItemsHwm", targetSignificantItemsHwm)
     );
-    validateSignificantItemCounts(cutoverEventHwm);
-    updateSignificantItemsProgressHighWaterMark(targetSignificantItemsHwm);
-    return copiedItems;
   }
 
   private int refreshCutoverCaseData() {
@@ -637,6 +693,14 @@ public class CcdDataMigrationTask implements Runnable {
         Long.class
     ));
     return hwm == null ? 0 : hwm;
+  }
+
+  private long nextFixedSignificantItemWindowEnd(long significantItemsHwm, long targetSignificantItemsHwm) {
+    long itemIdWindowSize = options.significantItemIdWindowSize();
+    long windowEnd = significantItemsHwm > Long.MAX_VALUE - itemIdWindowSize
+        ? Long.MAX_VALUE
+        : significantItemsHwm + itemIdWindowSize;
+    return Math.min(windowEnd, targetSignificantItemsHwm);
   }
 
   private void updateSignificantItemsProgressHighWaterMark(long significantItemsHwm) {
@@ -1335,6 +1399,24 @@ public class CcdDataMigrationTask implements Runnable {
 
     private CopyTotals markStoppedByTimeLimit() {
       return new CopyTotals(batches, events, caughtUp, true);
+    }
+  }
+
+  private record SignificantItemCopyTotals(long batches, long items, boolean caughtUp, boolean stoppedByTimeLimit) {
+    private SignificantItemCopyTotals() {
+      this(0, 0, false, false);
+    }
+
+    private SignificantItemCopyTotals plus(int copiedItems) {
+      return new SignificantItemCopyTotals(batches + 1, items + copiedItems, caughtUp, stoppedByTimeLimit);
+    }
+
+    private SignificantItemCopyTotals markCaughtUp() {
+      return new SignificantItemCopyTotals(batches, items, true, stoppedByTimeLimit);
+    }
+
+    private SignificantItemCopyTotals markStoppedByTimeLimit() {
+      return new SignificantItemCopyTotals(batches, items, caughtUp, true);
     }
   }
 }

--- a/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTaskOptions.java
+++ b/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTaskOptions.java
@@ -15,6 +15,7 @@ public record CcdDataMigrationTaskOptions(
     CcdDataMigrationMode mode,
     List<String> caseTypeIds,
     int eventIdWindowSize,
+    int significantItemIdWindowSize,
     long caseRevisionOffset,
     int maxBatchesPerRun,
     Duration maxRunTime,
@@ -33,6 +34,9 @@ public record CcdDataMigrationTaskOptions(
 
     if (eventIdWindowSize < 1) {
       throw new IllegalArgumentException("eventIdWindowSize must be greater than zero");
+    }
+    if (significantItemIdWindowSize < 1) {
+      throw new IllegalArgumentException("significantItemIdWindowSize must be greater than zero");
     }
     if (caseRevisionOffset < 0) {
       throw new IllegalArgumentException("caseRevisionOffset must be zero or greater");
@@ -116,6 +120,7 @@ public record CcdDataMigrationTaskOptions(
     private CcdDataMigrationMode mode = CcdDataMigrationMode.PRELOAD_EVENTS;
     private final List<String> caseTypeIds;
     private int eventIdWindowSize = 1_000_000;
+    private int significantItemIdWindowSize = 100_000;
     private long caseRevisionOffset = 1_000_000_000L;
     private int maxBatchesPerRun = Integer.MAX_VALUE;
     private Duration maxRunTime;
@@ -138,6 +143,11 @@ public record CcdDataMigrationTaskOptions(
 
     public Builder eventIdWindowSize(int eventIdWindowSize) {
       this.eventIdWindowSize = eventIdWindowSize;
+      return this;
+    }
+
+    public Builder significantItemIdWindowSize(int significantItemIdWindowSize) {
+      this.significantItemIdWindowSize = significantItemIdWindowSize;
       return this;
     }
 
@@ -172,6 +182,7 @@ public record CcdDataMigrationTaskOptions(
           mode,
           caseTypeIds,
           eventIdWindowSize,
+          significantItemIdWindowSize,
           caseRevisionOffset,
           maxBatchesPerRun,
           maxRunTime,

--- a/sdk/decentralised-runtime/src/main/resources/dataruntime-db/migration/V0024__data_migration_significant_items_hwm.sql
+++ b/sdk/decentralised-runtime/src/main/resources/dataruntime-db/migration/V0024__data_migration_significant_items_hwm.sql
@@ -1,13 +1,18 @@
 alter table ccd.ccd_data_migration_progress
-add column significant_items_event_hwm bigint not null default 0;
+add column significant_items_hwm bigint not null default 0;
 
 update ccd.ccd_data_migration_progress
 set source_event_hwm = greatest(source_event_hwm, cutover_event_hwm),
-    significant_items_event_hwm = cutover_event_hwm,
+    significant_items_hwm = coalesce((
+        select max(item.id)
+        from ccd.case_event_significant_items item
+        join ccd.case_event ce on ce.id = item.case_event_id
+        where ce.id <= ccd.ccd_data_migration_progress.cutover_event_hwm
+    ), 0),
     updated_at = now() at time zone 'UTC'
 where status = 'COMPLETE'
   and cutover_event_hwm is not null
   and (
     source_event_hwm = 0
-    or significant_items_event_hwm = 0
+    or significant_items_hwm = 0
   );

--- a/sdk/decentralised-runtime/src/main/resources/dataruntime-db/migration/V0024__data_migration_significant_items_hwm.sql
+++ b/sdk/decentralised-runtime/src/main/resources/dataruntime-db/migration/V0024__data_migration_significant_items_hwm.sql
@@ -1,0 +1,13 @@
+alter table ccd.ccd_data_migration_progress
+add column significant_items_event_hwm bigint not null default 0;
+
+update ccd.ccd_data_migration_progress
+set source_event_hwm = greatest(source_event_hwm, cutover_event_hwm),
+    significant_items_event_hwm = cutover_event_hwm,
+    updated_at = now() at time zone 'UTC'
+where status = 'COMPLETE'
+  and cutover_event_hwm is not null
+  and (
+    source_event_hwm = 0
+    or significant_items_event_hwm = 0
+  );

--- a/sdk/decentralised-runtime/src/main/resources/dataruntime-db/migration/V0024__data_migration_significant_items_hwm.sql
+++ b/sdk/decentralised-runtime/src/main/resources/dataruntime-db/migration/V0024__data_migration_significant_items_hwm.sql
@@ -3,16 +3,7 @@ add column significant_items_hwm bigint not null default 0;
 
 update ccd.ccd_data_migration_progress
 set source_event_hwm = greatest(source_event_hwm, cutover_event_hwm),
-    significant_items_hwm = coalesce((
-        select max(item.id)
-        from ccd.case_event_significant_items item
-        join ccd.case_event ce on ce.id = item.case_event_id
-        where ce.id <= ccd.ccd_data_migration_progress.cutover_event_hwm
-    ), 0),
     updated_at = now() at time zone 'UTC'
 where status = 'COMPLETE'
   and cutover_event_hwm is not null
-  and (
-    source_event_hwm = 0
-    or significant_items_hwm = 0
-  );
+  and source_event_hwm = 0;

--- a/sdk/decentralised-runtime/src/test/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTaskIntegrationTest.java
+++ b/sdk/decentralised-runtime/src/test/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTaskIntegrationTest.java
@@ -144,19 +144,20 @@ class CcdDataMigrationTaskIntegrationTest {
     assertThat(progressStatus()).isEqualTo("COMPLETE");
     assertThat(cutoverEventHwm()).isEqualTo(101);
     assertThat(sourceEventHwm()).isEqualTo(101);
-    assertThat(significantItemsEventHwm()).isEqualTo(101);
+    assertThat(significantItemsHwm()).isEqualTo(5001);
     assertThat(countRows("ccd.case_event_significant_items")).isEqualTo(1);
 
     updateSourceCase(10, 2, "Updated", "{\"field\":\"two\"}");
     insertSourceCaseEvent(102, 10, "update", "Updated", "{\"field\":\"two\"}", minutesAgo(30));
     insertSourceSignificantItem(5002, 102, "Second document", "http://dm-store/documents/second");
+    insertSourceSignificantItem(5003, 101, "Late old event document", "http://dm-store/documents/late-old-event");
 
     CcdDataMigrationRunResult preload = task(PRELOAD_EVENTS, 1000, 10).runMigration();
 
     assertThat(preload.caughtUp()).isTrue();
     assertThat(progressStatus()).isEqualTo("PRELOAD");
     assertThat(sourceEventHwm()).isEqualTo(102);
-    assertThat(significantItemsEventHwm()).isEqualTo(101);
+    assertThat(significantItemsHwm()).isEqualTo(5001);
     assertThat(countRows("ccd.case_event_significant_items")).isEqualTo(1);
 
     CcdDataMigrationRunResult secondCutover = task(CUTOVER, 1000, 10).runMigration();
@@ -165,11 +166,12 @@ class CcdDataMigrationTaskIntegrationTest {
     assertThat(progressStatus()).isEqualTo("COMPLETE");
     assertThat(cutoverEventHwm()).isEqualTo(102);
     assertThat(sourceEventHwm()).isEqualTo(102);
-    assertThat(significantItemsEventHwm()).isEqualTo(102);
+    assertThat(significantItemsHwm()).isEqualTo(5003);
     assertThat(countRows("ccd.case_event")).isEqualTo(2);
-    assertThat(countRows("ccd.case_event_significant_items")).isEqualTo(2);
+    assertThat(countRows("ccd.case_event_significant_items")).isEqualTo(3);
     assertThat(significantItemDescription(5001)).isEqualTo("First document");
     assertThat(significantItemDescription(5002)).isEqualTo("Second document");
+    assertThat(significantItemDescription(5003)).isEqualTo("Late old event document");
 
     updateSourceCase(10, 3, "Closed", "{\"field\":\"three\"}");
     insertSourceCaseEvent(103, 10, "close", "Closed", "{\"field\":\"three\"}", LocalDateTime.now());
@@ -180,9 +182,9 @@ class CcdDataMigrationTaskIntegrationTest {
     assertThat(thirdCutover.caughtUp()).isTrue();
     assertThat(cutoverEventHwm()).isEqualTo(103);
     assertThat(sourceEventHwm()).isEqualTo(103);
-    assertThat(significantItemsEventHwm()).isEqualTo(103);
+    assertThat(significantItemsHwm()).isEqualTo(5003);
     assertThat(countRows("ccd.case_event")).isEqualTo(3);
-    assertThat(countRows("ccd.case_event_significant_items")).isEqualTo(2);
+    assertThat(countRows("ccd.case_event_significant_items")).isEqualTo(3);
   }
 
   @Test
@@ -1189,9 +1191,9 @@ class CcdDataMigrationTaskIntegrationTest {
     );
   }
 
-  private long significantItemsEventHwm() {
+  private long significantItemsHwm() {
     return jdbc.queryForObject(
-        "select significant_items_event_hwm from ccd.ccd_data_migration_progress where task_name = :taskName",
+        "select significant_items_hwm from ccd.ccd_data_migration_progress where task_name = :taskName",
         Map.of("taskName", "ccd-data-migration"),
         Long.class
     );

--- a/sdk/decentralised-runtime/src/test/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTaskIntegrationTest.java
+++ b/sdk/decentralised-runtime/src/test/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTaskIntegrationTest.java
@@ -120,13 +120,14 @@ class CcdDataMigrationTaskIntegrationTest {
     assertThat(preloadResult.caughtUp()).isFalse();
     assertThat(countRows("ccd.case_event_significant_items")).isZero();
     assertThat(sourceEventHwm()).isEqualTo(101);
+    insertTargetSignificantItem(5001, 101, "Existing document", "http://dm-store/documents/existing");
 
     CcdDataMigrationRunResult cutoverResult = task(CUTOVER, 1000, 10).runMigration();
 
     assertThat(cutoverResult.caughtUp()).isTrue();
     assertThat(progressStatus()).isEqualTo("COMPLETE");
     assertThat(countRows("ccd.case_event_significant_items")).isEqualTo(2);
-    assertThat(significantItemDescription(5001)).isEqualTo("First document");
+    assertThat(significantItemDescription(5001)).isEqualTo("Existing document");
     assertThat(significantItemDescription(5002)).isEqualTo("Second document");
     assertThat(caseEventSignificantItemsSequenceLastValue()).isGreaterThanOrEqualTo(5002);
   }
@@ -590,6 +591,31 @@ class CcdDataMigrationTaskIntegrationTest {
     jdbc.update(
         """
         insert into source.case_event_significant_items (
+          id,
+          description,
+          "type",
+          url,
+          case_event_id
+        ) values (
+          :id,
+          :description,
+          'DOCUMENT',
+          :url,
+          :caseEventId
+        )
+        """,
+        new MapSqlParameterSource()
+            .addValue("id", id)
+            .addValue("description", description)
+            .addValue("url", url)
+            .addValue("caseEventId", caseEventId)
+    );
+  }
+
+  private void insertTargetSignificantItem(long id, long caseEventId, String description, String url) {
+    jdbc.update(
+        """
+        insert into ccd.case_event_significant_items (
           id,
           description,
           "type",

--- a/sdk/decentralised-runtime/src/test/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTaskIntegrationTest.java
+++ b/sdk/decentralised-runtime/src/test/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTaskIntegrationTest.java
@@ -132,6 +132,59 @@ class CcdDataMigrationTaskIntegrationTest {
   }
 
   @Test
+  void togglesPreloadAndCutoverWithSignificantItemDelta() {
+    insertSourceCase(10, 1000000000000010L, 1, "Submitted", "{\"field\":\"one\"}");
+    insertSourceCaseEvent(101, 10, "create", "Submitted", "{\"field\":\"one\"}", minutesAgo(60));
+    insertSourceSignificantItem(5001, 101, "First document", "http://dm-store/documents/first");
+
+    CcdDataMigrationRunResult firstCutover = task(CUTOVER, 1000, 10).runMigration();
+
+    assertThat(firstCutover.caughtUp()).isTrue();
+    assertThat(progressStatus()).isEqualTo("COMPLETE");
+    assertThat(cutoverEventHwm()).isEqualTo(101);
+    assertThat(sourceEventHwm()).isEqualTo(101);
+    assertThat(significantItemsEventHwm()).isEqualTo(101);
+    assertThat(countRows("ccd.case_event_significant_items")).isEqualTo(1);
+
+    updateSourceCase(10, 2, "Updated", "{\"field\":\"two\"}");
+    insertSourceCaseEvent(102, 10, "update", "Updated", "{\"field\":\"two\"}", minutesAgo(30));
+    insertSourceSignificantItem(5002, 102, "Second document", "http://dm-store/documents/second");
+
+    CcdDataMigrationRunResult preload = task(PRELOAD_EVENTS, 1000, 10).runMigration();
+
+    assertThat(preload.caughtUp()).isTrue();
+    assertThat(progressStatus()).isEqualTo("PRELOAD");
+    assertThat(sourceEventHwm()).isEqualTo(102);
+    assertThat(significantItemsEventHwm()).isEqualTo(101);
+    assertThat(countRows("ccd.case_event_significant_items")).isEqualTo(1);
+
+    CcdDataMigrationRunResult secondCutover = task(CUTOVER, 1000, 10).runMigration();
+
+    assertThat(secondCutover.caughtUp()).isTrue();
+    assertThat(progressStatus()).isEqualTo("COMPLETE");
+    assertThat(cutoverEventHwm()).isEqualTo(102);
+    assertThat(sourceEventHwm()).isEqualTo(102);
+    assertThat(significantItemsEventHwm()).isEqualTo(102);
+    assertThat(countRows("ccd.case_event")).isEqualTo(2);
+    assertThat(countRows("ccd.case_event_significant_items")).isEqualTo(2);
+    assertThat(significantItemDescription(5001)).isEqualTo("First document");
+    assertThat(significantItemDescription(5002)).isEqualTo("Second document");
+
+    updateSourceCase(10, 3, "Closed", "{\"field\":\"three\"}");
+    insertSourceCaseEvent(103, 10, "close", "Closed", "{\"field\":\"three\"}", LocalDateTime.now());
+
+    task(PRELOAD_EVENTS, 1000, 10).runMigration();
+    CcdDataMigrationRunResult thirdCutover = task(CUTOVER, 1000, 10).runMigration();
+
+    assertThat(thirdCutover.caughtUp()).isTrue();
+    assertThat(cutoverEventHwm()).isEqualTo(103);
+    assertThat(sourceEventHwm()).isEqualTo(103);
+    assertThat(significantItemsEventHwm()).isEqualTo(103);
+    assertThat(countRows("ccd.case_event")).isEqualTo(3);
+    assertThat(countRows("ccd.case_event_significant_items")).isEqualTo(2);
+  }
+
+  @Test
   void completedCutoverRerunCopiesSignificantItemsBeforeValidation() {
     insertSourceCase(10, 1000000000000010L, 1, "Submitted", "{\"field\":\"one\"}");
     insertSourceCaseEvent(101, 10, "create", "Submitted", "{\"field\":\"one\"}", minutesAgo(60));
@@ -145,7 +198,7 @@ class CcdDataMigrationTaskIntegrationTest {
 
     assertThat(result.caughtUp()).isTrue();
     assertThat(result.eventsProcessed()).isZero();
-    assertThat(sourceEventHwm()).isZero();
+    assertThat(sourceEventHwm()).isEqualTo(101);
     assertThat(countRows("ccd.case_event")).isEqualTo(1);
     assertThat(countRows("ccd.case_event_significant_items")).isEqualTo(1);
     assertThat(significantItemDescription(5001)).isEqualTo("First document");
@@ -205,16 +258,19 @@ class CcdDataMigrationTaskIntegrationTest {
   }
 
   @Test
-  void completedCutoverRerunValidatesBeforeReEnablingElasticsearchQueueTrigger() {
+  void completedCutoverRerunDeletesMigratedQueueRowsAndEnablesElasticsearchQueueTrigger() {
+    insertSourceCase(10, 1000000000000010L, 1, "Submitted", "{\"field\":\"one\"}");
+    insertSourceCaseEvent(101, 10, "create", "Submitted", "{\"field\":\"one\"}", minutesAgo(60));
     insertTargetCase(10, 1000000000000010L, 1, "Submitted", "{\"field\":\"one\"}", 1);
     createCompleteProgress(101);
     jdbc.getJdbcTemplate().execute("alter table ccd.case_data disable trigger trigger_enqueue_case_revision");
 
-    assertThatThrownBy(() -> task(CUTOVER, 101, 10).runMigration())
-        .isInstanceOf(CcdDataMigrationException.class)
-        .hasMessageContaining("CCD data migration left 1 Elasticsearch queue rows");
+    CcdDataMigrationRunResult result = task(CUTOVER, 101, 10).runMigration();
 
-    assertThat(caseDataTriggerEnabled("trigger_enqueue_case_revision")).isFalse();
+    assertThat(result.caughtUp()).isTrue();
+    assertThat(cutoverEventHwm()).isEqualTo(101);
+    assertThat(countElasticsearchQueueRows("TestCase")).isZero();
+    assertThat(caseDataTriggerEnabled("trigger_enqueue_case_revision")).isTrue();
   }
 
   @Test
@@ -1102,6 +1158,14 @@ class CcdDataMigrationTaskIntegrationTest {
   private long cutoverEventHwm() {
     return jdbc.queryForObject(
         "select cutover_event_hwm from ccd.ccd_data_migration_progress where task_name = :taskName",
+        Map.of("taskName", "ccd-data-migration"),
+        Long.class
+    );
+  }
+
+  private long significantItemsEventHwm() {
+    return jdbc.queryForObject(
+        "select significant_items_event_hwm from ccd.ccd_data_migration_progress where task_name = :taskName",
         Map.of("taskName", "ccd-data-migration"),
         Long.class
     );

--- a/sdk/decentralised-runtime/src/test/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTaskIntegrationTest.java
+++ b/sdk/decentralised-runtime/src/test/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTaskIntegrationTest.java
@@ -188,6 +188,26 @@ class CcdDataMigrationTaskIntegrationTest {
   }
 
   @Test
+  void batchesSignificantItemsAcrossCutoverRuns() {
+    insertSourceCase(10, 1000000000000010L, 1, "Submitted", "{\"field\":\"one\"}");
+    insertSourceCaseEvent(101, 10, "create", "Submitted", "{\"field\":\"one\"}", minutesAgo(60));
+    insertSourceSignificantItem(5001, 101, "First document", "http://dm-store/documents/first");
+    insertSourceSignificantItem(10002, 101, "Second document", "http://dm-store/documents/second");
+
+    CcdDataMigrationRunResult firstCutover = task(CUTOVER, 1000, 1, 5001).runMigration();
+
+    assertThat(firstCutover.caughtUp()).isFalse();
+    assertThat(significantItemsHwm()).isEqualTo(5001);
+    assertThat(countRows("ccd.case_event_significant_items")).isEqualTo(1);
+
+    CcdDataMigrationRunResult secondCutover = task(CUTOVER, 1000, 1, 5001).runMigration();
+
+    assertThat(secondCutover.caughtUp()).isTrue();
+    assertThat(significantItemsHwm()).isEqualTo(10002);
+    assertThat(countRows("ccd.case_event_significant_items")).isEqualTo(2);
+  }
+
+  @Test
   void completedCutoverRerunCopiesSignificantItemsBeforeValidation() {
     insertSourceCase(10, 1000000000000010L, 1, "Submitted", "{\"field\":\"one\"}");
     insertSourceCaseEvent(101, 10, "create", "Submitted", "{\"field\":\"one\"}", minutesAgo(60));
@@ -468,9 +488,19 @@ class CcdDataMigrationTaskIntegrationTest {
       int eventIdWindowSize,
       int maxBatchesPerRun
   ) {
+    return task(mode, eventIdWindowSize, maxBatchesPerRun, 100_000);
+  }
+
+  private CcdDataMigrationTask task(
+      CcdDataMigrationMode mode,
+      int eventIdWindowSize,
+      int maxBatchesPerRun,
+      int significantItemIdWindowSize
+  ) {
     var options = optionsBuilder(List.of("TestCase"))
         .mode(mode)
         .eventIdWindowSize(eventIdWindowSize)
+        .significantItemIdWindowSize(significantItemIdWindowSize)
         .maxBatchesPerRun(maxBatchesPerRun)
         .build();
     return new CcdDataMigrationTask(jdbc, transactionManager, options);

--- a/sdk/decentralised-runtime/src/test/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTaskOptionsTest.java
+++ b/sdk/decentralised-runtime/src/test/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTaskOptionsTest.java
@@ -17,6 +17,7 @@ class CcdDataMigrationTaskOptionsTest {
     assertThat(options.mode()).isEqualTo(CcdDataMigrationMode.PRELOAD_EVENTS);
     assertThat(options.sourceJurisdiction()).isEqualTo("TEST");
     assertThat(options.eventIdWindowSize()).isEqualTo(1_000_000);
+    assertThat(options.significantItemIdWindowSize()).isEqualTo(100_000);
     assertThat(options.caseRevisionOffset()).isEqualTo(1_000_000_000L);
     assertThat(options.maxBatchesPerRun()).isEqualTo(Integer.MAX_VALUE);
     assertThat(options.maxRunTime()).isNull();
@@ -86,6 +87,15 @@ class CcdDataMigrationTaskOptionsTest {
         .build())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("eventIdWindowSize");
+  }
+
+  @Test
+  void rejectsNonPositiveSignificantItemIdWindowSize() {
+    assertThatThrownBy(() -> builder(List.of("TestCase"))
+        .significantItemIdWindowSize(0)
+        .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("significantItemIdWindowSize");
   }
 
   @Test


### PR DESCRIPTION
## Summary
- allow CCD data migration to move from COMPLETE back to PRELOAD_EVENTS and then capture a fresh CUTOVER high-water mark
- add a significant_items_event_hwm checkpoint so case_event_significant_items copies only the new cutover delta
- backfill existing completed progress rows to avoid recopying previously validated significant items

## Tests
- ./gradlew -p sdk :decentralised-runtime:check