### PR TITLE
Remove source-deleted cases during CCD cutover

### DIFF
--- a/docs/ccd-data-migration-task.md
+++ b/docs/ccd-data-migration-task.md
@@ -47,7 +47,8 @@ Preloaded `case_data` is provisional. Its purpose is to satisfy the event FK. Ev
 batch inserts missing parent source `case_data` rows for that batch. Significant items are copied
 only during `CUTOVER`, using one `insert into ... select` query that reads source significant items
 and joins through already migrated target events up to the captured cutover event high-water mark.
-`CUTOVER` then upserts every selected source `case_data` row into the target and sets
+`CUTOVER` then upserts every selected source `case_data` row into the target, deletes selected target
+cases that no longer exist in the source, and sets
 `case_data.case_revision = max(case_event.case_revision) + caseRevisionOffset`.
 
 The runtime `case_data` revision trigger is deliberately disabled only inside the cutover refresh

--- a/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTask.java
+++ b/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTask.java
@@ -517,6 +517,7 @@ public class CcdDataMigrationTask implements Runnable {
       disableCaseDataRevisionTrigger();
       try {
         int refreshedCases = syncCaseDataForCutover();
+        deleteCasesRemovedFromSource();
         updateCaseRevisionsForCutover();
         return refreshedCases;
       } finally {
@@ -605,6 +606,25 @@ public class CcdDataMigrationTask implements Runnable {
         """,
         baseParams()
     );
+  }
+
+  private int deleteCasesRemovedFromSource() {
+    int deletedCases = db.update(
+        """
+        delete from ccd.case_data target
+        where target.jurisdiction = :sourceJurisdiction
+          and target.case_type_id in (:caseTypeIds)
+          and target.id not in (
+            select source.id
+            from fdw_stage.case_data source
+            where source.jurisdiction = :sourceJurisdiction
+              and source.case_type_id in (:caseTypeIds)
+          )
+        """,
+        baseParams()
+    );
+    log.info("Deleted CCD cases removed from source taskName={} cases={}", options.taskName(), deletedCases);
+    return deletedCases;
   }
 
   private int updateCaseRevisionsForCutover() {

--- a/sdk/decentralised-runtime/src/test/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTaskIntegrationTest.java
+++ b/sdk/decentralised-runtime/src/test/java/uk/gov/hmcts/ccd/sdk/migration/CcdDataMigrationTaskIntegrationTest.java
@@ -124,6 +124,35 @@ class CcdDataMigrationTaskIntegrationTest {
   }
 
   @Test
+  void cutoverDeletesCasesRemovedFromSourceWithoutDeletingCasesOutsideTheMigrationScope() {
+    insertSourceCase(10, 1000000000000010L, 1, "Submitted", "{\"field\":\"one\"}");
+    insertSourceCaseEvent(101, 10, "create", "Submitted", "{\"field\":\"one\"}", minutesAgo(60));
+    task(PRELOAD_EVENTS, 1000, 10).runMigration();
+
+    insertTargetCase(20, 1000000000000020L, 1, "Submitted", "{\"field\":\"other-type\"}", "OtherCase", 1);
+    insertTargetCase(
+        30,
+        1000000000000030L,
+        1,
+        "Submitted",
+        "{\"field\":\"other-jurisdiction\"}",
+        "OTHER",
+        "TestCase",
+        1
+    );
+    jdbc.getJdbcTemplate().execute("delete from source.case_event where case_data_id = 10");
+    jdbc.getJdbcTemplate().execute("delete from source.case_data where id = 10");
+
+    CcdDataMigrationRunResult result = task(CUTOVER, 1000, 10).runMigration();
+
+    assertThat(result.caughtUp()).isTrue();
+    assertThat(countRows("ccd.case_data")).isEqualTo(2);
+    assertThat(countRows("ccd.case_event")).isZero();
+    assertThat(targetCaseState(20)).isEqualTo("Submitted");
+    assertThat(targetCaseState(30)).isEqualTo("Submitted");
+  }
+
+  @Test
   void copiesSignificantItemsInSingleCutoverQuery() {
     insertSourceCase(10, 1000000000000010L, 1, "Submitted", "{\"field\":\"one\"}");
     insertSourceCaseEvent(101, 10, "create", "Submitted", "{\"field\":\"one\"}", minutesAgo(60));


### PR DESCRIPTION
CCD periodically removes cases, while the cutover refresh currently only upserts rows that still exist in the source. This can leave cases and their event history in the decentralised database after CCD has deleted them.

The cutover refresh now removes target cases whose IDs are absent from the FDW source. Both sides of the comparison are constrained to the configured source jurisdiction and case types, so cases outside the migration scope remain untouched. Existing foreign-key cascades remove the associated local event history.

Integration coverage exercises a case deleted after preload and confirms that its events are removed while cases from another jurisdiction or case type are retained.