### PR TITLE
Use ACR puller identity

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -55,7 +55,7 @@ jobs:
       if: steps.changes.outputs.docs_only != 'true'
       uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43
       with:
-        client-id: 82f79201-9a30-4160-b264-7bbed775c7f4
+        client-id: 7dbe3da2-315b-4937-bac6-3ab22a9c7b91
         tenant-id: 531ff96d-0ae9-462a-8d2d-bec7c0b42082
         allow-no-subscriptions: true
     - name: ACR Login
@@ -180,7 +180,7 @@ jobs:
       if: steps.changes.outputs.docs_only != 'true'
       uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43
       with:
-        client-id: 82f79201-9a30-4160-b264-7bbed775c7f4
+        client-id: 7dbe3da2-315b-4937-bac6-3ab22a9c7b91
         tenant-id: 531ff96d-0ae9-462a-8d2d-bec7c0b42082
         allow-no-subscriptions: true
     - name: ACR Login


### PR DESCRIPTION
The federation configuration moved dtsse-ccd-config-generator from ACR Publisher 3 to ACR Puller 1. GitHub Actions is currently failing Azure login because the workflow still uses the old client ID. This updates both ACR login jobs to use the new pull-only identity.
