### PR TITLE
Add incremental migration validation

### DIFF
--- a/docs/ccd-data-migration-task.md
+++ b/docs/ccd-data-migration-task.md
@@ -54,14 +54,21 @@ Validation is also resumable. The task records the highest local `case_event.id`
 walks local target rows to choose the next range end, then compares only that range with source CCD,
 so cutover does not need to repeat a full source count for all historical significant items.
 
-Source event high-water marks are selected from the configured jurisdiction/case types. The task
-finds the first matching source event inside `sourceEventSafetyWindow`, which defaults to two
-minutes, and will not advance the source event high-water mark beyond the row before it. This keeps
-preload and incremental validation away from rows that may still have related source writes in
-flight, even if a higher event ID is already old enough to copy. If a newly calculated safe event or
-significant-item high-water mark is lower than stored progress, the task fails rather than treating
-the run as caught up; that indicates source rows became visible after progress had already advanced
-and must be investigated before retrying.
+Source event and significant-item high-water marks stay in the same global CCD ID coordinate used by
+older task versions, so existing checkpoints can be resumed without resetting progress. To avoid
+unbounded source scans, the event high-water mark is selected by walking only the most recent global
+source events in descending ID order. If that bounded recent set contains rows inside
+`sourceEventSafetyWindow`, which defaults to two minutes, the task only advances to the row before
+the first fresh event. If the whole bounded recent set is still inside the safety window, progress is
+not advanced on that run. If a newly calculated safe event or significant-item high-water mark is
+lower than stored progress, the task fails rather than treating the run as caught up; that indicates
+source rows became visible after progress had already advanced and must be investigated before
+retrying.
+
+If source events appear after a `CUTOVER` high-water mark has been captured but before the final
+refresh, the task releases the captured high-water mark, returns the progress row to `PRELOAD`, and
+returns `caughtUp=false`. The next cutover attempt can then wait for the safety window and capture a
+new high-water mark instead of being stuck on the stale one.
 
 The runtime `case_data` revision trigger is deliberately disabled only inside the cutover refresh
 transaction so the final source-derived revision can be written. The trigger is re-enabled before the

--- a/docs/ccd-data-migration-task.md
+++ b/docs/ccd-data-migration-task.md
@@ -17,15 +17,19 @@ writes for the selected case types have been frozen.
 The task has one implementation with explicit modes:
 
 * `PRELOAD_EVENTS`: scheduled before cutover. Copies immutable source events by event ID high-water
-  mark and inserts provisional parent `case_data` rows so the target FK remains valid.
+  mark, inserts provisional parent `case_data` rows so the target FK remains valid, copies linked
+  significant items for copied events, and advances range-based validation checkpoints.
 * `CUTOVER`: explicit operator action during downtime. Captures the cutover event high-water mark,
-  copies the final event delta, copies linked `case_event_significant_items` in a single set-based
-  query, refreshes target `case_data` from source, sets final case revisions, resets sequences,
-  validates, and marks the migration complete.
+  copies the final event and significant-item delta, refreshes target `case_data` from source, sets
+  final case revisions, resets sequences, validates any remaining unvalidated local ranges, and
+  marks the migration complete.
 * `VALIDATE_ONLY`: runs final source-vs-target validation without copying data.
 
 Do not switch to `CUTOVER` automatically from a scheduler. The operator must first freeze source
-writes for the selected case types and wait for in-flight source transactions to drain.
+writes for the selected case types and wait for in-flight source transactions to drain. By default
+the task only targets a contiguous source event ID range before the first event inside the two-minute
+safety window. If `CUTOVER` sees source events inside that safety window before capturing its
+high-water mark, it leaves the migration in its current state and returns without the final refresh.
 
 ## Safety Model
 
@@ -40,10 +44,24 @@ The preload path keeps the target tables constraint-valid after every committed 
 
 Preloaded `case_data` is provisional. Its purpose is to satisfy the event FK. Every copied event
 batch inserts missing parent source `case_data` rows for that batch. Significant items are copied
-only during `CUTOVER`, using one `insert into ... select` query that reads source significant items
-and joins through already migrated target events up to the captured cutover event high-water mark.
-`CUTOVER` then overwrites target `case_data` columns from source and sets
+after event preload batches and during `CUTOVER`, using resumable ID windows that read source
+significant items and join through already migrated target events up to the current event high-water
+mark. `CUTOVER` then overwrites target `case_data` columns from source and sets
 `case_data.case_revision = max(case_event.case_revision) + caseRevisionOffset`.
+
+Validation is also resumable. The task records the highest local `case_event.id` and
+`case_event_significant_items.id` ranges whose source and target counts have matched. Validation
+walks local target rows to choose the next range end, then compares only that range with source CCD,
+so cutover does not need to repeat a full source count for all historical significant items.
+
+Source event high-water marks are selected from the configured jurisdiction/case types. The task
+finds the first matching source event inside `sourceEventSafetyWindow`, which defaults to two
+minutes, and will not advance the source event high-water mark beyond the row before it. This keeps
+preload and incremental validation away from rows that may still have related source writes in
+flight, even if a higher event ID is already old enough to copy. If a newly calculated safe event or
+significant-item high-water mark is lower than stored progress, the task fails rather than treating
+the run as caught up; that indicates source rows became visible after progress had already advanced
+and must be investigated before retrying.
 
 The runtime `case_data` revision trigger is deliberately disabled only inside the cutover refresh
 transaction so the final source-derived revision can be written. The trigger is re-enabled before the
@@ -66,10 +84,14 @@ state:
 * `status`: `PRELOAD`, `CUTOVER`, or `COMPLETE`
 * `cutover_event_hwm`
 * `source_event_hwm`
+* `significant_items_hwm`
+* `validated_event_hwm`
+* `validated_significant_items_hwm`
 * timestamps
 
 The migration configuration hash covers the migration identity. Runtime limits such as
-`eventIdWindowSize`, `significantItemIdWindowSize`, `maxBatchesPerRun`, `maxRunTime`, and `mode` can change between invocations.
+`eventIdWindowSize`, `significantItemIdWindowSize`, `maxBatchesPerRun`, `maxRunTime`,
+`sourceEventSafetyWindow`, and `mode` can change between invocations.
 If the migration identity changes after a task has already created a progress row, the task fails
 fast rather than resuming under different source filters. Operators must either keep the same
 identity configuration or explicitly reset/use a new `task-name` after confirming the target state.
@@ -92,9 +114,14 @@ ccd:
     significant-item-id-window-size: 100000
     max-batches-per-run: 100
     max-run-time: 4h
