### PR TITLE
Add explicit state grants and role-scoped search/workbasket fields

### DIFF
--- a/sdk/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/ConfigBuilderImpl.java
+++ b/sdk/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/ConfigBuilderImpl.java
@@ -140,6 +140,11 @@ public class ConfigBuilderImpl<T, S, R extends HasRole> implements Decentralised
   }
 
   @Override
+  public void explicitStateGrants() {
+    config.explicitStateGrants = true;
+  }
+
+  @Override
   public void omitHistoryForRoles(R... roles) {
     omitHistoryForRoles.addAll(Set.of(roles));
   }

--- a/sdk/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/ResolvedCCDConfig.java
+++ b/sdk/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/ResolvedCCDConfig.java
@@ -51,6 +51,7 @@ public class ResolvedCCDConfig<T, S, R extends HasRole> {
   String jurDesc = "";
   String hmctsServiceId = "";
   boolean shutterService = false;
+  boolean explicitStateGrants = false;
   Map<String, String> stateLabels = new HashMap<>();
 
   Table<S, R, Set<Permission>> stateRolePermissions = HashBasedTable.create();

--- a/sdk/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/api/ConfigBuilder.java
+++ b/sdk/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/api/ConfigBuilder.java
@@ -48,6 +48,24 @@ public interface ConfigBuilder<T, S, R extends HasRole> {
   void omitHistoryForRoles(R... roles);
 
   /**
+   * Emit AuthorisationCaseState rows only for the grants declared explicitly via
+   * {@link #grant(Object, Set, HasRole...)}. When set, no state permissions are inferred from
+   * event grants, so the generated AuthorisationCaseState contains exactly the rows this case
+   * type declares and nothing more.
+   *
+   * <p>By default (when this is not called) AuthorisationCaseState is broadened by deriving
+   * permissions from every event's grants, which produces wider access than an explicit
+   * {@code grant(state, ...)} row alone. Services migrating from hand-written JSON with
+   * deliberately narrow state permissions can call this to opt out of that derivation.
+   *
+   * <p>This is a whole case-type switch and applies to every state. It does not affect field
+   * authorisation; {@code Event.explicitGrants()} remains the switch for that.
+   */
+  default void explicitStateGrants() {
+    // Default no-op for backward compatibility; implementations may override.
+  }
+
+  /**
    * Set AuthorisationCaseState explicitly.
    * Note that additional AuthorisationCaseState permissions are inferred based on grants of
    * event-level permissions.

--- a/sdk/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/api/Search.java
+++ b/sdk/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/api/Search.java
@@ -29,8 +29,33 @@ public class Search<T, R extends HasRole> {
       return this;
     }
 
+    /**
+     * Add a role-scoped search/workbasket field. The row is emitted with a {@code UserRole} column
+     * ({@code AccessProfile} alias) so the definition store only makes the field visible to the
+     * given role; add one call per role to expose it to several roles (matching how the sheets scope
+     * individual rows). Follows the row-level scoping of {@link Tab.TabBuilder#forRoles} but per field.
+     *
+     * <p>Read permission for the referenced case field is injected for the scoped role only (not all
+     * roles) by the AuthorisationCaseField generator, which is what the definition store expects for a
+     * role-scoped search field.
+     */
+    public SearchBuilder<T, R> field(TypedPropertyGetter<T, ?> getter, String label, R role) {
+      String name = propertyUtils.getPropertyName(model, getter);
+      fields.add(SearchField.<R>builder().id(name).label(label).userRole(role).build());
+      return this;
+    }
+
     public SearchBuilder<T, R> field(String fieldName, String label) {
       fields.add(SearchField.<R>builder().id(fieldName).label(label).build());
+      return this;
+    }
+
+    /**
+     * Add a role-scoped search/workbasket field by raw field id. See
+     * {@link #field(TypedPropertyGetter, String, HasRole)} for the role-scoping semantics.
+     */
+    public SearchBuilder<T, R> field(String fieldName, String label, R role) {
+      fields.add(SearchField.<R>builder().id(fieldName).label(label).userRole(role).build());
       return this;
     }
 

--- a/sdk/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/AuthorisationCaseStateGenerator.java
+++ b/sdk/ccd-config-generator/src/main/java/uk/gov/hmcts/ccd/sdk/generator/AuthorisationCaseStateGenerator.java
@@ -28,27 +28,31 @@ class AuthorisationCaseStateGenerator<T, S, R extends HasRole> implements Config
   @SneakyThrows
   public void write(File root, ResolvedCCDConfig<T, S, R> config) {
 
-    for (Event<T, R, S> event : config.getEvents().values()) {
+    // When explicitStateGrants is set the case type opts out of deriving state permissions from
+    // event grants, so AuthorisationCaseState contains only the rows declared via grant(state,...).
+    if (!config.isExplicitStateGrants()) {
+      for (Event<T, R, S> event : config.getEvents().values()) {
 
-      SetMultimap<R, Permission> grants = event.getGrants();
-      for (R role : event.getGrants().keys()) {
-        // Don't add state access to history only roles
-        if (event.getHistoryOnlyRoles().contains(role.getRole())) {
-          continue;
-        }
-        // For state transitions if you have C then you get both states.
-        // Otherwise you only need permission for the destination state.
-        if (event.getPreState() != event.getPostState()) {
-          if (grants.get(role).contains(Permission.C) && !event.getPreState().isEmpty()) {
-            addPermissions(config.getStateRolePermissions(), event.getPreState(), role,
-                grants.get(role));
-            // They get R only on the destination state.
-            addPermissions(config.getStateRolePermissions(), event.getPostState(), role,
-                Collections.singleton(Permission.R));
+        SetMultimap<R, Permission> grants = event.getGrants();
+        for (R role : event.getGrants().keys()) {
+          // Don't add state access to history only roles
+          if (event.getHistoryOnlyRoles().contains(role.getRole())) {
+            continue;
           }
-        } else {
-          addPermissions(config.getStateRolePermissions(), event.getPostState(), role,
-              grants.get(role));
+          // For state transitions if you have C then you get both states.
+          // Otherwise you only need permission for the destination state.
+          if (event.getPreState() != event.getPostState()) {
+            if (grants.get(role).contains(Permission.C) && !event.getPreState().isEmpty()) {
+              addPermissions(config.getStateRolePermissions(), event.getPreState(), role,
+                  grants.get(role));
+              // They get R only on the destination state.
+              addPermissions(config.getStateRolePermissions(), event.getPostState(), role,
+                  Collections.singleton(Permission.R));
+            }
+          } else {
+            addPermissions(config.getStateRolePermissions(), event.getPostState(), role,
+                grants.get(role));
+          }
         }
       }
     }

--- a/sdk/ccd-config-generator/src/test/java/uk/gov/hmcts/ccd/sdk/E2EConfigGenerationTests.java
+++ b/sdk/ccd-config-generator/src/test/java/uk/gov/hmcts/ccd/sdk/E2EConfigGenerationTests.java
@@ -64,6 +64,14 @@ public class E2EConfigGenerationTests {
         CcdConfigComparator.assertEquals(expected, actual, JSONCompareMode.NON_EXTENSIBLE);
     }
 
+    @SneakyThrows
+    @Test
+    public void emitsOnlyExplicitStateGrants() {
+        File expected = resourceFile("ExplicitStateGrants/AuthorisationCaseState.json");
+        File actual = new File(tmp.getRoot(), "ExplicitStateGrants/AuthorisationCaseState.json");
+        CcdConfigComparator.assertEquals(expected, actual, JSONCompareMode.NON_EXTENSIBLE);
+    }
+
     @Test
     public void generatesDerivedConfig() {
         Map<String, File> actual = CcdConfigComparator.dirToMap(new File(tmp.getRoot(), "derived"));

--- a/sdk/ccd-config-generator/src/test/java/uk/gov/hmcts/ccd/sdk/SearchBuilderRoleTest.java
+++ b/sdk/ccd-config-generator/src/test/java/uk/gov/hmcts/ccd/sdk/SearchBuilderRoleTest.java
@@ -1,0 +1,58 @@
+package uk.gov.hmcts.ccd.sdk;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.hmcts.reform.fpl.enums.UserRole.HMCTS_ADMIN;
+import static uk.gov.hmcts.reform.fpl.enums.UserRole.LOCAL_AUTHORITY;
+
+import org.junit.Test;
+import uk.gov.hmcts.ccd.sdk.api.Search;
+import uk.gov.hmcts.ccd.sdk.api.Search.SearchBuilder;
+import uk.gov.hmcts.ccd.sdk.api.SearchField;
+import uk.gov.hmcts.reform.fpl.enums.UserRole;
+import uk.gov.hmcts.reform.fpl.model.CaseData;
+
+// Pins the fluent role-scoped SearchBuilder overloads used by the JSON -> Java converter to emit
+// WorkBasket/Search input & result rows carrying a UserRole (AccessProfile) column.
+public class SearchBuilderRoleTest {
+
+  private final PropertyUtils propertyUtils = new PropertyUtils();
+
+  @Test
+  public void rawFieldOverloadSetsUserRole() {
+    SearchBuilder<CaseData, UserRole> builder = SearchBuilder.builder(CaseData.class, propertyUtils);
+    builder.field("hearingDetails", "Hearing Details", LOCAL_AUTHORITY);
+
+    Search<CaseData, UserRole> search = builder.build();
+    SearchField<UserRole> field = search.getFields().get(0);
+
+    assertThat(field.getId()).isEqualTo("hearingDetails");
+    assertThat(field.getLabel()).isEqualTo("Hearing Details");
+    assertThat(field.getUserRole()).isEqualTo(LOCAL_AUTHORITY);
+    // Role-scoped: only visible to the scoped role.
+    assertThat(field.availableToRole(LOCAL_AUTHORITY.getRole())).isTrue();
+    assertThat(field.availableToRole(HMCTS_ADMIN.getRole())).isFalse();
+  }
+
+  @Test
+  public void getterOverloadSetsUserRole() {
+    SearchBuilder<CaseData, UserRole> builder = SearchBuilder.builder(CaseData.class, propertyUtils);
+    builder.field(CaseData::getCaseName, "Case name", HMCTS_ADMIN);
+
+    SearchField<UserRole> field = builder.build().getFields().get(0);
+
+    assertThat(field.getId()).isEqualTo("caseName");
+    assertThat(field.getUserRole()).isEqualTo(HMCTS_ADMIN);
+  }
+
+  @Test
+  public void unscopedFieldRemainsVisibleToAllRoles() {
+    SearchBuilder<CaseData, UserRole> builder = SearchBuilder.builder(CaseData.class, propertyUtils);
+    builder.field("caseName", "Case name");
+
+    SearchField<UserRole> field = builder.build().getFields().get(0);
+
+    assertThat(field.getUserRole()).isNull();
+    assertThat(field.availableToRole(LOCAL_AUTHORITY.getRole())).isTrue();
+    assertThat(field.availableToRole(HMCTS_ADMIN.getRole())).isTrue();
+  }
+}

--- a/sdk/ccd-config-generator/src/test/java/uk/gov/hmcts/reform/ExplicitState.java
+++ b/sdk/ccd-config-generator/src/test/java/uk/gov/hmcts/reform/ExplicitState.java
@@ -1,0 +1,10 @@
+package uk.gov.hmcts.reform;
+
+import uk.gov.hmcts.ccd.sdk.api.CCD;
+
+public enum ExplicitState {
+  @CCD(label = "Open state")
+  Open,
+  @CCD(label = "Submitted state")
+  Submitted
+}

--- a/sdk/ccd-config-generator/src/test/java/uk/gov/hmcts/reform/ExplicitStateGrantsCaseData.java
+++ b/sdk/ccd-config-generator/src/test/java/uk/gov/hmcts/reform/ExplicitStateGrantsCaseData.java
@@ -1,0 +1,9 @@
+package uk.gov.hmcts.reform;
+
+import uk.gov.hmcts.ccd.sdk.api.CCD;
+
+public class ExplicitStateGrantsCaseData {
+
+  @CCD(label = "A field")
+  private String aField;
+}

--- a/sdk/ccd-config-generator/src/test/java/uk/gov/hmcts/reform/ExplicitStateGrantsCaseType.java
+++ b/sdk/ccd-config-generator/src/test/java/uk/gov/hmcts/reform/ExplicitStateGrantsCaseType.java
@@ -1,0 +1,49 @@
+package uk.gov.hmcts.reform;
+
+import static uk.gov.hmcts.ccd.sdk.api.Permission.CRU;
+import static uk.gov.hmcts.ccd.sdk.api.Permission.R;
+import static uk.gov.hmcts.reform.ExplicitState.Open;
+import static uk.gov.hmcts.reform.ExplicitState.Submitted;
+import static uk.gov.hmcts.reform.fpl.enums.UserRole.HMCTS_ADMIN;
+import static uk.gov.hmcts.reform.fpl.enums.UserRole.LOCAL_AUTHORITY;
+
+import java.util.Set;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.ccd.sdk.api.CCDConfig;
+import uk.gov.hmcts.ccd.sdk.api.ConfigBuilder;
+import uk.gov.hmcts.reform.fpl.enums.UserRole;
+
+/**
+ * Exercises {@link ConfigBuilder#explicitStateGrants()}. The events below grant broad permissions
+ * that would normally be derived onto their states, but because the builder opts into explicit
+ * state grants only the narrow {@link ConfigBuilder#grant} rows below are emitted.
+ */
+@Component
+public class ExplicitStateGrantsCaseType
+    implements CCDConfig<ExplicitStateGrantsCaseData, ExplicitState, UserRole> {
+
+  @Override
+  public void configure(ConfigBuilder<ExplicitStateGrantsCaseData, ExplicitState, UserRole> builder) {
+    builder.caseType("ExplicitStateGrants", "ExplicitStateGrants", "Explicit state grants case type");
+    builder.explicitStateGrants();
+
+    // These event grants would derive broad AuthorisationCaseState permissions if derivation were
+    // enabled: CRU for both roles on the destination state, plus the C-granting transition would
+    // additionally grant CRU on the Open pre-state and R on the Submitted post-state.
+    builder.event("create")
+        .forStateTransition(Open, Submitted)
+        .name("Create")
+        .grant(CRU, HMCTS_ADMIN)
+        .grant(CRU, LOCAL_AUTHORITY);
+
+    builder.event("edit")
+        .forState(Submitted)
+        .name("Edit")
+        .grant(CRU, HMCTS_ADMIN)
+        .grant(CRU, LOCAL_AUTHORITY);
+
+    // Only these narrow explicit rows should appear in AuthorisationCaseState.
+    builder.grant(Open, Set.of(R), LOCAL_AUTHORITY);
+    builder.grant(Submitted, Set.of(R), HMCTS_ADMIN);
+  }
+}

--- a/sdk/ccd-config-generator/src/test/resources/ExplicitStateGrants/AuthorisationCaseState.json
+++ b/sdk/ccd-config-generator/src/test/resources/ExplicitStateGrants/AuthorisationCaseState.json
@@ -1,0 +1,16 @@
+[
+  {
+    "CRUD" : "R",
+    "CaseStateID" : "Open",
+    "CaseTypeID" : "ExplicitStateGrants",
+    "LiveFrom" : "01/01/2017",
+    "UserRole" : "caseworker-publiclaw-solicitor"
+  },
+  {
+    "CRUD" : "R",
+    "CaseStateID" : "Submitted",
+    "CaseTypeID" : "ExplicitStateGrants",
+    "LiveFrom" : "01/01/2017",
+    "UserRole" : "caseworker-publiclaw-courtadmin"
+  }
+]


### PR DESCRIPTION
Adds two additive, default-off `ConfigBuilder` capabilities aimed at services migrating from hand-written CCD definitions:

- **`explicitStateGrants()`** — opts a case type out of deriving `AuthorisationCaseState` rows from event grants, so the generated state permissions are exactly the `grant(state, permissions, roles)` rows the case type declares. Needed for services whose existing definitions deliberately keep state access narrower than event-grant derivation would produce.
- **Role-scoped `SearchBuilder.field(..., role)` overloads** — let a workbasket/search field carry a `UserRole` (AccessProfile) column so it is only visible to that role, matching how hand-written definition sheets scope individual rows. Add one call per role to expose a field to several roles.

Both are opt-in; behaviour without them is unchanged and all existing golden snapshots are unaffected. Covered by a new `ExplicitStateGrants` end-to-end snapshot case type and `SearchBuilderRoleTest`.
