### PR TITLE
Reconcile CCD data at migration cutover

### DIFF
--- a/docs/ccd-data-migration-task.md
+++ b/docs/ccd-data-migration-task.md
@@ -20,7 +20,7 @@ The task has one implementation with explicit modes:
   mark and inserts provisional parent `case_data` rows so the target FK remains valid.
 * `CUTOVER`: explicit operator action during downtime. Captures the cutover event high-water mark,
   copies the final event delta, copies linked `case_event_significant_items` in a single set-based
-  query, refreshes target `case_data` from source, sets final case revisions, resets sequences,
+  query, reconciles target `case_data` with source, sets final case revisions, resets sequences,
   validates, and marks the migration complete.
 * `VALIDATE_ONLY`: runs final source-vs-target validation without copying data.
 
@@ -47,8 +47,15 @@ Preloaded `case_data` is provisional. Its purpose is to satisfy the event FK. Ev
 batch inserts missing parent source `case_data` rows for that batch. Significant items are copied
 only during `CUTOVER`, using one `insert into ... select` query that reads source significant items
 and joins through already migrated target events up to the captured cutover event high-water mark.
-`CUTOVER` then upserts every selected source `case_data` row into the target and sets
+`CUTOVER` stages every selected source `case_data` row in its final refresh transaction, upserts that
+stable set into the target, and deletes target cases in the configured jurisdiction and case types
+that are no longer present in source. The existing foreign-key cascades remove their case events and
+event dependants. It then sets
 `case_data.case_revision = max(case_event.case_revision) + caseRevisionOffset`.
+
+The source write freeze must include retain-and-dispose work, and operators must wait for its
+in-flight transactions to drain. A source case deleted after the cutover snapshot cannot be observed
+by that cutover run.
 
 The runtime `case_data` revision trigger is deliberately disabled only inside the cutover refresh
 transaction so the final source-derived revision can be written. The trigger is re-enabled before the

--- a/docs/ccd-data-migration-task.md
+++ b/docs/ccd-data-migration-task.md
@@ -47,10 +47,9 @@ Preloaded `case_data` is provisional. Its purpose is to satisfy the event FK. Ev
 batch inserts missing parent source `case_data` rows for that batch. Significant items are copied
 only during `CUTOVER`, using one `insert into ... select` query that reads source significant items
 and joins through already migrated target events up to the captured cutover event high-water mark.
-`CUTOVER` stages every selected source `case_data` row in its final refresh transaction, upserts that
-stable set into the target, and deletes target cases in the configured jurisdiction and case types
-that are no longer present in source. The existing foreign-key cascades remove their case events and
-event dependants. It then sets
+`CUTOVER` uses a filtered `MERGE` from the source `case_data` table to update changed rows and insert
+missing rows, followed by a scoped delete of target-only rows. The existing foreign-key cascades
+remove deleted cases' events and event dependants. It then sets
 `case_data.case_revision = max(case_event.case_revision) + caseRevisionOffset`.
 
 The source write freeze must include retain-and-dispose work, and operators must wait for its

--- a/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTask.java
+++ b/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTask.java
@@ -230,18 +230,17 @@ public class CcdDataMigrationTask implements Runnable {
           significantItemTotals.stoppedByTimeLimit()
       );
     }