+    source-event-safety-window: 2m
     case-revision-offset: 1000000000
     fdw-additional-select-grantee: DTS JIT Access et DB Reader SC
 ```
+
+`max-batches-per-run` is a run-level budget shared by event copy, significant-item copy, event
+validation, and significant-item validation. If the budget is exhausted before all phases catch up,
+the task returns `caughtUp=false` and resumes from the stored high-water marks on the next run.
 
 `fdw-additional-select-grantee` is optional. When set, the Java task grants the role local access to
 query the existing FDW tables after validating them: `USAGE` on the FDW staging schema, `USAGE` on
@@ -167,9 +194,9 @@ period. Run `CUTOVER` explicitly during the agreed downtime window.
 
 ## Validation
 
-After cutover, the task logs final `case_data`, `case_event`, and `case_event_significant_items`
-counts for the selected case types. It also compares source and target significant-item counts up to
-the captured cutover event high-water mark.
+After cutover, the task logs final target `case_data`, `case_event`, and
+`case_event_significant_items` counts for the selected case types. Source/target validation is
+performed incrementally in ID windows and only unvalidated ranges are checked during cutover.
 
 ## Performance Harness
 

--- a/docs/fdw-data-migration.md
+++ b/docs/fdw-data-migration.md
@@ -158,9 +158,10 @@ the FDW server; create it during setup with `FDW_ADDITIONAL_GRANTEE` or have Pla
 create it manually. The Java task does not create user mappings because they contain source database
 credentials. Leave it blank to skip the extra grant.
 
-For services using the Java task, `case_event_significant_items` is copied during `CUTOVER` after
-events have caught up. It uses one set-based insert query joined through the migrated target events
-up to the captured cutover event high-water mark, so the preload event walk is not restarted.
+For services using the Java task, `case_event_significant_items` is copied during preload and again
+during `CUTOVER` for the final delta. It uses resumable ID windows joined through migrated target
+events, and validation advances separate event and significant-item checkpoints so cutover only
+checks ranges that have not already been validated.
 
 Required environment variables:
 

--- a/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationProperties.java
+++ b/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationProperties.java
@@ -20,6 +20,7 @@ public class CcdDataMigrationProperties {
   private int maxBatchesPerRun = Integer.MAX_VALUE;
   private Duration maxRunTime;
   private Duration statementTimeout = Duration.ofMinutes(10);
+  private Duration sourceEventSafetyWindow = Duration.ofMinutes(2);
   private String sourceJurisdiction;
   private String fdwAdditionalSelectGrantee;
 
@@ -40,6 +41,7 @@ public class CcdDataMigrationProperties {
         .maxBatchesPerRun(maxBatchesPerRun)
         .maxRunTime(maxRunTime)
         .statementTimeout(statementTimeout)
+        .sourceEventSafetyWindow(sourceEventSafetyWindow)
         .sourceJurisdiction(sourceJurisdiction)
         .fdwAdditionalSelectGrantee(fdwAdditionalSelectGrantee)
         .build();

--- a/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTask.java
+++ b/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTask.java
@@ -106,14 +106,15 @@ public class CcdDataMigrationTask implements Runnable {
   public final CcdDataMigrationRunResult runMigration() {
     log.info(
         "Starting CCD data migration task taskName={} mode={} caseTypeIds={} eventIdWindowSize={} "
-            + "significantItemIdWindowSize={} maxBatchesPerRun={} maxRunTime={}",
+            + "significantItemIdWindowSize={} maxBatchesPerRun={} maxRunTime={} sourceEventSafetyWindow={}",
         options.taskName(),
         options.mode(),
         options.caseTypeIds(),
         options.eventIdWindowSize(),
         options.significantItemIdWindowSize(),
         options.maxBatchesPerRun(),
-        options.maxRunTime()
+        options.maxRunTime(),
+        options.sourceEventSafetyWindow()
     );
 
     validateDecentralisedRuntimeDisabled();
@@ -153,27 +154,47 @@ public class CcdDataMigrationTask implements Runnable {
 
     prepareElasticsearchQueueForMigration();
     long targetEventHwm = sourceEventHighWaterMark();
-    CopyTotals totals = copyEventBatches(targetEventHwm, calculateStopAt());
+    validateSourceEventHighWaterMarkHasNotRegressed(targetEventHwm);
+    LocalDateTime stopAt = calculateStopAt();
+    BatchBudget batchBudget = new BatchBudget(options.maxBatchesPerRun());
+    CopyTotals totals = copyEventBatches(targetEventHwm, stopAt, batchBudget);
     long sourceEventHwm = sourceEventProgressHighWaterMark();
-    boolean caughtUp = sourceEventHwm >= targetEventHwm;
+    SignificantItemCopyTotals significantItemTotals = copySignificantItemBatches(sourceEventHwm, stopAt, batchBudget);
+    ValidationTotals eventValidationTotals = validateEventBatches(localEventHighWaterMark(), stopAt, batchBudget);
+    ValidationTotals significantItemValidationTotals = validateSignificantItemBatches(stopAt, batchBudget);
+    boolean caughtUp = sourceEventHwm >= targetEventHwm
+        && significantItemTotals.caughtUp()
+        && eventValidationTotals.caughtUp()
+        && significantItemValidationTotals.caughtUp();
     log.info(
         "Completed CCD data migration preload taskName={} targetEventHwm={} batches={} cases={} events={} "
-            + "caughtUp={} stoppedByTimeLimit={}",
+            + "significantItems={} significantItemBatches={} validatedEventBatches={} "
+            + "validatedSignificantItemBatches={} caughtUp={} stoppedByTimeLimit={}",
         options.taskName(),
         targetEventHwm,
-        totals.batches(),
+        batchBudget.consumed(),
         0,
         totals.events(),
+        significantItemTotals.items(),
+        significantItemTotals.batches(),
+        eventValidationTotals.batches(),
+        significantItemValidationTotals.batches(),
         caughtUp,
         totals.stoppedByTimeLimit()
+            || significantItemTotals.stoppedByTimeLimit()
+            || eventValidationTotals.stoppedByTimeLimit()
+            || significantItemValidationTotals.stoppedByTimeLimit()
     );
     return new CcdDataMigrationRunResult(
         true,
-        totals.batches(),
+        batchBudget.consumed(),
         0,
         totals.events(),
         caughtUp,
         totals.stoppedByTimeLimit()
+            || significantItemTotals.stoppedByTimeLimit()
+            || eventValidationTotals.stoppedByTimeLimit()
+            || significantItemValidationTotals.stoppedByTimeLimit()
     );
   }
 
@@ -183,12 +204,24 @@ public class CcdDataMigrationTask implements Runnable {
       prepareCompleteProgressForNextCutover(progress.requiredCutoverEventHwm());
     }
 
+    if (progress.cutoverEventHwm() == null || STATUS_COMPLETE.equals(progress.status())) {
+      validateSourceEventHighWaterMarkHasNotRegressed(sourceEventHighWaterMark());
+      if (sourceHasFreshEvents()) {
+        log.info(
+            "CCD data migration cutover paused before capturing high-water mark taskName={} because source events "
+                + "inside safety window still exist",
+            options.taskName()
+        );
+        return new CcdDataMigrationRunResult(true, 0, 0, 0, false, false);
+      }
+    }
     prepareElasticsearchQueueForMigration();
     long cutoverEventHwm = progress.cutoverEventHwm() == null || STATUS_COMPLETE.equals(progress.status())
         ? captureCutoverEventHighWaterMark()
         : progress.cutoverEventHwm();
     LocalDateTime stopAt = calculateStopAt();
-    CopyTotals totals = copyEventBatches(cutoverEventHwm, stopAt);
+    BatchBudget batchBudget = new BatchBudget(options.maxBatchesPerRun());
+    CopyTotals totals = copyEventBatches(cutoverEventHwm, stopAt, batchBudget);
     long sourceEventHwm = sourceEventProgressHighWaterMark();
     if (totals.stoppedByTimeLimit() || sourceEventHwm < cutoverEventHwm) {
       log.info(
@@ -197,20 +230,20 @@ public class CcdDataMigrationTask implements Runnable {
           options.taskName(),
           cutoverEventHwm,
           sourceEventHwm,
-          totals.batches(),
+          batchBudget.consumed(),
           totals.events(),
           totals.stoppedByTimeLimit()
       );
       return new CcdDataMigrationRunResult(
           true,
-          totals.batches(),
+          batchBudget.consumed(),
           0,
           totals.events(),
           false,
           totals.stoppedByTimeLimit()
       );
     }
-    SignificantItemCopyTotals significantItemTotals = copySignificantItemBatches(cutoverEventHwm, stopAt);
+    SignificantItemCopyTotals significantItemTotals = copySignificantItemBatches(cutoverEventHwm, stopAt, batchBudget);
     if (!significantItemTotals.caughtUp()) {
       log.info(
           "CCD data migration cutover paused before final refresh taskName={} cutoverEventHwm={} "
@@ -223,23 +256,45 @@ public class CcdDataMigrationTask implements Runnable {
       );
       return new CcdDataMigrationRunResult(
           true,
-          totals.batches(),
+          batchBudget.consumed(),
           0,
           totals.events(),
           false,
           significantItemTotals.stoppedByTimeLimit()
       );
     }
+    ValidationTotals eventValidationTotals = validateEventBatches(localEventHighWaterMark(), stopAt, batchBudget);
+    ValidationTotals significantItemValidationTotals = validateSignificantItemBatches(stopAt, batchBudget);
+    if (!eventValidationTotals.caughtUp() || !significantItemValidationTotals.caughtUp()) {
+      log.info(
+          "CCD data migration cutover paused before final refresh taskName={} cutoverEventHwm={} "
+              + "validatedEventBatches={} validatedSignificantItemBatches={} stoppedByTimeLimit={}",
+          options.taskName(),
+          cutoverEventHwm,
+          eventValidationTotals.batches(),
+          significantItemValidationTotals.batches(),
+          eventValidationTotals.stoppedByTimeLimit() || significantItemValidationTotals.stoppedByTimeLimit()
+      );
+      return new CcdDataMigrationRunResult(
+          true,
+          batchBudget.consumed(),
+          0,
+          totals.events(),
+          false,
+          eventValidationTotals.stoppedByTimeLimit() || significantItemValidationTotals.stoppedByTimeLimit()
+      );
+    }
+    validateSourceDidNotAdvanceAfterCutoverHighWaterMark(cutoverEventHwm);
     final int refreshedCases = refreshCutoverCaseData();
     resetSequences();
-    completeCutover(cutoverEventHwm);
+    completeCutover(cutoverEventHwm, stopAt);
 
     log.info(
         "Completed CCD data migration cutover taskName={} cutoverEventHwm={} batches={} refreshedCases={} events={} "
             + "significantItems={} significantItemBatches={} stoppedByTimeLimit={}",
         options.taskName(),
         cutoverEventHwm,
-        totals.batches(),
+        batchBudget.consumed(),
         refreshedCases,
         totals.events(),
         significantItemTotals.items(),
@@ -248,7 +303,7 @@ public class CcdDataMigrationTask implements Runnable {
     );
     return new CcdDataMigrationRunResult(
         true,
-        totals.batches(),
+        batchBudget.consumed(),
         refreshedCases,
         totals.events(),
         !totals.stoppedByTimeLimit(),
@@ -261,14 +316,16 @@ public class CcdDataMigrationTask implements Runnable {
     long validationEventHwm = progress.cutoverEventHwm() == null
         ? sourceEventHighWaterMark()
         : progress.cutoverEventHwm();
-    validateFinal(validationEventHwm);
-    return new CcdDataMigrationRunResult(true, 0, 0, 0, true, false);
+    validateSourceEventHighWaterMarkHasNotRegressed(validationEventHwm);
+    BatchBudget batchBudget = new BatchBudget(options.maxBatchesPerRun());
+    validateFinal(validationEventHwm, calculateStopAt(), batchBudget);
+    return new CcdDataMigrationRunResult(true, batchBudget.consumed(), 0, 0, true, false);
   }
 
-  private CopyTotals copyEventBatches(long targetEventHwm, LocalDateTime stopAt) {
+  private CopyTotals copyEventBatches(long targetEventHwm, LocalDateTime stopAt, BatchBudget batchBudget) {
     var totals = new CopyTotals();
 
-    for (int i = 0; i < options.maxBatchesPerRun(); i++) {
+    while (batchBudget.hasRemaining()) {
       long sourceEventHwm = effectiveSourceEventHighWaterMark(targetEventHwm);
       if (sourceEventHwm >= targetEventHwm) {
         totals = totals.markCaughtUp();
@@ -283,6 +340,7 @@ public class CcdDataMigrationTask implements Runnable {
         updateSourceEventProgressHighWaterMark(batchEndEventHwm);
         return copiedEvents;
       });
+      batchBudget.consume();
       totals = totals.plus(events);
       log.info(
           "CCD data migration progress taskName={} mode={} sourceEventHwm={} targetEventHwm={} "
@@ -435,14 +493,18 @@ public class CcdDataMigrationTask implements Runnable {
     );
   }
 
-  private SignificantItemCopyTotals copySignificantItemBatches(long cutoverEventHwm, LocalDateTime stopAt) {
+  private SignificantItemCopyTotals copySignificantItemBatches(
+      long cutoverEventHwm,
+      LocalDateTime stopAt,
+      BatchBudget batchBudget
+  ) {
     long targetSignificantItemsHwm = sourceSignificantItemsHighWaterMark(cutoverEventHwm);
+    validateSignificantItemsHighWaterMarkHasNotRegressed(targetSignificantItemsHwm);
     var totals = new SignificantItemCopyTotals();
 
-    for (int i = 0; i < options.maxBatchesPerRun(); i++) {
+    while (batchBudget.hasRemaining()) {
       long significantItemsHwm = significantItemsProgressHighWaterMark();
       if (significantItemsHwm >= targetSignificantItemsHwm) {
-        validateSignificantItemCounts(cutoverEventHwm);
         return totals.markCaughtUp();
       }
       if (isTimeLimitReached(stopAt)) {
@@ -456,6 +518,7 @@ public class CcdDataMigrationTask implements Runnable {
         updateSignificantItemsProgressHighWaterMark(batchEndItemHwm);
         return copied;
       });
+      batchBudget.consume();
       totals = totals.plus(copiedItems);
       log.info(
           "CCD data migration significant item progress taskName={} cutoverEventHwm={} "
@@ -473,10 +536,241 @@ public class CcdDataMigrationTask implements Runnable {
       }
     }
     if (significantItemsProgressHighWaterMark() >= targetSignificantItemsHwm) {
-      validateSignificantItemCounts(cutoverEventHwm);
       return totals.markCaughtUp();
     }
     return totals;
+  }
+
+  private ValidationTotals validateEventBatches(
+      long targetEventHwm,
+      LocalDateTime stopAt,
+      BatchBudget batchBudget
+  ) {
+    var totals = new ValidationTotals();
+    while (batchBudget.hasRemaining()) {
+      long validatedEventHwm = validatedEventHighWaterMark();
+      if (validatedEventHwm >= targetEventHwm) {
+        return totals.markCaughtUp();
+      }
+      if (isTimeLimitReached(stopAt)) {
+        return totals.markStoppedByTimeLimit();
+      }
+
+      long batchEndEventHwm = nextLocalEventValidationHighWaterMark(validatedEventHwm, targetEventHwm);
+      if (batchEndEventHwm <= validatedEventHwm) {
+        updateValidatedEventHighWaterMark(targetEventHwm);
+        return totals.markCaughtUp();
+      }
+      validateEventCounts(validatedEventHwm, batchEndEventHwm);
+      updateValidatedEventHighWaterMark(batchEndEventHwm);
+      batchBudget.consume();
+      totals = totals.plus();
+      log.info(
+          "CCD data migration event validation progress taskName={} batchStartEventId={} batchEndEventHwm={} "
+              + "totalBatches={}",
+          options.taskName(),
+          validatedEventHwm + 1L,
+          batchEndEventHwm,
+          totals.batches()
+      );
+    }
+    return validatedEventHighWaterMark() >= targetEventHwm ? totals.markCaughtUp() : totals;
+  }
+
+  private long nextLocalEventValidationHighWaterMark(long validatedEventHwm, long targetEventHwm) {
+    Long hwm = db.queryForObject(
+        """
+        select coalesce(max(id), :validatedEventHwm)
+        from (
+          select ce.id
+          from ccd.case_event ce
+          join ccd.case_data cd on cd.id = ce.case_data_id
+          where cd.jurisdiction = :sourceJurisdiction
+            and cd.case_type_id in (:caseTypeIds)
+            and ce.case_type_id in (:caseTypeIds)
+            and ce.id > :validatedEventHwm
+            and ce.id <= :targetEventHwm
+          order by ce.id
+          limit :validationBatchSize
+        ) local_events
+        """,
+        baseParams()
+            .addValue("validatedEventHwm", validatedEventHwm)
+            .addValue("targetEventHwm", targetEventHwm)
+            .addValue("validationBatchSize", options.eventIdWindowSize()),
+        Long.class
+    );
+    return hwm == null ? validatedEventHwm : hwm;
+  }
+
+  private void validateEventCounts(long fromExclusiveEventHwm, long toInclusiveEventHwm) {
+    MapSqlParameterSource params = baseParams()
+        .addValue("fromExclusiveEventHwm", fromExclusiveEventHwm)
+        .addValue("toInclusiveEventHwm", toInclusiveEventHwm);
+    Long sourceCount = withMigrationStatementTimeout(() -> db.queryForObject(
+        """
+        select count(*)
+        from fdw_stage.case_event ce
+        join fdw_stage.case_data cd on cd.id = ce.case_data_id
+        where cd.jurisdiction = :sourceJurisdiction
+          and cd.case_type_id in (:caseTypeIds)
+          and ce.case_type_id in (:caseTypeIds)
+          and ce.id > :fromExclusiveEventHwm
+          and ce.id <= :toInclusiveEventHwm
+        """,
+        params,
+        Long.class
+    ));
+    Long targetCount = db.queryForObject(
+        """
+        select count(*)
+        from ccd.case_event ce
+        join ccd.case_data cd on cd.id = ce.case_data_id
+        where cd.jurisdiction = :sourceJurisdiction
+          and cd.case_type_id in (:caseTypeIds)
+          and ce.case_type_id in (:caseTypeIds)
+          and ce.id > :fromExclusiveEventHwm
+          and ce.id <= :toInclusiveEventHwm
+        """,
+        params,
+        Long.class
+    );
+
+    long sourceRows = sourceCount == null ? 0 : sourceCount;
+    long targetRows = targetCount == null ? 0 : targetCount;
+    if (sourceRows != targetRows) {
+      throw new CcdDataMigrationException(
+          "CCD data migration event count mismatch source=" + sourceRows
+              + " target=" + targetRows
+              + " fromExclusiveEventHwm=" + fromExclusiveEventHwm
+              + " toInclusiveEventHwm=" + toInclusiveEventHwm
+      );
+    }
+  }
+
+  private ValidationTotals validateSignificantItemBatches(LocalDateTime stopAt, BatchBudget batchBudget) {
+    long targetSignificantItemsHwm = localSignificantItemsHighWaterMark(validatedEventHighWaterMark());
+    var totals = new ValidationTotals();
+    while (batchBudget.hasRemaining()) {
+      long validatedSignificantItemsHwm = validatedSignificantItemsHighWaterMark();
+      if (validatedSignificantItemsHwm >= targetSignificantItemsHwm) {
+        return totals.markCaughtUp();
+      }
+      if (isTimeLimitReached(stopAt)) {
+        return totals.markStoppedByTimeLimit();
+      }
+
+      long batchEndItemHwm = nextLocalSignificantItemValidationHighWaterMark(
+          validatedSignificantItemsHwm,
+          targetSignificantItemsHwm,
+          validatedEventHighWaterMark()
+      );
+      if (batchEndItemHwm <= validatedSignificantItemsHwm) {
+        updateValidatedSignificantItemsHighWaterMark(targetSignificantItemsHwm);
+        return totals.markCaughtUp();
+      }
+      validateSignificantItemCounts(validatedSignificantItemsHwm, batchEndItemHwm, validatedEventHighWaterMark());
+      updateValidatedSignificantItemsHighWaterMark(batchEndItemHwm);
+      batchBudget.consume();
+      totals = totals.plus();
+      log.info(
+          "CCD data migration significant item validation progress taskName={} batchStartItemId={} "
+              + "batchEndItemHwm={} totalBatches={}",
+          options.taskName(),
+          validatedSignificantItemsHwm + 1L,
+          batchEndItemHwm,
+          totals.batches()
+      );
+    }
+    return validatedSignificantItemsHighWaterMark() >= targetSignificantItemsHwm ? totals.markCaughtUp() : totals;
+  }
+
+  private long nextLocalSignificantItemValidationHighWaterMark(
+      long validatedSignificantItemsHwm,
+      long targetSignificantItemsHwm,
+      long eventHwm
+  ) {
+    Long hwm = db.queryForObject(
+        """
+        select coalesce(max(id), :validatedSignificantItemsHwm)
+        from (
+          select item.id
+          from ccd.case_event_significant_items item
+          join ccd.case_event ce on ce.id = item.case_event_id
+          join ccd.case_data cd on cd.id = ce.case_data_id
+          where cd.jurisdiction = :sourceJurisdiction
+            and cd.case_type_id in (:caseTypeIds)
+            and ce.case_type_id in (:caseTypeIds)
+            and ce.id <= :eventHwm
+            and item.id > :validatedSignificantItemsHwm
+            and item.id <= :targetSignificantItemsHwm
+          order by item.id
+          limit :validationBatchSize
+        ) local_items
+        """,
+        baseParams()
+            .addValue("validatedSignificantItemsHwm", validatedSignificantItemsHwm)
+            .addValue("targetSignificantItemsHwm", targetSignificantItemsHwm)
+            .addValue("eventHwm", eventHwm)
+            .addValue("validationBatchSize", options.significantItemIdWindowSize()),
+        Long.class
+    );
+    return hwm == null ? validatedSignificantItemsHwm : hwm;
+  }
+
+  private void validateSignificantItemCounts(
+      long fromExclusiveSignificantItemsHwm,
+      long toInclusiveSignificantItemsHwm,
+      long eventHwm
+  ) {
+    MapSqlParameterSource params = baseParams()
+        .addValue("fromExclusiveSignificantItemsHwm", fromExclusiveSignificantItemsHwm)
+        .addValue("toInclusiveSignificantItemsHwm", toInclusiveSignificantItemsHwm)
+        .addValue("eventHwm", eventHwm);
+    Long sourceCount = withMigrationStatementTimeout(() -> db.queryForObject(
+        """
+        select count(*)
+        from fdw_stage.case_event_significant_items item
+        join fdw_stage.case_event ce on ce.id = item.case_event_id
+        join fdw_stage.case_data cd on cd.id = ce.case_data_id
+        where cd.jurisdiction = :sourceJurisdiction
+          and cd.case_type_id in (:caseTypeIds)
+          and ce.case_type_id in (:caseTypeIds)
+          and ce.id <= :eventHwm
+          and item.id > :fromExclusiveSignificantItemsHwm
+          and item.id <= :toInclusiveSignificantItemsHwm
+        """,
+        params,
+        Long.class
+    ));
+    Long targetCount = db.queryForObject(
+        """
+        select count(*)
+        from ccd.case_event_significant_items item
+        join ccd.case_event ce on ce.id = item.case_event_id
+        join ccd.case_data cd on cd.id = ce.case_data_id
+        where cd.jurisdiction = :sourceJurisdiction
+          and cd.case_type_id in (:caseTypeIds)
+          and ce.case_type_id in (:caseTypeIds)
+          and ce.id <= :eventHwm
+          and item.id > :fromExclusiveSignificantItemsHwm
+          and item.id <= :toInclusiveSignificantItemsHwm
+        """,
+        params,
+        Long.class
+    );
+
+    long sourceRows = sourceCount == null ? 0 : sourceCount;
+    long targetRows = targetCount == null ? 0 : targetCount;
+    if (sourceRows != targetRows) {
+      throw new CcdDataMigrationException(
+          "CCD data migration significant item count mismatch source=" + sourceRows
+              + " target=" + targetRows
+              + " fromExclusiveSignificantItemsHwm=" + fromExclusiveSignificantItemsHwm
+              + " toInclusiveSignificantItemsHwm=" + toInclusiveSignificantItemsHwm
+              + " eventHwm=" + eventHwm
+      );
+    }
   }
 
   private int copySignificantItemBatch(
@@ -505,6 +799,7 @@ public class CcdDataMigrationTask implements Runnable {
         join ccd.case_event target_event on target_event.id = item.case_event_id
         where cd.jurisdiction = :sourceJurisdiction
           and cd.case_type_id in (:caseTypeIds)
+          and ce.case_type_id in (:caseTypeIds)
           and ce.id <= :cutoverEventHwm
           and item.id > :significantItemsHwm
           and item.id <= :targetSignificantItemsHwm
@@ -606,17 +901,84 @@ public class CcdDataMigrationTask implements Runnable {
   }
 
   private long sourceEventHighWaterMark() {
+    LocalDateTime sourceEventCreatedBefore = sourceEventCreatedBefore();
     return withMigrationStatementTimeout(() -> {
       Long hwm = db.queryForObject(
           """
-          select coalesce(max(id), 0)
-          from fdw_stage.case_event
+          select coalesce(
+                   case
+                     when min(ce.id) filter (where ce.created_date >= :sourceEventCreatedBefore) is null then
+                       max(ce.id)
+                     else
+                       least(
+                         coalesce(max(ce.id), 0),
+                         min(ce.id) filter (where ce.created_date >= :sourceEventCreatedBefore) - 1
+                       )
+                   end,
+                   0
+                 )
+          from fdw_stage.case_event ce
+          join fdw_stage.case_data cd on cd.id = ce.case_data_id
+          where cd.jurisdiction = :sourceJurisdiction
+            and cd.case_type_id in (:caseTypeIds)
+            and ce.case_type_id in (:caseTypeIds)
           """,
-          baseParams(),
+          baseParams().addValue("sourceEventCreatedBefore", sourceEventCreatedBefore),
           Long.class
       );
       return hwm == null ? 0 : hwm;
     });
+  }
+
+  private boolean sourceHasFreshEvents() {
+    LocalDateTime sourceEventCreatedBefore = sourceEventCreatedBefore();
+    Boolean exists = withMigrationStatementTimeout(() -> db.queryForObject(
+        """
+        select exists (
+          select 1
+          from fdw_stage.case_event ce
+          join fdw_stage.case_data cd on cd.id = ce.case_data_id
+          where cd.jurisdiction = :sourceJurisdiction
+            and cd.case_type_id in (:caseTypeIds)
+            and ce.case_type_id in (:caseTypeIds)
+            and ce.created_date >= :sourceEventCreatedBefore
+        )
+        """,
+        baseParams().addValue("sourceEventCreatedBefore", sourceEventCreatedBefore),
+        Boolean.class
+    ));
+    return Boolean.TRUE.equals(exists);
+  }
+
+  private void validateSourceDidNotAdvanceAfterCutoverHighWaterMark(long cutoverEventHwm) {
+    long currentSourceEventHwm = sourceEventHighWaterMark();
+    if (currentSourceEventHwm > cutoverEventHwm) {
+      throw new CcdDataMigrationException(
+          "CCD data migration source advanced after cutover high-water mark was captured taskName=" + options.taskName()
+              + " cutoverEventHwm=" + cutoverEventHwm
+              + " currentSourceEventHwm=" + currentSourceEventHwm
+              + ". Confirm source writes are frozen before retrying cutover."
+      );
+    }
+    if (sourceHasFreshEvents()) {
+      throw new CcdDataMigrationException(
+          "CCD data migration source has events inside the safety window after cutover high-water mark was captured "
+              + "taskName=" + options.taskName()
+              + ". Wait for the safety window to elapse and retry cutover before final refresh."
+      );
+    }
+  }
+
+  private void validateSourceEventHighWaterMarkHasNotRegressed(long currentSourceEventHwm) {
+    long progressEventHwm = sourceEventProgressHighWaterMark();
+    if (progressEventHwm > currentSourceEventHwm) {
+      throw new CcdDataMigrationException(
+          "CCD data migration source event high-water mark regressed taskName=" + options.taskName()
+              + " sourceEventHwm=" + progressEventHwm
+              + " currentSourceEventHwm=" + currentSourceEventHwm
+              + ". A lower source event may have become visible after progress advanced; investigate before retrying."
+      );
+    }
   }
 
   private long localEventHighWaterMark() {
@@ -678,16 +1040,98 @@ public class CcdDataMigrationTask implements Runnable {
     return hwm == null ? 0 : hwm;
   }
 
+  private long validatedEventHighWaterMark() {
+    Long hwm = db.queryForObject(
+        """
+        select validated_event_hwm
+        from ccd.ccd_data_migration_progress
+        where task_name = :taskName
+        """,
+        Map.of("taskName", options.taskName()),
+        Long.class
+    );
+    return hwm == null ? 0 : hwm;
+  }
+
+  private void updateValidatedEventHighWaterMark(long validatedEventHwm) {
+    db.update(
+        """
+        update ccd.ccd_data_migration_progress
+        set validated_event_hwm = greatest(validated_event_hwm, :validatedEventHwm),
+            updated_at = now() at time zone 'UTC'
+        where task_name = :taskName
+        """,
+        Map.of(
+            "taskName", options.taskName(),
+            "validatedEventHwm", validatedEventHwm
+        )
+    );
+  }
+
+  private long validatedSignificantItemsHighWaterMark() {
+    Long hwm = db.queryForObject(
+        """
+        select validated_significant_items_hwm
+        from ccd.ccd_data_migration_progress
+        where task_name = :taskName
+        """,
+        Map.of("taskName", options.taskName()),
+        Long.class
+    );
+    return hwm == null ? 0 : hwm;
+  }
+
+  private void updateValidatedSignificantItemsHighWaterMark(long validatedSignificantItemsHwm) {
+    db.update(
+        """
+        update ccd.ccd_data_migration_progress
+        set validated_significant_items_hwm = greatest(
+              validated_significant_items_hwm,
+              :validatedSignificantItemsHwm
+            ),
+            updated_at = now() at time zone 'UTC'
+        where task_name = :taskName
+        """,
+        Map.of(
+            "taskName", options.taskName(),
+            "validatedSignificantItemsHwm", validatedSignificantItemsHwm
+        )
+    );
+  }
+
   private long sourceSignificantItemsHighWaterMark(long cutoverEventHwm) {
     Long hwm = withMigrationStatementTimeout(() -> db.queryForObject(
         """
         select coalesce(max(item.id), 0)
         from fdw_stage.case_event_significant_items item
-        where item.case_event_id <= :cutoverEventHwm
+        join fdw_stage.case_event ce on ce.id = item.case_event_id
+        join fdw_stage.case_data cd on cd.id = ce.case_data_id
+        where cd.jurisdiction = :sourceJurisdiction
+          and cd.case_type_id in (:caseTypeIds)
+          and ce.case_type_id in (:caseTypeIds)
+          and ce.id <= :cutoverEventHwm
         """,
         baseParams().addValue("cutoverEventHwm", cutoverEventHwm),
         Long.class
     ));
+    return hwm == null ? 0 : hwm;
+  }
+
+  private long localSignificantItemsHighWaterMark(long eventHwm) {
+    Long hwm = db.queryForObject(
+        """
+        select coalesce(max(item.id), 0)
+        from ccd.case_event_significant_items item
+        join ccd.case_event ce on ce.id = item.case_event_id
+        join ccd.case_data cd on cd.id = ce.case_data_id
+        where cd.jurisdiction = :sourceJurisdiction
+          and cd.case_type_id in (:caseTypeIds)
+          and ce.case_type_id in (:caseTypeIds)
+          and ce.id <= :eventHwm
+        """,
+        baseParams().addValue("eventHwm", eventHwm),
+        Long.class
+    );
     return hwm == null ? 0 : hwm;
   }
 
@@ -712,6 +1156,19 @@ public class CcdDataMigrationTask implements Runnable {
             "significantItemsHwm", significantItemsHwm
         )
     );
+  }
+
+  private void validateSignificantItemsHighWaterMarkHasNotRegressed(long currentSignificantItemsHwm) {
+    long progressSignificantItemsHwm = significantItemsProgressHighWaterMark();
+    if (progressSignificantItemsHwm > currentSignificantItemsHwm) {
+      throw new CcdDataMigrationException(
+          "CCD data migration significant-item high-water mark regressed taskName=" + options.taskName()
+              + " significantItemsHwm=" + progressSignificantItemsHwm
+              + " currentSignificantItemsHwm=" + currentSignificantItemsHwm
+              + ". A lower source significant item may have become visible after progress advanced; "
+              + "investigate before retrying."
+      );
+    }
   }
 
   private long effectiveSourceEventHighWaterMark(long targetEventHwm) {
@@ -742,6 +1199,7 @@ public class CcdDataMigrationTask implements Runnable {
 
   private long captureCutoverEventHighWaterMark() {
     long hwm = sourceEventHighWaterMark();
+    validateSourceEventHighWaterMarkHasNotRegressed(hwm);
     db.update(
         """
         update ccd.ccd_data_migration_progress
@@ -799,17 +1257,17 @@ public class CcdDataMigrationTask implements Runnable {
     );
   }
 
-  private void completeCutover(long cutoverEventHwm) {
+  private void completeCutover(long cutoverEventHwm, LocalDateTime stopAt) {
     transaction.execute(status -> {
       applyMigrationStatementTimeout();
-      validateFinal(cutoverEventHwm);
+      validateFinal(cutoverEventHwm, stopAt, new BatchBudget(options.maxBatchesPerRun()));
       enableElasticsearchQueueTrigger();
       markComplete();
       return null;
     });
   }
 
-  private void validateFinal(long eventHwm) {
+  private void validateFinal(long eventHwm, LocalDateTime stopAt, BatchBudget batchBudget) {
     log.info("CCD data migration final counts taskName={} caseData={}", options.taskName(), queryCounts("case_data"));
     log.info("CCD data migration final counts taskName={} caseEvent={}", options.taskName(), queryCounts("case_event"));
     log.info(
@@ -817,7 +1275,14 @@ public class CcdDataMigrationTask implements Runnable {
         options.taskName(),
         queryCounts("case_event_significant_items")
     );
-    validateSignificantItemCounts(eventHwm);
+    ValidationTotals eventValidationTotals = validateEventBatches(localEventHighWaterMark(), stopAt, batchBudget);
+    ValidationTotals significantItemValidationTotals = validateSignificantItemBatches(stopAt, batchBudget);
+    if (!eventValidationTotals.caughtUp() || !significantItemValidationTotals.caughtUp()) {
+      throw new CcdDataMigrationException(
+          "CCD data migration validation did not catch up before cutover completion taskName=" + options.taskName()
+              + " eventHwm=" + eventHwm
+      );
+    }
     long esQueueRows = countElasticsearchQueueRows();
     log.info("CCD data migration final counts taskName={} esQueue={}", options.taskName(), esQueueRows);
     if (esQueueRows > 0) {
@@ -843,6 +1308,7 @@ public class CcdDataMigrationTask implements Runnable {
           join ccd.case_data cd on cd.id = ce.case_data_id
           where cd.jurisdiction = :sourceJurisdiction
             and cd.case_type_id in (:caseTypeIds)
+            and ce.case_type_id in (:caseTypeIds)
           group by ce.case_type_id
           order by ce.case_type_id
           """;
@@ -853,50 +1319,13 @@ public class CcdDataMigrationTask implements Runnable {
           join ccd.case_data cd on cd.id = ce.case_data_id
           where cd.jurisdiction = :sourceJurisdiction
             and cd.case_type_id in (:caseTypeIds)
+            and ce.case_type_id in (:caseTypeIds)
           group by cd.case_type_id
           order by cd.case_type_id
           """;
       default -> throw new IllegalArgumentException("Unsupported table name: " + tableName);
     };
     return db.queryForList(sql, baseParams());
-  }
-
-  private void validateSignificantItemCounts(long eventHwm) {
-    MapSqlParameterSource params = baseParams().addValue("eventHwm", eventHwm);
-    Long sourceCount = db.queryForObject(
-        """
-        select count(*)
-        from fdw_stage.case_event_significant_items item
-        join fdw_stage.case_event ce on ce.id = item.case_event_id
-        join fdw_stage.case_data cd on cd.id = ce.case_data_id
-        where cd.jurisdiction = :sourceJurisdiction
-          and cd.case_type_id in (:caseTypeIds)
-          and ce.id <= :eventHwm
-        """,
-        params,
-        Long.class
-    );
-    Long targetCount = db.queryForObject(
-        """
-        select count(*)
-        from ccd.case_event_significant_items item
-        join ccd.case_event ce on ce.id = item.case_event_id
-        join ccd.case_data cd on cd.id = ce.case_data_id
-        where cd.jurisdiction = :sourceJurisdiction
-          and cd.case_type_id in (:caseTypeIds)
-          and ce.id <= :eventHwm
-        """,
-        params,
-        Long.class
-    );
-
-    long sourceRows = sourceCount == null ? 0 : sourceCount;
-    long targetRows = targetCount == null ? 0 : targetCount;
-    if (sourceRows != targetRows) {
-      throw new CcdDataMigrationException(
-          "CCD data migration significant item count mismatch source=" + sourceRows + " target=" + targetRows
-      );
-    }
   }
 
   private void resetSequences() {
@@ -978,6 +1407,9 @@ public class CcdDataMigrationTask implements Runnable {
             'status',
             'cutover_event_hwm',
             'source_event_hwm',
+            'significant_items_hwm',
+            'validated_event_hwm',
+            'validated_significant_items_hwm',
             'created_at',
             'updated_at'
           )
@@ -985,7 +1417,7 @@ public class CcdDataMigrationTask implements Runnable {
         Map.of("schema", TARGET_SCHEMA),
         Integer.class
     );
-    if (columnCount == null || columnCount != 7) {
+    if (columnCount == null || columnCount != 10) {
       throw new CcdDataMigrationException(
           "CCD data migration progress table is missing or incomplete. "
               + "Run the decentralised-runtime Flyway migrations before starting the task."
@@ -1017,7 +1449,9 @@ public class CcdDataMigrationTask implements Runnable {
                status,
                cutover_event_hwm,
                source_event_hwm,
-               significant_items_hwm
+               significant_items_hwm,
+               validated_event_hwm,
+               validated_significant_items_hwm
         from ccd.ccd_data_migration_progress
         where task_name = :taskName
         """,
@@ -1054,7 +1488,9 @@ public class CcdDataMigrationTask implements Runnable {
         rs.getString("status"),
         cutoverEventHwm,
         rs.getLong("source_event_hwm"),
-        rs.getLong("significant_items_hwm")
+        rs.getLong("significant_items_hwm"),
+        rs.getLong("validated_event_hwm"),
+        rs.getLong("validated_significant_items_hwm")
     );
   }
 
@@ -1277,6 +1713,10 @@ public class CcdDataMigrationTask implements Runnable {
     return options.maxRunTime() == null ? null : LocalDateTime.now(clock).plus(options.maxRunTime());
   }
 
+  private LocalDateTime sourceEventCreatedBefore() {
+    return LocalDateTime.now(clock).minus(options.sourceEventSafetyWindow());
+  }
+
   private boolean isTimeLimitReached(LocalDateTime stopAt) {
     return stopAt != null && !LocalDateTime.now(clock).isBefore(stopAt);
   }
@@ -1418,7 +1858,9 @@ public class CcdDataMigrationTask implements Runnable {
       String status,
       Long cutoverEventHwm,
       long sourceEventHwm,
-      long significantItemsHwm
+      long significantItemsHwm,
+      long validatedEventHwm,
+      long validatedSignificantItemsHwm
   ) {
     long requiredCutoverEventHwm() {
       if (cutoverEventHwm == null) {
@@ -1461,6 +1903,46 @@ public class CcdDataMigrationTask implements Runnable {
 
     private SignificantItemCopyTotals markStoppedByTimeLimit() {
       return new SignificantItemCopyTotals(batches, items, caughtUp, true);
+    }
+  }
+
+  private record ValidationTotals(long batches, boolean caughtUp, boolean stoppedByTimeLimit) {
+    private ValidationTotals() {
+      this(0, false, false);
+    }
+
+    private ValidationTotals plus() {
+      return new ValidationTotals(batches + 1, caughtUp, stoppedByTimeLimit);
+    }
+
+    private ValidationTotals markCaughtUp() {
+      return new ValidationTotals(batches, true, stoppedByTimeLimit);
+    }
+
+    private ValidationTotals markStoppedByTimeLimit() {
+      return new ValidationTotals(batches, caughtUp, true);
+    }
+  }
+
+  private static final class BatchBudget {
+    private int remaining;
+    private int consumed;
+
+    private BatchBudget(int remaining) {
+      this.remaining = remaining;
+    }
+
+    private boolean hasRemaining() {
+      return remaining > 0;
+    }
+
+    private void consume() {
+      remaining--;
+      consumed++;
+    }
+
+    private int consumed() {
+      return consumed;
     }
   }
 }

--- a/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTask.java
+++ b/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTask.java
@@ -34,6 +34,7 @@ public class CcdDataMigrationTask implements Runnable {
   private static final String STATUS_PRELOAD = "PRELOAD";
   private static final String STATUS_CUTOVER = "CUTOVER";
   private static final String STATUS_COMPLETE = "COMPLETE";
+  private static final int SOURCE_EVENT_SAFETY_SCAN_LIMIT = 100_000;
 
   private final NamedParameterJdbcTemplate db;
   private final TransactionOperations transaction;
@@ -160,7 +161,7 @@ public class CcdDataMigrationTask implements Runnable {
     CopyTotals totals = copyEventBatches(targetEventHwm, stopAt, batchBudget);
     long sourceEventHwm = sourceEventProgressHighWaterMark();
     SignificantItemCopyTotals significantItemTotals = copySignificantItemBatches(sourceEventHwm, stopAt, batchBudget);
-    ValidationTotals eventValidationTotals = validateEventBatches(localEventHighWaterMark(), stopAt, batchBudget);
+    ValidationTotals eventValidationTotals = validateEventBatches(sourceEventHwm, stopAt, batchBudget);
     ValidationTotals significantItemValidationTotals = validateSignificantItemBatches(stopAt, batchBudget);
     boolean caughtUp = sourceEventHwm >= targetEventHwm
         && significantItemTotals.caughtUp()
@@ -263,7 +264,7 @@ public class CcdDataMigrationTask implements Runnable {
           significantItemTotals.stoppedByTimeLimit()
       );
     }
-    ValidationTotals eventValidationTotals = validateEventBatches(localEventHighWaterMark(), stopAt, batchBudget);
+    ValidationTotals eventValidationTotals = validateEventBatches(cutoverEventHwm, stopAt, batchBudget);
     ValidationTotals significantItemValidationTotals = validateSignificantItemBatches(stopAt, batchBudget);
     if (!eventValidationTotals.caughtUp() || !significantItemValidationTotals.caughtUp()) {
       log.info(
@@ -284,7 +285,9 @@ public class CcdDataMigrationTask implements Runnable {
           eventValidationTotals.stoppedByTimeLimit() || significantItemValidationTotals.stoppedByTimeLimit()
       );
     }
-    validateSourceDidNotAdvanceAfterCutoverHighWaterMark(cutoverEventHwm);
+    if (releaseCutoverHighWaterMarkIfSourceAdvanced(cutoverEventHwm)) {
+      return new CcdDataMigrationRunResult(true, batchBudget.consumed(), 0, totals.events(), false, false);
+    }
     final int refreshedCases = refreshCutoverCaseData();
     resetSequences();
     completeCutover(cutoverEventHwm, stopAt);
@@ -649,7 +652,7 @@ public class CcdDataMigrationTask implements Runnable {
   }
 
   private ValidationTotals validateSignificantItemBatches(LocalDateTime stopAt, BatchBudget batchBudget) {
-    long targetSignificantItemsHwm = localSignificantItemsHighWaterMark(validatedEventHighWaterMark());
+    long targetSignificantItemsHwm = significantItemsProgressHighWaterMark();
     var totals = new ValidationTotals();
     while (batchBudget.hasRemaining()) {
       long validatedSignificantItemsHwm = validatedSignificantItemsHighWaterMark();
@@ -905,25 +908,33 @@ public class CcdDataMigrationTask implements Runnable {
     return withMigrationStatementTimeout(() -> {
       Long hwm = db.queryForObject(
           """
+          with recent_events as materialized (
+            select ce.id, ce.created_date
+            from fdw_stage.case_event ce
+            order by ce.id desc
+            limit :sourceEventSafetyScanLimit
+          ),
+          recent_stats as (
+            select max(id) as max_event_hwm,
+                   min(id) as min_scanned_event_hwm,
+                   min(id) filter (where created_date >= :sourceEventCreatedBefore) as first_fresh_event_hwm,
+                   bool_and(created_date >= :sourceEventCreatedBefore) as all_scanned_events_are_fresh
+            from recent_events
+          )
           select coalesce(
                    case
-                     when min(ce.id) filter (where ce.created_date >= :sourceEventCreatedBefore) is null then
-                       max(ce.id)
-                     else
-                       least(
-                         coalesce(max(ce.id), 0),
-                         min(ce.id) filter (where ce.created_date >= :sourceEventCreatedBefore) - 1
-                       )
+                     when first_fresh_event_hwm is null then max_event_hwm
+                     when all_scanned_events_are_fresh then :progressEventHwm
+                     else first_fresh_event_hwm - 1
                    end,
                    0
                  )
-          from fdw_stage.case_event ce
-          join fdw_stage.case_data cd on cd.id = ce.case_data_id
-          where cd.jurisdiction = :sourceJurisdiction
-            and cd.case_type_id in (:caseTypeIds)
-            and ce.case_type_id in (:caseTypeIds)
+          from recent_stats
           """,
-          baseParams().addValue("sourceEventCreatedBefore", sourceEventCreatedBefore),
+          baseParams()
+              .addValue("sourceEventCreatedBefore", sourceEventCreatedBefore)
+              .addValue("sourceEventSafetyScanLimit", SOURCE_EVENT_SAFETY_SCAN_LIMIT)
+              .addValue("progressEventHwm", sourceEventProgressHighWaterMark()),
           Long.class
       );
       return hwm == null ? 0 : hwm;
@@ -936,37 +947,58 @@ public class CcdDataMigrationTask implements Runnable {
         """
         select exists (
           select 1
-          from fdw_stage.case_event ce
-          join fdw_stage.case_data cd on cd.id = ce.case_data_id
-          where cd.jurisdiction = :sourceJurisdiction
-            and cd.case_type_id in (:caseTypeIds)
-            and ce.case_type_id in (:caseTypeIds)
-            and ce.created_date >= :sourceEventCreatedBefore
+          from (
+            select ce.created_date
+            from fdw_stage.case_event ce
+            order by ce.id desc
+            limit :sourceEventSafetyScanLimit
+          ) recent_events
+          where created_date >= :sourceEventCreatedBefore
         )
         """,
-        baseParams().addValue("sourceEventCreatedBefore", sourceEventCreatedBefore),
+        baseParams()
+            .addValue("sourceEventCreatedBefore", sourceEventCreatedBefore)
+            .addValue("sourceEventSafetyScanLimit", SOURCE_EVENT_SAFETY_SCAN_LIMIT),
         Boolean.class
     ));
     return Boolean.TRUE.equals(exists);
   }
 
-  private void validateSourceDidNotAdvanceAfterCutoverHighWaterMark(long cutoverEventHwm) {
+  private boolean releaseCutoverHighWaterMarkIfSourceAdvanced(long cutoverEventHwm) {
     long currentSourceEventHwm = sourceEventHighWaterMark();
-    if (currentSourceEventHwm > cutoverEventHwm) {
-      throw new CcdDataMigrationException(
-          "CCD data migration source advanced after cutover high-water mark was captured taskName=" + options.taskName()
-              + " cutoverEventHwm=" + cutoverEventHwm
-              + " currentSourceEventHwm=" + currentSourceEventHwm
-              + ". Confirm source writes are frozen before retrying cutover."
-      );
+    boolean sourceHasFreshEvents = sourceHasFreshEvents();
+    if (currentSourceEventHwm <= cutoverEventHwm && !sourceHasFreshEvents) {
+      return false;
     }
-    if (sourceHasFreshEvents()) {
-      throw new CcdDataMigrationException(
-          "CCD data migration source has events inside the safety window after cutover high-water mark was captured "
-              + "taskName=" + options.taskName()
-              + ". Wait for the safety window to elapse and retry cutover before final refresh."
-      );
-    }
+
+    log.info(
+        "CCD data migration cutover high-water mark released taskName={} cutoverEventHwm={} "
+            + "currentSourceEventHwm={} sourceHasFreshEvents={}",
+        options.taskName(),
+        cutoverEventHwm,
+        currentSourceEventHwm,
+        sourceHasFreshEvents
+    );
+    releaseCutoverHighWaterMark(cutoverEventHwm);
+    return true;
+  }
+
+  private void releaseCutoverHighWaterMark(long cutoverEventHwm) {
+    db.update(
+        """
+        update ccd.ccd_data_migration_progress
+        set status = :status,
+            cutover_event_hwm = null,
+            source_event_hwm = greatest(source_event_hwm, :cutoverEventHwm),
+            updated_at = now() at time zone 'UTC'
+        where task_name = :taskName
+        """,
+        Map.of(
+            "taskName", options.taskName(),
+            "status", STATUS_PRELOAD,
+            "cutoverEventHwm", cutoverEventHwm
+        )
+    );
   }
 
   private void validateSourceEventHighWaterMarkHasNotRegressed(long currentSourceEventHwm) {
@@ -985,12 +1017,16 @@ public class CcdDataMigrationTask implements Runnable {
     return withMigrationStatementTimeout(() -> {
       Long hwm = db.queryForObject(
           """
-          select coalesce(max(ce.id), 0)
-          from ccd.case_event ce
-          join ccd.case_data cd on cd.id = ce.case_data_id
-          where cd.jurisdiction = :sourceJurisdiction
-            and cd.case_type_id in (:caseTypeIds)
-            and ce.case_type_id in (:caseTypeIds)
+          select coalesce((
+            select ce.id
+            from ccd.case_event ce
+            join ccd.case_data cd on cd.id = ce.case_data_id
+            where cd.jurisdiction = :sourceJurisdiction
+              and cd.case_type_id in (:caseTypeIds)
+              and ce.case_type_id in (:caseTypeIds)
+            order by ce.id desc
+            limit 1
+          ), 0)
           """,
           baseParams(),
           Long.class
@@ -1102,36 +1138,17 @@ public class CcdDataMigrationTask implements Runnable {
   private long sourceSignificantItemsHighWaterMark(long cutoverEventHwm) {
     Long hwm = withMigrationStatementTimeout(() -> db.queryForObject(
         """
-        select coalesce(max(item.id), 0)
-        from fdw_stage.case_event_significant_items item
-        join fdw_stage.case_event ce on ce.id = item.case_event_id
-        join fdw_stage.case_data cd on cd.id = ce.case_data_id
-        where cd.jurisdiction = :sourceJurisdiction
-          and cd.case_type_id in (:caseTypeIds)
-          and ce.case_type_id in (:caseTypeIds)
-          and ce.id <= :cutoverEventHwm
+        select coalesce((
+          select item.id
+          from fdw_stage.case_event_significant_items item
+          where item.case_event_id <= :cutoverEventHwm
+          order by item.id desc
+          limit 1
+        ), 0)
         """,
         baseParams().addValue("cutoverEventHwm", cutoverEventHwm),
         Long.class
     ));
-    return hwm == null ? 0 : hwm;
-  }
-
-  private long localSignificantItemsHighWaterMark(long eventHwm) {
-    Long hwm = db.queryForObject(
-        """
-        select coalesce(max(item.id), 0)
-        from ccd.case_event_significant_items item
-        join ccd.case_event ce on ce.id = item.case_event_id
-        join ccd.case_data cd on cd.id = ce.case_data_id
-        where cd.jurisdiction = :sourceJurisdiction
-          and cd.case_type_id in (:caseTypeIds)
-          and ce.case_type_id in (:caseTypeIds)
-          and ce.id <= :eventHwm
-        """,
-        baseParams().addValue("eventHwm", eventHwm),
-        Long.class
-    );
     return hwm == null ? 0 : hwm;
   }
 
@@ -1275,7 +1292,7 @@ public class CcdDataMigrationTask implements Runnable {
         options.taskName(),
         queryCounts("case_event_significant_items")
     );
-    ValidationTotals eventValidationTotals = validateEventBatches(localEventHighWaterMark(), stopAt, batchBudget);
+    ValidationTotals eventValidationTotals = validateEventBatches(eventHwm, stopAt, batchBudget);
     ValidationTotals significantItemValidationTotals = validateSignificantItemBatches(stopAt, batchBudget);
     if (!eventValidationTotals.caughtUp() || !significantItemValidationTotals.caughtUp()) {
       throw new CcdDataMigrationException(

--- a/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTaskOptions.java
+++ b/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTaskOptions.java
@@ -20,12 +20,14 @@ public record CcdDataMigrationTaskOptions(
     int maxBatchesPerRun,
     Duration maxRunTime,
     Duration statementTimeout,
+    Duration sourceEventSafetyWindow,
     String sourceJurisdiction,
     String fdwAdditionalSelectGrantee
 ) {
   private static final String TARGET_SCHEMA = "ccd";
   private static final String FDW_SCHEMA = "fdw_stage";
   private static final Duration DEFAULT_STATEMENT_TIMEOUT = Duration.ofMinutes(10);
+  private static final Duration DEFAULT_SOURCE_EVENT_SAFETY_WINDOW = Duration.ofMinutes(2);
 
   public CcdDataMigrationTaskOptions {
     taskName = requireText(taskName, "taskName");
@@ -51,6 +53,12 @@ public record CcdDataMigrationTaskOptions(
     }
     if (statementTimeout != null && !statementTimeout.isPositive()) {
       throw new IllegalArgumentException("statementTimeout must be positive when set");
+    }
+    sourceEventSafetyWindow = sourceEventSafetyWindow == null
+        ? DEFAULT_SOURCE_EVENT_SAFETY_WINDOW
+        : sourceEventSafetyWindow;
+    if (sourceEventSafetyWindow.isNegative()) {
+      throw new IllegalArgumentException("sourceEventSafetyWindow must be zero or greater");
     }
   }
 
@@ -131,6 +139,7 @@ public record CcdDataMigrationTaskOptions(
     private int maxBatchesPerRun = Integer.MAX_VALUE;
     private Duration maxRunTime;
     private Duration statementTimeout = DEFAULT_STATEMENT_TIMEOUT;
+    private Duration sourceEventSafetyWindow = DEFAULT_SOURCE_EVENT_SAFETY_WINDOW;
     private String sourceJurisdiction;
     private String fdwAdditionalSelectGrantee;
 
@@ -178,6 +187,11 @@ public record CcdDataMigrationTaskOptions(
       return this;
     }
 
+    public Builder sourceEventSafetyWindow(Duration sourceEventSafetyWindow) {
+      this.sourceEventSafetyWindow = sourceEventSafetyWindow;
+      return this;
+    }
+
     public Builder sourceJurisdiction(String sourceJurisdiction) {
       this.sourceJurisdiction = sourceJurisdiction;
       return this;
@@ -199,6 +213,7 @@ public record CcdDataMigrationTaskOptions(
           maxBatchesPerRun,
           maxRunTime,
           statementTimeout,
+          sourceEventSafetyWindow,
           sourceJurisdiction,
           fdwAdditionalSelectGrantee
       );

--- a/sdk/decentralised-runtime/src/main/resources/dataruntime-db/migration/V0025__data_migration_validation_hwm.sql
+++ b/sdk/decentralised-runtime/src/main/resources/dataruntime-db/migration/V0025__data_migration_validation_hwm.sql
@@ -1,0 +1,9 @@
+alter table ccd.ccd_data_migration_progress
+add column validated_event_hwm bigint not null default 0,
+add column validated_significant_items_hwm bigint not null default 0;
+
+update ccd.ccd_data_migration_progress
+set validated_event_hwm = greatest(validated_event_hwm, source_event_hwm),
+    validated_significant_items_hwm = greatest(validated_significant_items_hwm, significant_items_hwm),
+    updated_at = now() at time zone 'UTC'
+where status = 'COMPLETE';

--- a/sdk/decentralised-runtime/src/main/resources/dataruntime-db/migration/V0025__data_migration_validation_hwm.sql
+++ b/sdk/decentralised-runtime/src/main/resources/dataruntime-db/migration/V0025__data_migration_validation_hwm.sql
@@ -5,5 +5,4 @@ add column validated_significant_items_hwm bigint not null default 0;
 update ccd.ccd_data_migration_progress
 set validated_event_hwm = greatest(validated_event_hwm, source_event_hwm),
     validated_significant_items_hwm = greatest(validated_significant_items_hwm, significant_items_hwm),
-    updated_at = now() at time zone 'UTC'
-where status = 'COMPLETE';
+    updated_at = now() at time zone 'UTC';

--- a/sdk/decentralised-runtime/src/test/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTaskIntegrationTest.java
+++ b/sdk/decentralised-runtime/src/test/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTaskIntegrationTest.java
@@ -7,6 +7,7 @@ import static uk.gov.hmcts.ccd.sdk.migration.CcdDataMigrationMode.PRELOAD_EVENTS
 
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -64,7 +65,7 @@ class CcdDataMigrationTaskIntegrationTest {
   void preloadsEventsBySourceHighWaterMarkWithoutDroppingTargetProtections() {
     insertSourceCase(10, 1000000000000010L, 1, "Submitted", "{\"field\":\"one\"}");
     insertSourceCaseEvent(101, 10, "create", "Submitted", "{\"field\":\"one\"}", minutesAgo(60));
-    insertSourceCaseEvent(102, 10, "update", "Updated", "{\"field\":\"two\"}", LocalDateTime.now());
+    insertSourceCaseEvent(102, 10, "update", "Updated", "{\"field\":\"two\"}", minutesAgo(60));
 
     CcdDataMigrationRunResult result = task(PRELOAD_EVENTS, 1000, 10).runMigration();
 
@@ -74,6 +75,8 @@ class CcdDataMigrationTaskIntegrationTest {
     assertThat(countRows("ccd.case_event")).isEqualTo(2);
     assertThat(progressStatus()).isEqualTo("PRELOAD");
     assertThat(localEventHwm()).isEqualTo(102);
+    assertThat(validatedEventHwm()).isEqualTo(102);
+    assertThat(validatedSignificantItemsHwm()).isZero();
     assertThat(caseEventRevision(101)).isEqualTo(1);
     assertThat(caseEventRevision(102)).isEqualTo(2);
     assertThat(caseRevision(10)).isZero();
@@ -83,13 +86,117 @@ class CcdDataMigrationTaskIntegrationTest {
   }
 
   @Test
+  void preloadOnlyTargetsSourceEventsOutsideTheSafetyWindow() {
+    insertSourceCase(10, 1000000000000010L, 1, "Submitted", "{\"field\":\"one\"}");
+    insertSourceCaseEvent(101, 10, "create", "Submitted", "{\"field\":\"one\"}", minutesAgo(60));
+    insertSourceCaseEvent(102, 10, "update", "Updated", "{\"field\":\"fresh\"}", LocalDateTime.now(Clock.systemUTC()));
+    insertSourceCaseEvent(103, 10, "close", "Closed", "{\"field\":\"old-but-after-fresh\"}", minutesAgo(60));
+
+    CcdDataMigrationRunResult defaultWindowResult = task(PRELOAD_EVENTS, 1000, 10).runMigration();
+
+    assertThat(defaultWindowResult.caughtUp()).isTrue();
+    assertThat(sourceEventHwm()).isEqualTo(101);
+    assertThat(countRows("ccd.case_event")).isEqualTo(1);
+    assertThat(validatedEventHwm()).isEqualTo(101);
+
+    CcdDataMigrationRunResult zeroWindowResult = new CcdDataMigrationTask(
+        jdbc,
+        transactionManager,
+        optionsBuilder(List.of("TestCase"))
+            .mode(PRELOAD_EVENTS)
+            .eventIdWindowSize(1000)
+            .sourceEventSafetyWindow(Duration.ZERO)
+            .build()
+    ).runMigration();
+
+    assertThat(zeroWindowResult.caughtUp()).isTrue();
+    assertThat(sourceEventHwm()).isEqualTo(103);
+    assertThat(countRows("ccd.case_event")).isEqualTo(3);
+    assertThat(validatedEventHwm()).isEqualTo(103);
+  }
+
+  @Test
+  void failsWhenSafeSourceEventHighWaterMarkRegressesBehindStoredProgress() {
+    insertSourceCase(10, 1000000000000010L, 1, "Submitted", "{\"field\":\"one\"}");
+    insertSourceCaseEvent(101, 10, "create", "Submitted", "{\"field\":\"one\"}", minutesAgo(60));
+    insertSourceCaseEvent(102, 10, "update", "Updated", "{\"field\":\"fresh\"}", LocalDateTime.now(Clock.systemUTC()));
+
+    new CcdDataMigrationTask(
+        jdbc,
+        transactionManager,
+        optionsBuilder(List.of("TestCase"))
+            .mode(PRELOAD_EVENTS)
+            .eventIdWindowSize(1000)
+            .sourceEventSafetyWindow(Duration.ZERO)
+            .build()
+    ).runMigration();
+
+    assertThat(sourceEventHwm()).isEqualTo(102);
+
+    assertThatThrownBy(() -> task(PRELOAD_EVENTS, 1000, 10).runMigration())
+        .isInstanceOf(CcdDataMigrationException.class)
+        .hasMessageContaining("source event high-water mark regressed")
+        .hasMessageContaining("sourceEventHwm=102")
+        .hasMessageContaining("currentSourceEventHwm=101");
+  }
+
+  @Test
+  void cutoverPausesBeforeCapturingHighWaterMarkWhenFreshSourceEventsExist() {
+    insertSourceCase(10, 1000000000000010L, 1, "Submitted", "{\"field\":\"one\"}");
+    insertSourceCaseEvent(101, 10, "create", "Submitted", "{\"field\":\"one\"}", minutesAgo(60));
+    task(PRELOAD_EVENTS, 1000, 10).runMigration();
+
+    updateSourceCase(10, 2, "Updated", "{\"field\":\"fresh\"}");
+    insertSourceCaseEvent(102, 10, "update", "Updated", "{\"field\":\"fresh\"}", LocalDateTime.now(Clock.systemUTC()));
+
+    CcdDataMigrationRunResult pausedCutover = task(CUTOVER, 1000, 10).runMigration();
+
+    assertThat(pausedCutover.caughtUp()).isFalse();
+    assertThat(progressStatus()).isEqualTo("PRELOAD");
+    assertThat(countRows("ccd.case_event")).isEqualTo(1);
+    assertThat(targetCaseState(10)).isEqualTo("Submitted");
+
+    CcdDataMigrationRunResult completedCutover = new CcdDataMigrationTask(
+        jdbc,
+        transactionManager,
+        optionsBuilder(List.of("TestCase"))
+            .mode(CUTOVER)
+            .eventIdWindowSize(1000)
+            .sourceEventSafetyWindow(Duration.ZERO)
+            .build()
+    ).runMigration();
+
+    assertThat(completedCutover.caughtUp()).isTrue();
+    assertThat(progressStatus()).isEqualTo("COMPLETE");
+    assertThat(cutoverEventHwm()).isEqualTo(102);
+    assertThat(countRows("ccd.case_event")).isEqualTo(2);
+    assertThat(targetCaseState(10)).isEqualTo("Updated");
+  }
+
+  @Test
+  void cutoverFailsWhenFreshSourceEventWouldRegressSafeHighWaterMark() {
+    insertSourceCase(10, 1000000000000010L, 1, "Submitted", "{\"field\":\"one\"}");
+    insertSourceCaseEvent(101, 10, "create", "Submitted", "{\"field\":\"one\"}", minutesAgo(60));
+    task(PRELOAD_EVENTS, 1000, 10).runMigration();
+
+    insertSourceCaseEvent(100, 10, "late-visible", "Submitted", "{\"field\":\"late\"}",
+        LocalDateTime.now(Clock.systemUTC()));
+
+    assertThatThrownBy(() -> task(CUTOVER, 1000, 10).runMigration())
+        .isInstanceOf(CcdDataMigrationException.class)
+        .hasMessageContaining("source event high-water mark regressed")
+        .hasMessageContaining("sourceEventHwm=101")
+        .hasMessageContaining("currentSourceEventHwm=99");
+  }
+
+  @Test
   void cutoverCopiesRemainingEventsRefreshesCaseDataAndMarksComplete() {
     insertSourceCase(10, 1000000000000010L, 1, "Submitted", "{\"field\":\"one\"}");
     insertSourceCaseEvent(101, 10, "create", "Submitted", "{\"field\":\"one\"}", minutesAgo(60));
     task(PRELOAD_EVENTS, 1000, 10).runMigration();
 
     updateSourceCase(10, 2, "Updated", "{\"field\":\"cutover\"}");
-    insertSourceCaseEvent(102, 10, "update", "Updated", "{\"field\":\"cutover\"}", LocalDateTime.now());
+    insertSourceCaseEvent(102, 10, "update", "Updated", "{\"field\":\"cutover\"}", minutesAgo(60));
 
     CcdDataMigrationRunResult result = task(CUTOVER, 1000, 10).runMigration();
 
@@ -109,28 +216,66 @@ class CcdDataMigrationTaskIntegrationTest {
   }
 
   @Test
-  void copiesSignificantItemsInSingleCutoverQuery() {
+  void failsWhenSourceSignificantItemsHighWaterMarkRegressesBehindStoredProgress() {
+    insertSourceCase(10, 1000000000000010L, 1, "Submitted", "{\"field\":\"one\"}");
+    insertSourceCaseEvent(101, 10, "create", "Submitted", "{\"field\":\"one\"}", minutesAgo(60));
+    insertSourceSignificantItem(5001, 101, "First document", "http://dm-store/documents/first");
+    createProgress();
+    updateSignificantItemsHwm(10002);
+
+    assertThatThrownBy(() -> task(PRELOAD_EVENTS, 1000, 10).runMigration())
+        .isInstanceOf(CcdDataMigrationException.class)
+        .hasMessageContaining("significant-item high-water mark regressed")
+        .hasMessageContaining("significantItemsHwm=10002")
+        .hasMessageContaining("currentSignificantItemsHwm=5001");
+  }
+
+  @Test
+  void preloadsSignificantItemsAndValidatesIncrementally() {
     insertSourceCase(10, 1000000000000010L, 1, "Submitted", "{\"field\":\"one\"}");
     insertSourceCaseEvent(101, 10, "create", "Submitted", "{\"field\":\"one\"}", minutesAgo(60));
     insertSourceCaseEvent(102, 10, "update", "Updated", "{\"field\":\"two\"}", minutesAgo(30));
     insertSourceSignificantItem(5001, 101, "First document", "http://dm-store/documents/first");
     insertSourceSignificantItem(5002, 102, "Second document", "http://dm-store/documents/second");
 
-    CcdDataMigrationRunResult preloadResult = task(PRELOAD_EVENTS, 101, 1).runMigration();
+    CcdDataMigrationRunResult preloadResult = task(PRELOAD_EVENTS, 1000, 4).runMigration();
 
-    assertThat(preloadResult.caughtUp()).isFalse();
-    assertThat(countRows("ccd.case_event_significant_items")).isZero();
-    assertThat(sourceEventHwm()).isEqualTo(101);
-    insertTargetSignificantItem(5001, 101, "Existing document", "http://dm-store/documents/existing");
+    assertThat(preloadResult.caughtUp()).isTrue();
+    assertThat(countRows("ccd.case_event_significant_items")).isEqualTo(2);
+    assertThat(sourceEventHwm()).isEqualTo(102);
+    assertThat(significantItemsHwm()).isEqualTo(5002);
+    assertThat(validatedEventHwm()).isEqualTo(102);
+    assertThat(validatedSignificantItemsHwm()).isEqualTo(5002);
 
     CcdDataMigrationRunResult cutoverResult = task(CUTOVER, 1000, 10).runMigration();
 
     assertThat(cutoverResult.caughtUp()).isTrue();
     assertThat(progressStatus()).isEqualTo("COMPLETE");
     assertThat(countRows("ccd.case_event_significant_items")).isEqualTo(2);
-    assertThat(significantItemDescription(5001)).isEqualTo("Existing document");
+    assertThat(significantItemDescription(5001)).isEqualTo("First document");
     assertThat(significantItemDescription(5002)).isEqualTo("Second document");
     assertThat(caseEventSignificantItemsSequenceLastValue()).isGreaterThanOrEqualTo(5002);
+  }
+
+  @Test
+  void significantItemCopyAndValidationUseSourceEventCaseTypeScope() {
+    insertSourceCase(10, 1000000000000010L, 1, "Submitted", "{\"field\":\"one\"}");
+    insertSourceCaseEvent(101, 10, "create", "Submitted", "{\"field\":\"one\"}", minutesAgo(60));
+    insertSourceSignificantItem(5002, 101, "Migrated document", "http://dm-store/documents/migrated");
+
+    insertSourceCase(20, 1000000000000020L, 1, "Submitted", "{\"field\":\"other\"}");
+    insertSourceCaseEvent(100, 20, "other-create", "Submitted", "{\"field\":\"other\"}", "OtherCase", minutesAgo(60));
+    insertSourceSignificantItem(5001, 100, "Other document", "http://dm-store/documents/other");
+    insertTargetCase(20, 1000000000000020L, 1, "Submitted", "{\"field\":\"other\"}", 0);
+    insertTargetEvent(100, 20, "other-create", "Submitted", "{\"field\":\"other\"}", "OtherCase", 1);
+
+    CcdDataMigrationRunResult result = task(PRELOAD_EVENTS, 1000, 10).runMigration();
+
+    assertThat(result.caughtUp()).isTrue();
+    assertThat(countRows("ccd.case_event_significant_items")).isEqualTo(1);
+    assertThat(significantItemDescription(5002)).isEqualTo("Migrated document");
+    assertThat(significantItemsHwm()).isEqualTo(5002);
+    assertThat(validatedSignificantItemsHwm()).isEqualTo(5002);
   }
 
   @Test
@@ -146,6 +291,8 @@ class CcdDataMigrationTaskIntegrationTest {
     assertThat(cutoverEventHwm()).isEqualTo(101);
     assertThat(sourceEventHwm()).isEqualTo(101);
     assertThat(significantItemsHwm()).isEqualTo(5001);
+    assertThat(validatedEventHwm()).isEqualTo(101);
+    assertThat(validatedSignificantItemsHwm()).isEqualTo(5001);
     assertThat(countRows("ccd.case_event_significant_items")).isEqualTo(1);
 
     updateSourceCase(10, 2, "Updated", "{\"field\":\"two\"}");
@@ -158,8 +305,10 @@ class CcdDataMigrationTaskIntegrationTest {
     assertThat(preload.caughtUp()).isTrue();
     assertThat(progressStatus()).isEqualTo("PRELOAD");
     assertThat(sourceEventHwm()).isEqualTo(102);
-    assertThat(significantItemsHwm()).isEqualTo(5001);
-    assertThat(countRows("ccd.case_event_significant_items")).isEqualTo(1);
+    assertThat(significantItemsHwm()).isEqualTo(5003);
+    assertThat(validatedEventHwm()).isEqualTo(102);
+    assertThat(validatedSignificantItemsHwm()).isEqualTo(5003);
+    assertThat(countRows("ccd.case_event_significant_items")).isEqualTo(3);
 
     CcdDataMigrationRunResult secondCutover = task(CUTOVER, 1000, 10).runMigration();
 
@@ -175,7 +324,7 @@ class CcdDataMigrationTaskIntegrationTest {
     assertThat(significantItemDescription(5003)).isEqualTo("Late old event document");
 
     updateSourceCase(10, 3, "Closed", "{\"field\":\"three\"}");
-    insertSourceCaseEvent(103, 10, "close", "Closed", "{\"field\":\"three\"}", LocalDateTime.now());
+    insertSourceCaseEvent(103, 10, "close", "Closed", "{\"field\":\"three\"}", minutesAgo(60));
 
     task(PRELOAD_EVENTS, 1000, 10).runMigration();
     CcdDataMigrationRunResult thirdCutover = task(CUTOVER, 1000, 10).runMigration();
@@ -197,14 +346,40 @@ class CcdDataMigrationTaskIntegrationTest {
 
     CcdDataMigrationRunResult firstCutover = task(CUTOVER, 1000, 1, 5001).runMigration();
 
+    assertThat(firstCutover.batchesProcessed()).isEqualTo(1);
     assertThat(firstCutover.caughtUp()).isFalse();
-    assertThat(significantItemsHwm()).isEqualTo(5001);
-    assertThat(countRows("ccd.case_event_significant_items")).isEqualTo(1);
+    assertThat(sourceEventHwm()).isEqualTo(101);
+    assertThat(significantItemsHwm()).isZero();
+    assertThat(countRows("ccd.case_event_significant_items")).isZero();
 
     CcdDataMigrationRunResult secondCutover = task(CUTOVER, 1000, 1, 5001).runMigration();
 
-    assertThat(secondCutover.caughtUp()).isTrue();
+    assertThat(secondCutover.batchesProcessed()).isEqualTo(1);
+    assertThat(secondCutover.caughtUp()).isFalse();
+    assertThat(significantItemsHwm()).isEqualTo(5001);
+    assertThat(validatedSignificantItemsHwm()).isZero();
+    assertThat(countRows("ccd.case_event_significant_items")).isEqualTo(1);
+
+    CcdDataMigrationRunResult thirdCutover = task(CUTOVER, 1000, 1, 5001).runMigration();
+
+    assertThat(thirdCutover.batchesProcessed()).isEqualTo(1);
+    assertThat(thirdCutover.caughtUp()).isFalse();
     assertThat(significantItemsHwm()).isEqualTo(10002);
+    assertThat(validatedSignificantItemsHwm()).isZero();
+    assertThat(countRows("ccd.case_event_significant_items")).isEqualTo(2);
+
+    CcdDataMigrationRunResult fourthCutover = task(CUTOVER, 1000, 1, 5001).runMigration();
+
+    assertThat(fourthCutover.batchesProcessed()).isEqualTo(1);
+    assertThat(fourthCutover.caughtUp()).isFalse();
+    assertThat(validatedEventHwm()).isEqualTo(101);
+    assertThat(validatedSignificantItemsHwm()).isZero();
+
+    CcdDataMigrationRunResult fifthCutover = task(CUTOVER, 1000, 1, 5001).runMigration();
+
+    assertThat(fifthCutover.batchesProcessed()).isEqualTo(1);
+    assertThat(fifthCutover.caughtUp()).isTrue();
+    assertThat(validatedSignificantItemsHwm()).isEqualTo(10002);
     assertThat(countRows("ccd.case_event_significant_items")).isEqualTo(2);
   }
 
@@ -239,7 +414,7 @@ class CcdDataMigrationTaskIntegrationTest {
 
     assertThat(result.caughtUp()).isTrue();
     assertThat(countRows("ccd.case_event")).isEqualTo(1);
-    assertThat(countRows("ccd.case_event_significant_items")).isZero();
+    assertThat(countRows("ccd.case_event_significant_items")).isEqualTo(1);
     assertThat(fdwTableExists("case_data")).isTrue();
     assertThat(fdwTableExists("case_event")).isTrue();
     assertThat(fdwTableExists("case_event_significant_items")).isTrue();
@@ -315,6 +490,22 @@ class CcdDataMigrationTaskIntegrationTest {
     assertThat(result.caughtUp()).isTrue();
     assertThat(cutoverEventHwm()).isEqualTo(101);
     assertThat(countElasticsearchQueueRows("TestCase")).isZero();
+    assertThat(caseDataTriggerEnabled("trigger_enqueue_case_revision")).isTrue();
+  }
+
+  @Test
+  void completedCutoverRerunPausedByFreshEventsDoesNotPrepareElasticsearchQueue() {
+    insertSourceCase(10, 1000000000000010L, 1, "Submitted", "{\"field\":\"one\"}");
+    insertSourceCaseEvent(101, 10, "create", "Submitted", "{\"field\":\"one\"}", minutesAgo(60));
+    insertSourceCaseEvent(102, 10, "update", "Updated", "{\"field\":\"fresh\"}", LocalDateTime.now(Clock.systemUTC()));
+    insertTargetCase(10, 1000000000000010L, 1, "Submitted", "{\"field\":\"one\"}", 1);
+    createCompleteProgress(101);
+
+    CcdDataMigrationRunResult result = task(CUTOVER, 1000, 10).runMigration();
+
+    assertThat(result.caughtUp()).isFalse();
+    assertThat(progressStatus()).isEqualTo("COMPLETE");
+    assertThat(countElasticsearchQueueRows("TestCase")).isEqualTo(1);
     assertThat(caseDataTriggerEnabled("trigger_enqueue_case_revision")).isTrue();
   }
 
@@ -402,7 +593,7 @@ class CcdDataMigrationTaskIntegrationTest {
     assertThat(result.caughtUp()).isTrue();
     assertThat(result.eventsProcessed()).isZero();
     assertThat(countRows("ccd.case_event")).isZero();
-    assertThat(sourceEventHwm()).isEqualTo(101);
+    assertThat(sourceEventHwm()).isZero();
   }
 
   @Test
@@ -945,6 +1136,18 @@ class CcdDataMigrationTaskIntegrationTest {
       String data,
       long caseRevision
   ) {
+    insertTargetEvent(id, caseDataId, eventId, stateId, data, "TestCase", caseRevision);
+  }
+
+  private void insertTargetEvent(
+      long id,
+      long caseDataId,
+      String eventId,
+      String stateId,
+      String data,
+      String caseTypeId,
+      long caseRevision
+  ) {
     jdbc.update(
         """
         insert into ccd.case_event (
@@ -980,7 +1183,7 @@ class CcdDataMigrationTaskIntegrationTest {
           'summary',
           'description',
           'user-1',
-          'TestCase',
+          :caseTypeId,
           :stateId,
           :data::jsonb,
           'Test',
@@ -1001,6 +1204,7 @@ class CcdDataMigrationTaskIntegrationTest {
             .addValue("eventId", eventId)
             .addValue("stateId", stateId)
             .addValue("data", data)
+            .addValue("caseTypeId", caseTypeId)
             .addValue("caseRevision", caseRevision)
     );
   }
@@ -1021,6 +1225,20 @@ class CcdDataMigrationTaskIntegrationTest {
             .addValue("configHash", optionsBuilder(List.of("TestCase"))
                 .build()
                 .migrationConfigHash())
+    );
+  }
+
+  private void updateSignificantItemsHwm(long significantItemsHwm) {
+    jdbc.update(
+        """
+        update ccd.ccd_data_migration_progress
+        set significant_items_hwm = :significantItemsHwm
+        where task_name = :taskName
+        """,
+        Map.of(
+            "taskName", "ccd-data-migration",
+            "significantItemsHwm", significantItemsHwm
+        )
     );
   }
 
@@ -1251,6 +1469,26 @@ class CcdDataMigrationTaskIntegrationTest {
     );
   }
 
+  private long validatedEventHwm() {
+    return jdbc.queryForObject(
+        "select validated_event_hwm from ccd.ccd_data_migration_progress where task_name = :taskName",
+        Map.of("taskName", "ccd-data-migration"),
+        Long.class
+    );
+  }
+
+  private long validatedSignificantItemsHwm() {
+    return jdbc.queryForObject(
+        """
+        select validated_significant_items_hwm
+        from ccd.ccd_data_migration_progress
+        where task_name = :taskName
+        """,
+        Map.of("taskName", "ccd-data-migration"),
+        Long.class
+    );
+  }
+
   private long caseEventSequenceLastValue() {
     return jdbc.getJdbcTemplate().queryForObject("select last_value from ccd.case_event_id_seq", Long.class);
   }
@@ -1424,7 +1662,7 @@ class CcdDataMigrationTaskIntegrationTest {
   }
 
   private LocalDateTime minutesAgo(int minutes) {
-    return LocalDateTime.now().minusMinutes(minutes);
+    return LocalDateTime.now(Clock.systemUTC()).minusMinutes(minutes);
   }
 
   @Configuration

--- a/sdk/decentralised-runtime/src/test/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTaskIntegrationTest.java
+++ b/sdk/decentralised-runtime/src/test/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTaskIntegrationTest.java
@@ -190,6 +190,31 @@ class CcdDataMigrationTaskIntegrationTest {
   }
 
   @Test
+  void cutoverReleasesCapturedHighWaterMarkWhenSourceAdvancesBeforeFinalRefresh() {
+    insertSourceCase(10, 1000000000000010L, 1, "Submitted", "{\"field\":\"one\"}");
+    insertSourceCaseEvent(101, 10, "create", "Submitted", "{\"field\":\"one\"}", minutesAgo(60));
+    insertSourceCaseEvent(102, 10, "update", "Updated", "{\"field\":\"two\"}", minutesAgo(60));
+    insertTargetCase(10, 1000000000000010L, 1, "Submitted", "{\"field\":\"one\"}", 1);
+    insertTargetEvent(101, 10, "create", "Submitted", "{\"field\":\"one\"}", 1);
+    createCutoverProgress(101);
+
+    CcdDataMigrationRunResult staleCutover = task(CUTOVER, 1000, 10).runMigration();
+
+    assertThat(staleCutover.caughtUp()).isFalse();
+    assertThat(progressStatus()).isEqualTo("PRELOAD");
+    assertThat(cutoverEventHwm()).isNull();
+    assertThat(countRows("ccd.case_event")).isEqualTo(1);
+    assertThat(targetCaseState(10)).isEqualTo("Submitted");
+
+    CcdDataMigrationRunResult completedCutover = task(CUTOVER, 1000, 10).runMigration();
+
+    assertThat(completedCutover.caughtUp()).isTrue();
+    assertThat(progressStatus()).isEqualTo("COMPLETE");
+    assertThat(cutoverEventHwm()).isEqualTo(102);
+    assertThat(countRows("ccd.case_event")).isEqualTo(2);
+  }
+
+  @Test
   void cutoverCopiesRemainingEventsRefreshesCaseDataAndMarksComplete() {
     insertSourceCase(10, 1000000000000010L, 1, "Submitted", "{\"field\":\"one\"}");
     insertSourceCaseEvent(101, 10, "create", "Submitted", "{\"field\":\"one\"}", minutesAgo(60));
@@ -593,7 +618,7 @@ class CcdDataMigrationTaskIntegrationTest {
     assertThat(result.caughtUp()).isTrue();
     assertThat(result.eventsProcessed()).isZero();
     assertThat(countRows("ccd.case_event")).isZero();
-    assertThat(sourceEventHwm()).isZero();
+    assertThat(sourceEventHwm()).isEqualTo(101);
   }
 
   @Test
@@ -1266,6 +1291,32 @@ class CcdDataMigrationTaskIntegrationTest {
     );
   }
 
+  private void createCutoverProgress(long cutoverEventHwm) {
+    jdbc.update(
+        """
+        insert into ccd.ccd_data_migration_progress (
+          task_name,
+          config_hash,
+          status,
+          cutover_event_hwm,
+          source_event_hwm
+        ) values (
+          :taskName,
+          :configHash,
+          'CUTOVER',
+          :cutoverEventHwm,
+          :cutoverEventHwm
+        )
+        """,
+        new MapSqlParameterSource()
+            .addValue("taskName", "ccd-data-migration")
+            .addValue("configHash", optionsBuilder(List.of("TestCase"))
+                .build()
+                .migrationConfigHash())
+            .addValue("cutoverEventHwm", cutoverEventHwm)
+    );
+  }
+
   private CcdDataMigrationTaskOptions.Builder optionsBuilder(List<String> caseTypeIds) {
     return CcdDataMigrationTaskOptions.builder(caseTypeIds)
         .sourceJurisdiction("TEST");
@@ -1453,7 +1504,7 @@ class CcdDataMigrationTaskIntegrationTest {
     );
   }
 
-  private long cutoverEventHwm() {
+  private Long cutoverEventHwm() {
     return jdbc.queryForObject(
         "select cutover_event_hwm from ccd.ccd_data_migration_progress where task_name = :taskName",
         Map.of("taskName", "ccd-data-migration"),

--- a/sdk/decentralised-runtime/src/test/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTaskOptionsTest.java
+++ b/sdk/decentralised-runtime/src/test/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTaskOptionsTest.java
@@ -22,6 +22,7 @@ class CcdDataMigrationTaskOptionsTest {
     assertThat(options.maxBatchesPerRun()).isEqualTo(Integer.MAX_VALUE);
     assertThat(options.maxRunTime()).isNull();
     assertThat(options.statementTimeout()).isEqualTo(Duration.ofMinutes(10));
+    assertThat(options.sourceEventSafetyWindow()).isEqualTo(Duration.ofMinutes(2));
     assertThat(options.fdwAdditionalSelectGrantee()).isNull();
   }
 
@@ -33,6 +34,7 @@ class CcdDataMigrationTaskOptionsTest {
         .maxBatchesPerRun(1)
         .maxRunTime(Duration.ofMinutes(10))
         .statementTimeout(Duration.ofSeconds(30))
+        .sourceEventSafetyWindow(Duration.ZERO)
         .build();
 
     var second = builder(List.of("CaseA", "CaseB"))
@@ -41,6 +43,7 @@ class CcdDataMigrationTaskOptionsTest {
         .maxBatchesPerRun(500)
         .maxRunTime(Duration.ofHours(4))
         .statementTimeout(Duration.ofMinutes(15))
+        .sourceEventSafetyWindow(Duration.ofMinutes(5))
         .build();
 
     assertThat(second.migrationConfigHash()).isEqualTo(first.migrationConfigHash());
@@ -124,6 +127,15 @@ class CcdDataMigrationTaskOptionsTest {
         .build())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("statementTimeout");
+  }
+
+  @Test
+  void rejectsNegativeSourceEventSafetyWindow() {
+    assertThatThrownBy(() -> builder(List.of("TestCase"))
+        .sourceEventSafetyWindow(Duration.ofSeconds(-1))
+        .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("sourceEventSafetyWindow");
   }
 
   @Test


### PR DESCRIPTION
## Summary

- Move significant item copying into preload and keep it resumable by ID window.
- Add incremental validation checkpoints for case events and significant items.
- Add a source event safety window before cutover HWM capture and fail fast if stored progress would regress.
- Update migration docs and add Flyway state for validation HWMs.

## Validation

- ./gradlew :sdk:decentralised-runtime:test --tests '*CcdDataMigrationTaskIntegrationTest' --tests '*CcdDataMigrationTaskOptionsTest'
- ./gradlew :sdk:decentralised-runtime:check
- git diff --check

Full ./gradlew check currently fails before reaching this change on :et:checkstyleCftlibIDE because Gradle cannot resolve the existing LZ4 capability conflict between at.yawk.lz4:lz4-java:1.10.1 and org.lz4:lz4-java:1.8.0.