### PR TITLE
Document unsupported decentralised search APIs

### DIFF
--- a/docs/decentralisation-for-existing-services.md
+++ b/docs/decentralisation-for-existing-services.md
@@ -50,13 +50,13 @@ CCD Data Store still exposes a legacy case-search path backed by the central Pos
 
 The following CCD endpoints cannot be used to search for cases owned by a decentralised service:
 
-| API surface | Method and path |
-| --- | --- |
-| Standard case API | `GET /caseworkers/{uid}/jurisdictions/{jid}/case-types/{ctid}/cases` |
-| Standard case API | `GET /citizens/{uid}/jurisdictions/{jid}/case-types/{ctid}/cases` |
-| Standard case API | `GET /caseworkers/{uid}/jurisdictions/{jid}/case-types/{ctid}/cases/pagination_metadata` |
-| Standard case API | `GET /citizens/{uid}/jurisdictions/{jid}/case-types/{ctid}/cases/pagination_metadata` |
-| Aggregated UI API | `GET /aggregated/caseworkers/{uid}/jurisdictions/{jid}/case-types/{ctid}/cases` |
+| Method and path |
+| --- |
+| [`GET /caseworkers/{uid}/jurisdictions/{jid}/case-types/{ctid}/cases`](https://github.com/hmcts/ccd-data-store-api/blob/master/src/main/java/uk/gov/hmcts/ccd/endpoint/std/CaseDetailsEndpoint.java#L431) |
+| [`GET /citizens/{uid}/jurisdictions/{jid}/case-types/{ctid}/cases`](https://github.com/hmcts/ccd-data-store-api/blob/master/src/main/java/uk/gov/hmcts/ccd/endpoint/std/CaseDetailsEndpoint.java#L451) |
+| [`GET /caseworkers/{uid}/jurisdictions/{jid}/case-types/{ctid}/cases/pagination_metadata`](https://github.com/hmcts/ccd-data-store-api/blob/master/src/main/java/uk/gov/hmcts/ccd/endpoint/std/CaseDetailsEndpoint.java#L475) |
+| [`GET /citizens/{uid}/jurisdictions/{jid}/case-types/{ctid}/cases/pagination_metadata`](https://github.com/hmcts/ccd-data-store-api/blob/master/src/main/java/uk/gov/hmcts/ccd/endpoint/std/CaseDetailsEndpoint.java#L487) |
+| [`GET /aggregated/caseworkers/{uid}/jurisdictions/{jid}/case-types/{ctid}/cases`](https://github.com/hmcts/ccd-data-store-api/blob/master/src/main/java/uk/gov/hmcts/ccd/endpoint/ui/QueryEndpoint.java#L156) |
 
 Decentralised services should either use CCD's elasticsearch endpoints or, for system access, query their database directly.
 

--- a/docs/decentralisation-for-existing-services.md
+++ b/docs/decentralisation-for-existing-services.md
@@ -44,6 +44,22 @@ AboutToSubmit and Submitted callbacks are consolidated into a single 'Submit' op
 Submit combines validation and persistence in a single step; services can validate the incoming event payload, rejecting it or accepting and persisting it.
 
 
+## Case search
+
+CCD Data Store still exposes a legacy case-search path backed by the central Postgres `case_data` table.
+
+The following CCD endpoints cannot be used to search for cases owned by a decentralised service:
+
+| API surface | Method and path |
+| --- | --- |
+| Standard case API | `GET /caseworkers/{uid}/jurisdictions/{jid}/case-types/{ctid}/cases` |
+| Standard case API | `GET /citizens/{uid}/jurisdictions/{jid}/case-types/{ctid}/cases` |
+| Standard case API | `GET /caseworkers/{uid}/jurisdictions/{jid}/case-types/{ctid}/cases/pagination_metadata` |
+| Standard case API | `GET /citizens/{uid}/jurisdictions/{jid}/case-types/{ctid}/cases/pagination_metadata` |
+| Aggregated UI API | `GET /aggregated/caseworkers/{uid}/jurisdictions/{jid}/case-types/{ctid}/cases` |
+
+Decentralised services should either use CCD's elasticsearch endpoints or, for system access, query their database directly.
+
 ## Callback emulation
 
 To keep existing applications working without large-scale changes, the SDK provides callback emulation.


### PR DESCRIPTION
CCD Data Store retains legacy case-search routes backed by the central Postgres case_data table. This documents the standard worker and citizen search routes, their pagination metadata routes, and the aggregated UI search route as unsupported for cases owned by a decentralised service.

The guidance points consumers to CCD's Elasticsearch search endpoints or the owning service's database for system access.