### PR TITLE
Fix external callbacks through Application Gateway

### DIFF
--- a/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/impl/json/JsonCallbackBridge.java
+++ b/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/impl/json/JsonCallbackBridge.java
@@ -74,7 +74,10 @@ public class JsonCallbackBridge {
     this.requestMapper = mapper.copy()
         .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
         .setSerializationInclusion(JsonInclude.Include.ALWAYS);
-    this.httpClient = HttpClient.newHttpClient();
+    // Application Gateway rejects the h2c upgrade attempted by the default client for HTTP URLs.
+    this.httpClient = HttpClient.newBuilder()
+        .version(HttpClient.Version.HTTP_1_1)
+        .build();
     this.routes = indexPostRoutes(handlerMapping);
     this.localCallbackPlaceholder = normalisePlaceholderName(
         environment.getProperty(LOCAL_CALLBACK_PLACEHOLDER, "")


### PR DESCRIPTION
External JSON callbacks now use HTTP/1.1 explicitly. The JDK client otherwise prefers HTTP/2 and attempts a clear-text h2c upgrade for internal HTTP service URLs, which Azure Application Gateway rejects with 403 before routing the request to the service. This prevented ET's submitted Notice of Change callback from reaching AAC.