### PR TITLE
Use global significant item high water mark

### DIFF
--- a/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTask.java
+++ b/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTask.java
@@ -683,11 +683,7 @@ public class CcdDataMigrationTask implements Runnable {
         """
         select coalesce(max(item.id), 0)
         from fdw_stage.case_event_significant_items item
-        join fdw_stage.case_event ce on ce.id = item.case_event_id
-        join fdw_stage.case_data cd on cd.id = ce.case_data_id
-        where cd.jurisdiction = :sourceJurisdiction
-          and cd.case_type_id in (:caseTypeIds)
-          and ce.id <= :cutoverEventHwm
+        where item.case_event_id <= :cutoverEventHwm
         """,
         baseParams().addValue("cutoverEventHwm", cutoverEventHwm),
         Long.class


### PR DESCRIPTION
The significant-item cutover currently calculates its high-water mark by joining the foreign significant-item, event, and case-data tables and applying the migration filters. With a large CCD case event dataset, that lookup can time out before batching starts.