### PR TITLE
Use PostgreSQL 15 as the supported SDK baseline

### DIFF
--- a/docs/decentralised-runtime.md
+++ b/docs/decentralised-runtime.md
@@ -97,6 +97,8 @@ If an incoming request has already been processed, the runtime replays the store
 
 To fulfil the aforementioned responsibilities, the SDK provisions and manages a dedicated `ccd` schema within your application's database.
 
+The SDK targets PostgreSQL 15 for the decentralised runtime. Service-owned databases should use PostgreSQL 15 as the supported baseline.
+
 - `case_data` mirrors CCD’s `case_data` table, including metadata such as state, security classification, TTL and the JSON payload.
 - `case_event` mirrors CCD’s `case_event` table and adds an idempotency key.
 - `es_queue` tracks cases that require Elasticsearch indexing 

--- a/sdk/ccd-runtime-indexing/src/chaosTest/java/uk/gov/hmcts/ccd/sdk/DecentralisedESIndexerChaosTest.java
+++ b/sdk/ccd-runtime-indexing/src/chaosTest/java/uk/gov/hmcts/ccd/sdk/DecentralisedESIndexerChaosTest.java
@@ -59,7 +59,7 @@ class DecentralisedESIndexerChaosTest {
   private static final HttpClient HTTP = HttpClient.newHttpClient();
 
   @Container
-  private static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>("postgres:16-alpine")
+  private static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>("postgres:15-alpine")
       .withDatabaseName("ccd");
 
   @Container

--- a/sdk/decentralised-runtime/src/test/java/uk/gov/hmcts/ccd/sdk/impl/IdempotentReplayIntegrationTest.java
+++ b/sdk/decentralised-runtime/src/test/java/uk/gov/hmcts/ccd/sdk/impl/IdempotentReplayIntegrationTest.java
@@ -34,7 +34,7 @@ import uk.gov.hmcts.ccd.sdk.api.HasRole;
 import uk.gov.hmcts.ccd.sdk.config.DecentralisedDataConfiguration;
 
 @SpringBootTest(classes = IdempotentReplayIntegrationTest.TestConfig.class, properties = {
-    "spring.datasource.url=jdbc:tc:postgresql:16-alpine:///ccd",
+    "spring.datasource.url=jdbc:tc:postgresql:15-alpine:///ccd",
     "spring.datasource.driver-class-name=org.testcontainers.jdbc.ContainerDatabaseDriver"
 })
 class IdempotentReplayIntegrationTest {

--- a/sdk/decentralised-runtime/src/test/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTaskIntegrationTest.java
+++ b/sdk/decentralised-runtime/src/test/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTaskIntegrationTest.java
@@ -31,7 +31,7 @@ import org.springframework.transaction.PlatformTransactionManager;
 import uk.gov.hmcts.ccd.sdk.config.DecentralisedDataConfiguration;
 
 @SpringBootTest(classes = CcdDataMigrationTaskIntegrationTest.TestConfig.class, properties = {
-    "spring.datasource.url=jdbc:tc:postgresql:16-alpine:///ccd",
+    "spring.datasource.url=jdbc:tc:postgresql:15-alpine:///ccd",
     "spring.datasource.driver-class-name=org.testcontainers.jdbc.ContainerDatabaseDriver"
 })
 class CcdDataMigrationTaskIntegrationTest {

--- a/test-projects/e2e/build.gradle
+++ b/test-projects/e2e/build.gradle
@@ -169,6 +169,7 @@ tasks.withType(CftlibExec).configureEach {
   group = 'ccd tasks'
   dependsOn tasks.named('generateJsonLegacyDefinitions')
   authMode = AuthMode.Local
+  environment 'POSTGRES_VERSION', '15'
   environment 'CCD_DECENTRALISED_CASE-TYPE-SERVICE-URLS_E2E', 'http://localhost:4013'
   environment 'CCD_DECENTRALISED_CASE-TYPE-SERVICE-URLS_case-type-a', 'http://localhost:4013'
   environment 'CCD_DECENTRALISED_CASE-TYPE-SERVICE-URLS_case-type-b', 'http://localhost:4013'

--- a/test-projects/e2e/src/test/java/uk/gov/hmcts/divorce/integration/CcdDataMigrationSpringBootTest.java
+++ b/test-projects/e2e/src/test/java/uk/gov/hmcts/divorce/integration/CcdDataMigrationSpringBootTest.java
@@ -12,7 +12,7 @@ import uk.gov.hmcts.ccd.sdk.migration.CcdDataMigrationTask;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
 @TestPropertySource(properties = {
-    "spring.datasource.url=jdbc:tc:postgresql:16-alpine:///e2e",
+    "spring.datasource.url=jdbc:tc:postgresql:15-alpine:///e2e",
     "spring.datasource.driverClassName=org.testcontainers.jdbc.ContainerDatabaseDriver",
     "spring.jms.servicebus.enabled=false",
     "spring.autoconfigure.exclude=com.azure.spring.cloud.autoconfigure.implementation.jms.ServiceBusJmsAutoConfiguration",

--- a/test-projects/e2e/src/test/java/uk/gov/hmcts/divorce/integration/UnknownEventCallbackTest.java
+++ b/test-projects/e2e/src/test/java/uk/gov/hmcts/divorce/integration/UnknownEventCallbackTest.java
@@ -19,7 +19,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
 @AutoConfigureMockMvc
 @TestPropertySource(properties = {
-    "spring.datasource.url=jdbc:tc:postgresql:16-alpine:///e2e",
+    "spring.datasource.url=jdbc:tc:postgresql:15-alpine:///e2e",
     "spring.datasource.driverClassName=org.testcontainers.jdbc.ContainerDatabaseDriver",
     "spring.jms.servicebus.enabled=false",
     "spring.autoconfigure.exclude=com.azure.spring.cloud.autoconfigure.implementation.jms.ServiceBusJmsAutoConfiguration",


### PR DESCRIPTION
Document postgres 15 as the sdk baseline supported version and align all our tests to it.