### PR TITLE
Support explicit per-field Publish/PublishAs on CaseEventToFields

### DIFF
--- a/sdk/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/api/Field.java
+++ b/sdk/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/api/Field.java
@@ -34,6 +34,8 @@ public class Field<Type, StateType, Parent, Grandparent> {
   boolean readOnly;
   private MidEvent midEventCallback;
   boolean retainHiddenValue;
+  Boolean publish;
+  String publishAs;
 
   Class<Type> clazz;
   @ToString.Exclude
@@ -112,6 +114,27 @@ public class Field<Type, StateType, Parent, Grandparent> {
 
     public FieldBuilder<Type, StateType, Parent, Grandparent> readOnly() {
       this.context = DisplayContext.ReadOnly;
+      return this;
+    }
+
+    /**
+     * Explicitly sets this field's {@code CaseEventToFields.Publish} column, overriding the
+     * event-level {@code publishToCamunda()} cascade for this field only: {@code false} opts the
+     * field out of a publishing event, {@code true} publishes it on a non-publishing event.
+     */
+    public FieldBuilder<Type, StateType, Parent, Grandparent> publish(boolean publish) {
+      this.publish = publish;
+      return this;
+    }
+
+    /**
+     * Sets this field's {@code CaseEventToFields.PublishAs} alias. Implies {@code publish(true)}
+     * per the definition-store parser, which treats {@code PublishAs} as meaningless without
+     * {@code Publish}.
+     */
+    public FieldBuilder<Type, StateType, Parent, Grandparent> publishAs(String publishAs) {
+      this.publishAs = publishAs;
+      this.publish = true;
       return this;
     }
   }

--- a/sdk/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/api/FieldCollection.java
+++ b/sdk/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/api/FieldCollection.java
@@ -375,6 +375,31 @@ public class FieldCollection {
       return this;
     }
 
+    /**
+     * Explicitly sets the most-recently-added field's {@code CaseEventToFields.Publish} column,
+     * overriding the event-level {@code publishToCamunda()} cascade for that field only:
+     * {@code false} opts the field out of a publishing event, {@code true} publishes it on a
+     * non-publishing event.
+     */
+    public FieldCollectionBuilder<Type, StateType, Parent> publish(boolean publish) {
+      lastField().publish(publish);
+      return this;
+    }
+
+    /**
+     * Sets the most-recently-added field's {@code CaseEventToFields.PublishAs} alias. Implies
+     * {@code publish(true)} per the definition-store parser, which treats {@code PublishAs} as
+     * meaningless without {@code Publish}.
+     */
+    public FieldCollectionBuilder<Type, StateType, Parent> publishAs(String publishAs) {
+      lastField().publishAs(publishAs);
+      return this;
+    }
+
+    private FieldBuilder<?, StateType, Type, Parent> lastField() {
+      return fields.get(fields.size() - 1);
+    }
+
     public <U> FieldCollectionBuilder<U, StateType, FieldCollectionBuilder<Type, StateType, Parent>> complex(
         TypedPropertyGetter<Type, U> getter, String showCondition, String eventFieldLabel, String eventFieldHint) {
       return complex(getter, true, showCondition, eventFieldLabel, eventFieldHint, false);

--- a/sdk/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/CaseEventToFieldsGenerator.java
+++ b/sdk/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/CaseEventToFieldsGenerator.java
@@ -53,7 +53,7 @@ class CaseEventToFieldsGenerator<T, S, R extends HasRole> implements ConfigGener
       Map<String, Object> row = JsonUtils.caseRow(config.getCaseType());
       entries.add(row);
       populateCoreColumns(row, event, field);
-      applyPublishFlag(row, event);
+      applyPublishFlag(row, event, field);
 
       Object pageId = resolvePageId(field.getPage());
       row.put("PageID", pageId);
@@ -83,13 +83,28 @@ class CaseEventToFieldsGenerator<T, S, R extends HasRole> implements ConfigGener
         .orElse("COMPLEX");
   }
 
-  private void applyPublishFlag(Map<String, Object> row, Event<T, R, S> event) {
-    if (!event.isPublishToCamunda()) {
+  /**
+   * Resolves {@code Publish}/{@code PublishAs} for a single field. An explicit
+   * {@code field.publish(boolean)} overrides the event-level {@code publishToCamunda()} cascade:
+   * {@code publish(false)} opts the field out of a publishing event, while {@code publish(true)}
+   * (or {@code publishAs}, which implies it) publishes the field even on a non-publishing event.
+   * With no explicit value the cascade applies as before. The definition store rejects a
+   * {@code Publish} column on {@code COMPLEX} fields, so neither the cascade nor an explicit
+   * override is written there.
+   */
+  private void applyPublishFlag(Map<String, Object> row, Event<T, R, S> event, Field field) {
+    String context = row.get("DisplayContext").toString();
+    if (context.equals(DisplayContext.Complex.toString().toUpperCase())) {
       return;
     }
-    String context = row.get("DisplayContext").toString();
-    if (!context.equals(DisplayContext.Complex.toString().toUpperCase())) {
-      row.put("Publish", "Y");
+    Boolean explicit = field.getPublish();
+    boolean publish = explicit != null ? explicit : event.isPublishToCamunda();
+    if (!publish) {
+      return;
+    }
+    row.put("Publish", "Y");
+    if (field.getPublishAs() != null) {
+      row.put("PublishAs", field.getPublishAs());
     }
   }
 

--- a/sdk/ccd-config-generator/src/test/java/uk/gov/hmcts/reform/fpl/CCDConfig.java
+++ b/sdk/ccd-config-generator/src/test/java/uk/gov/hmcts/reform/fpl/CCDConfig.java
@@ -177,8 +177,8 @@ public class CCDConfig implements uk.gov.hmcts.ccd.sdk.api.CCDConfig<CaseData, S
             .optional(OrganisationPolicy::getOrgPolicyReference, null, null, "Org ref", "Sol org ref")
             .done()
           .done()
-        .optional(CaseData::getCaseName)
-        .optionalWithLabel(CaseData::getGatekeeperEmail, "Gate keeper email")
+        .optional(CaseData::getCaseName).publishAs("caseNameAlias")
+        .optionalWithLabel(CaseData::getGatekeeperEmail, "Gate keeper email").publish(false)
         .mandatoryWithoutDefaultValue(CaseData::getAllocatedJudge, "hearingPreferencesWelsh=\"yes\"", "Judge is bilingual", true)
         .mandatoryWithLabel(CaseData::getCaseLocalAuthority, "Please enter a case local authority");
 
@@ -416,7 +416,7 @@ public class CCDConfig implements uk.gov.hmcts.ccd.sdk.api.CCDConfig<CaseData, S
         .grant(CRU, HMCTS_ADMIN)
         .fields()
         .page("SetAField")
-        .optional(CaseData::getAField);
+        .optional(CaseData::getAField).publish(true);
 
     builder.event("listApplicantsEvent")
         .forAllStates()

--- a/sdk/ccd-config-generator/src/test/resources/CARE_SUPERVISION_EPO/CaseEventToFields/addNotes.json
+++ b/sdk/ccd-config-generator/src/test/resources/CARE_SUPERVISION_EPO/CaseEventToFields/addNotes.json
@@ -91,7 +91,8 @@
     "DisplayContext": "OPTIONAL",
     "PageDisplayOrder": 1,
     "ShowSummaryChangeOption" : "Y",
-    "Publish": "Y"
+    "Publish": "Y",
+    "PublishAs": "caseNameAlias"
   },
   {
     "CaseEventFieldLabel" : "Gate keeper email",
@@ -104,8 +105,7 @@
     "PageDisplayOrder" : 1,
     "PageFieldDisplayOrder" : 8,
     "PageID" : 1,
-    "ShowSummaryChangeOption" : "Y",
-    "Publish": "Y"
+    "ShowSummaryChangeOption" : "Y"
   },
   {
     "CaseEventFieldLabel" : "Judge is bilingual",

--- a/sdk/ccd-config-generator/src/test/resources/CARE_SUPERVISION_EPO/CaseEventToFields/set-a-field.json
+++ b/sdk/ccd-config-generator/src/test/resources/CARE_SUPERVISION_EPO/CaseEventToFields/set-a-field.json
@@ -9,6 +9,7 @@
     "PageDisplayOrder": 1,
     "PageFieldDisplayOrder": 1,
     "PageID": "SetAField",
-    "ShowSummaryChangeOption": "Y"
+    "ShowSummaryChangeOption": "Y",
+    "Publish": "Y"
   }
 ]


### PR DESCRIPTION
Adds `publish(boolean)` and `publishAs(String)` to the field-authoring API, letting a service opt an individual field out of an event's publish-to-Camunda cascade, or publish a field (optionally under an alias) on an event that doesn't otherwise publish. Without either call, existing event-level cascade behaviour is unchanged.

The definition store only reads `PublishAs` on `CaseEventToFields` (and `EventToComplexTypes`) — there is no event-level `publish_as` column — so this per-field surface is the schema-accurate shape. `COMPLEX` display-context fields remain skipped, matching definition-store validation. `EventToComplexTypes`-level `PublishAs` is left as follow-up.

Covered by extending the FPL golden-file fixtures: a `publishAs` alias and a `publish(false)` opt-out on a publishing event, and a `publish(true)` field on a non-publishing event. No other generated output changes.