-    CutoverCaseRefreshTotals caseRefreshTotals = refreshCutoverCaseData();
+    int reconciledCases = refreshCutoverCaseData();
     resetSequences();
     completeCutover();
 
     log.info(
-        "Completed CCD data migration cutover taskName={} cutoverEventHwm={} batches={} refreshedCases={} "
-            + "deletedCases={} events={} significantItems={} significantItemBatches={} stoppedByTimeLimit={}",
+        "Completed CCD data migration cutover taskName={} cutoverEventHwm={} batches={} reconciledCases={} "
+            + "events={} significantItems={} significantItemBatches={} stoppedByTimeLimit={}",
         options.taskName(),
         cutoverEventHwm,
         totals.batches(),
-        caseRefreshTotals.refreshedCases(),
-        caseRefreshTotals.deletedCases(),
+        reconciledCases,
         totals.events(),
         significantItemTotals.items(),
         significantItemTotals.batches(),
@@ -250,7 +249,7 @@ public class CcdDataMigrationTask implements Runnable {
     return new CcdDataMigrationRunResult(
         true,
         totals.batches(),
-        caseRefreshTotals.totalCases(),
+        reconciledCases,
         totals.events(),
         !totals.stoppedByTimeLimit(),
         totals.stoppedByTimeLimit()
@@ -512,45 +511,73 @@ public class CcdDataMigrationTask implements Runnable {
     );
   }
 
-  private CutoverCaseRefreshTotals refreshCutoverCaseData() {
+  private int refreshCutoverCaseData() {
     return transaction.execute(status -> {
       applyMigrationStatementTimeout();
-      stageCutoverCaseData();
       disableCaseDataRevisionTrigger();
       try {
-        int refreshedCases = syncCaseDataForCutover();
-        int deletedCases = deleteTargetCasesMissingAtCutover();
+        int reconciledCases = mergeCaseDataForCutover();
+        reconciledCases += deleteTargetCasesMissingAtCutover();
         updateCaseRevisionsForCutover();
-        return new CutoverCaseRefreshTotals(refreshedCases, deletedCases);
+        return reconciledCases;
       } finally {
         enableCaseDataRevisionTrigger();
       }
     });
   }
 
-  private void stageCutoverCaseData() {
-    db.update(
-        """
-        create temporary table ccd_data_migration_cutover_cases
-        on commit drop
-        as
-        select source.*
-        from fdw_stage.case_data source
-        where source.jurisdiction = :sourceJurisdiction
-          and source.case_type_id in (:caseTypeIds)
-        """,
-        baseParams()
-    );
-    db.getJdbcTemplate().execute(
-        "create unique index on ccd_data_migration_cutover_cases (id)"
-    );
-    db.getJdbcTemplate().execute("analyze ccd_data_migration_cutover_cases");
-  }
-
-  private int syncCaseDataForCutover() {
+  private int mergeCaseDataForCutover() {
     return db.update(
         """
-        insert into ccd.case_data as target (
+        merge into ccd.case_data target
+        using (
+          select source.*
+          from fdw_stage.case_data source
+          where source.jurisdiction = :sourceJurisdiction
+            and source.case_type_id in (:caseTypeIds)
+        ) source
+        on target.id = source.id
+        when matched and (
+          target.reference,
+          target.version,
+          target.created_date,
+          target.security_classification,
+          target.last_state_modified_date,
+          target.resolved_ttl,
+          target.last_modified,
+          target.jurisdiction,
+          target.case_type_id,
+          target.state,
+          target.data,
+          target.supplementary_data
+        ) is distinct from (
+          source.reference,
+          source.version,
+          source.created_date,
+          source.security_classification,
+          source.last_state_modified_date,
+          source.resolved_ttl,
+          source.last_modified,
+          source.jurisdiction,
+          source.case_type_id,
+          source.state,
+          source.data,
+          coalesce(source.supplementary_data, jsonb_build_object())
+        )
+        then update set
+          reference = source.reference,
+          version = source.version,
+          created_date = source.created_date,
+          security_classification = source.security_classification,
+          last_state_modified_date = source.last_state_modified_date,
+          resolved_ttl = source.resolved_ttl,
+          last_modified = source.last_modified,
+          jurisdiction = source.jurisdiction,
+          case_type_id = source.case_type_id,
+          state = source.state,
+          data = source.data,
+          supplementary_data = coalesce(source.supplementary_data, jsonb_build_object())
+        when not matched then insert (
           reference,
           version,
           created_date,
@@ -565,8 +592,7 @@ public class CcdDataMigrationTask implements Runnable {
           supplementary_data,
           id,
           case_revision
-        )
-        select
+        ) values (
           source.reference,
           source.version,
           source.created_date,
@@ -581,46 +607,6 @@ public class CcdDataMigrationTask implements Runnable {
           coalesce(source.supplementary_data, jsonb_build_object()),
           source.id,
           0
-        from ccd_data_migration_cutover_cases source
-        on conflict (id) do update
-        set reference = excluded.reference,
-            version = excluded.version,
-            created_date = excluded.created_date,
-            security_classification = excluded.security_classification,
-            last_state_modified_date = excluded.last_state_modified_date,
-            resolved_ttl = excluded.resolved_ttl,
-            last_modified = excluded.last_modified,
-            jurisdiction = excluded.jurisdiction,
-            case_type_id = excluded.case_type_id,
-            state = excluded.state,
-            data = excluded.data,
-            supplementary_data = excluded.supplementary_data
-        where (
-          target.reference,
-          target.version,
-          target.created_date,
-          target.security_classification,
-          target.last_state_modified_date,
-          target.resolved_ttl,
-          target.last_modified,
-          target.jurisdiction,
-          target.case_type_id,
-          target.state,
-          target.data,
-          target.supplementary_data
-        ) is distinct from (
-          excluded.reference,
-          excluded.version,
-          excluded.created_date,
-          excluded.security_classification,
-          excluded.last_state_modified_date,
-          excluded.resolved_ttl,
-          excluded.last_modified,
-          excluded.jurisdiction,
-          excluded.case_type_id,
-          excluded.state,
-          excluded.data,
-          excluded.supplementary_data
         )
         """,
         baseParams()
@@ -635,8 +621,10 @@ public class CcdDataMigrationTask implements Runnable {
           and target.case_type_id in (:caseTypeIds)
           and not exists (
             select 1
-            from ccd_data_migration_cutover_cases source
+            from fdw_stage.case_data source
             where source.id = target.id
+              and source.jurisdiction = :sourceJurisdiction
+              and source.case_type_id in (:caseTypeIds)
           )
         """,
         baseParams()
@@ -661,6 +649,7 @@ public class CcdDataMigrationTask implements Runnable {
         where target.id = event_counts.case_data_id
           and target.jurisdiction = :sourceJurisdiction
           and target.case_type_id in (:caseTypeIds)
+          and target.case_revision is distinct from event_counts.max_revision + :caseRevisionOffset
         """,
         baseParams().addValue("caseRevisionOffset", options.caseRevisionOffset())
     );
@@ -1443,9 +1432,4 @@ public class CcdDataMigrationTask implements Runnable {
     }
   }
 
-  private record CutoverCaseRefreshTotals(int refreshedCases, int deletedCases) {
-    private int totalCases() {
-      return refreshedCases + deletedCases;
-    }
-  }
 }

--- a/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTask.java
+++ b/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTask.java
@@ -230,17 +230,18 @@ public class CcdDataMigrationTask implements Runnable {
           significantItemTotals.stoppedByTimeLimit()
       );
     }
-    final int refreshedCases = refreshCutoverCaseData();
+    CutoverCaseRefreshTotals caseRefreshTotals = refreshCutoverCaseData();
     resetSequences();
     completeCutover();
 
     log.info(
-        "Completed CCD data migration cutover taskName={} cutoverEventHwm={} batches={} refreshedCases={} events={} "
-            + "significantItems={} significantItemBatches={} stoppedByTimeLimit={}",
+        "Completed CCD data migration cutover taskName={} cutoverEventHwm={} batches={} refreshedCases={} "
+            + "deletedCases={} events={} significantItems={} significantItemBatches={} stoppedByTimeLimit={}",
         options.taskName(),
         cutoverEventHwm,
         totals.batches(),
-        refreshedCases,
+        caseRefreshTotals.refreshedCases(),
+        caseRefreshTotals.deletedCases(),
         totals.events(),
         significantItemTotals.items(),
         significantItemTotals.batches(),
@@ -249,7 +250,7 @@ public class CcdDataMigrationTask implements Runnable {
     return new CcdDataMigrationRunResult(
         true,
         totals.batches(),
-        refreshedCases,
+        caseRefreshTotals.totalCases(),
         totals.events(),
         !totals.stoppedByTimeLimit(),
         totals.stoppedByTimeLimit()
@@ -511,18 +512,39 @@ public class CcdDataMigrationTask implements Runnable {
     );
   }
 
-  private int refreshCutoverCaseData() {
+  private CutoverCaseRefreshTotals refreshCutoverCaseData() {
     return transaction.execute(status -> {
       applyMigrationStatementTimeout();
+      stageCutoverCaseData();
       disableCaseDataRevisionTrigger();
       try {
         int refreshedCases = syncCaseDataForCutover();
+        int deletedCases = deleteTargetCasesMissingAtCutover();
         updateCaseRevisionsForCutover();
-        return refreshedCases;
+        return new CutoverCaseRefreshTotals(refreshedCases, deletedCases);
       } finally {
         enableCaseDataRevisionTrigger();
       }
     });
+  }
+
+  private void stageCutoverCaseData() {
+    db.update(
+        """
+        create temporary table ccd_data_migration_cutover_cases
+        on commit drop
+        as
+        select source.*
+        from fdw_stage.case_data source
+        where source.jurisdiction = :sourceJurisdiction
+          and source.case_type_id in (:caseTypeIds)
+        """,
+        baseParams()
+    );
+    db.getJdbcTemplate().execute(
+        "create unique index on ccd_data_migration_cutover_cases (id)"
+    );
+    db.getJdbcTemplate().execute("analyze ccd_data_migration_cutover_cases");
   }
 
   private int syncCaseDataForCutover() {
@@ -559,9 +581,7 @@ public class CcdDataMigrationTask implements Runnable {
           coalesce(source.supplementary_data, jsonb_build_object()),
           source.id,
           0
-        from fdw_stage.case_data source
-        where source.jurisdiction = :sourceJurisdiction
-          and source.case_type_id in (:caseTypeIds)
+        from ccd_data_migration_cutover_cases source
         on conflict (id) do update
         set reference = excluded.reference,
             version = excluded.version,
@@ -602,6 +622,22 @@ public class CcdDataMigrationTask implements Runnable {
           excluded.data,
           excluded.supplementary_data
         )
+        """,
+        baseParams()
+    );
+  }
+
+  private int deleteTargetCasesMissingAtCutover() {
+    return db.update(
+        """
+        delete from ccd.case_data target
+        where target.jurisdiction = :sourceJurisdiction
+          and target.case_type_id in (:caseTypeIds)
+          and not exists (
+            select 1
+            from ccd_data_migration_cutover_cases source
+            where source.id = target.id
+          )
         """,
         baseParams()
     );
@@ -1404,6 +1440,12 @@ public class CcdDataMigrationTask implements Runnable {
 
     private SignificantItemCopyTotals markStoppedByTimeLimit() {
       return new SignificantItemCopyTotals(batches, items, caughtUp, true);
+    }
+  }
+
+  private record CutoverCaseRefreshTotals(int refreshedCases, int deletedCases) {
+    private int totalCases() {
+      return refreshedCases + deletedCases;
     }
   }
 }

--- a/sdk/decentralised-runtime/src/test/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTaskIntegrationTest.java
+++ b/sdk/decentralised-runtime/src/test/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTaskIntegrationTest.java
@@ -109,6 +109,41 @@ class CcdDataMigrationTaskIntegrationTest {
   }
 
   @Test
+  void cutoverDeletesPreloadedCasesDisposedFromSourceAndCascadesTheirEvents() {
+    insertSourceCase(10, 1000000000000010L, 1, "Submitted", "{\"field\":\"one\"}");
+    insertSourceCaseEvent(101, 10, "create", "Submitted", "{\"field\":\"one\"}", minutesAgo(60));
+    task(PRELOAD_EVENTS, 1000, 10).runMigration();
+    insertTargetSignificantItem(5001, 101, "Preloaded document", "http://dm-store/documents/preloaded");
+
+    insertTargetCase(20, 1000000000000020L, 1, "Submitted", "{\"field\":\"other-type\"}", "OtherCase", 1);
+    insertTargetCase(
+        30,
+        1000000000000030L,
+        1,
+        "Submitted",
+        "{\"field\":\"other-jurisdiction\"}",
+        "OTHER",
+        "TestCase",
+        1
+    );
+
+    jdbc.getJdbcTemplate().execute("delete from source.case_event where case_data_id = 10");
+    jdbc.getJdbcTemplate().execute("delete from source.case_data where id = 10");
+
+    CcdDataMigrationRunResult result = task(CUTOVER, 1000, 10).runMigration();
+
+    assertThat(result.caughtUp()).isTrue();
+    assertThat(result.casesProcessed()).isEqualTo(1);
+    assertThat(progressStatus()).isEqualTo("COMPLETE");
+    assertThat(countRows("ccd.case_data")).isEqualTo(2);
+    assertThat(countRows("ccd.case_event")).isZero();
+    assertThat(countRows("ccd.case_event_significant_items")).isZero();
+    assertThat(targetCaseState(20)).isEqualTo("Submitted");
+    assertThat(targetCaseState(30)).isEqualTo("Submitted");
+    assertTargetProtectionsPresent();
+  }
+
+  @Test
   void cutoverInsertsSourceCaseDataWithoutPreloadedEvents() {
     insertSourceCase(10, 1000000000000010L, 2, "Updated", "{\"field\":\"source\"}");
 

--- a/sdk/decentralised-runtime/src/test/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTaskIntegrationTest.java
+++ b/sdk/decentralised-runtime/src/test/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTaskIntegrationTest.java
@@ -31,7 +31,7 @@ import org.springframework.transaction.PlatformTransactionManager;
 import uk.gov.hmcts.ccd.sdk.config.DecentralisedDataConfiguration;
 
 @SpringBootTest(classes = CcdDataMigrationTaskIntegrationTest.TestConfig.class, properties = {
-    "spring.datasource.url=jdbc:tc:postgresql:16-alpine:///ccd",
+    "spring.datasource.url=jdbc:tc:postgresql:15-alpine:///ccd",
     "spring.datasource.driver-class-name=org.testcontainers.jdbc.ContainerDatabaseDriver"
 })
 class CcdDataMigrationTaskIntegrationTest {
@@ -156,6 +156,20 @@ class CcdDataMigrationTaskIntegrationTest {
     assertThat(targetCaseState(10)).isEqualTo("Updated");
     assertThat(targetCaseData(10)).isEqualTo("{\"field\": \"source\"}");
     assertThat(caseRevision(10)).isZero();
+  }
+
+  @Test
+  void cutoverDoesNotUpdateUnchangedCaseData() {
+    insertSourceCase(10, 1000000000000010L, 1, "Submitted", "{\"field\":\"same\"}");
+    insertTargetCase(10, 1000000000000010L, 1, "Submitted", "{\"field\":\"same\"}", 0);
+    long rowVersionBeforeCutover = targetCaseRowVersion(10);
+
+    CcdDataMigrationRunResult result = task(CUTOVER, 1000, 10).runMigration();
+
+    assertThat(result.casesProcessed()).isZero();
+    assertThat(targetCaseRowVersion(10)).isEqualTo(rowVersionBeforeCutover);
+    assertThat(targetCaseState(10)).isEqualTo("Submitted");
+    assertThat(targetCaseData(10)).isEqualTo("{\"field\": \"same\"}");
   }
 
   @Test
@@ -1281,6 +1295,14 @@ class CcdDataMigrationTaskIntegrationTest {
 
   private String targetCaseData(long id) {
     return jdbc.queryForObject("select data::text from ccd.case_data where id = :id", Map.of("id", id), String.class);
+  }
+
+  private long targetCaseRowVersion(long id) {
+    return jdbc.queryForObject(
+        "select xmin::text::bigint from ccd.case_data where id = :id",
+        Map.of("id", id),
+        Long.class
+    );
   }
 
   private String progressStatus() {


### PR DESCRIPTION
Cutover now uses a filtered PostgreSQL `MERGE` from the FDW source table to update changed cases and insert missing cases. A scoped `DELETE` removes cases disposed from the source with their dependent events through the existing foreign-key cascades.

The source predicates are applied inside both FDW queries so only the configured jurisdiction and case types are considered. Matched rows and final case revisions are written only when their values differ, avoiding unnecessary row churn on PostgreSQL 15.
