### PR TITLE
Support SDP case event extraction

### DIFF
--- a/sdk/decentralised-runtime/src/main/resources/dataruntime-db/migration/V0025__index_case_events_for_sdp_extraction.sql
+++ b/sdk/decentralised-runtime/src/main/resources/dataruntime-db/migration/V0025__index_case_events_for_sdp_extraction.sql
@@ -1,0 +1,4 @@
+-- The Strategic Data Platform extracts CCD event history by case type and
+-- created-date window, ordered by creation date and event ID for paging.
+create index concurrently idx_case_event_case_type_created_date_id
+    on ccd.case_event (case_type_id, created_date, id);


### PR DESCRIPTION
The Strategic Data Platform extracts CCD event history by case type and created-date window, ordered by creation date and event ID in pages of 5,000 rows. The existing case event history index starts with `case_data_id`, so it cannot efficiently support that extraction pattern.

This adds a concurrent index on `(case_type_id, created_date, id)`. It allows PostgreSQL to select the requested case type and date range in SDP's required order without sorting the matching event history, while avoiding a blocking index build when the SDK migration is deployed.
