### PR TITLE
Scope circuit breaker thresholds by state

### DIFF
--- a/docs/retain-and-dispose.md
+++ b/docs/retain-and-dispose.md
@@ -99,6 +99,21 @@ The same check runs in `dry-run`, allowing policy changes to be tested before en
 
 To handle low population case types the circuit breaker only applies once `minimum-candidate-count` is reached: default 10
 
+Use `maximum-candidate-percentage-by-state` when all cases in a state are expected to be eligible while retaining the
+default safeguard for other states. For example, an explicit deletion state can allow all of its cases to proceed:
+
+```yaml
+ccd:
+  decentralised-runtime:
+    retain-and-dispose:
+      maximum-candidate-percentage: 5
+      maximum-candidate-percentage-by-state:
+        Delete: 100
+```
+
+State-specific values must be between 0 and 100. A state without an override uses `maximum-candidate-percentage`.
+If any case type and state exceeds its applicable percentage, the whole run is aborted before any cases are marked.
+
 ## Scheduling
 
 The consuming application must enable Spring scheduling. For example:

--- a/docs/retain-and-dispose.md
+++ b/docs/retain-and-dispose.md
@@ -106,7 +106,6 @@ default safeguard for other states. For example, an explicit deletion state can 
 ccd:
   decentralised-runtime:
     retain-and-dispose:
-      maximum-candidate-percentage: 5
       maximum-candidate-percentage-by-state:
         Delete: 100
 ```

--- a/docs/retain-and-dispose.md
+++ b/docs/retain-and-dispose.md
@@ -110,7 +110,8 @@ ccd:
         Delete: 100
 ```
 
-State-specific values must be between 0 and 100. A state without an override uses `maximum-candidate-percentage`.
+State IDs are matched case-insensitively and values must be between 0 and 100.
+A state without an override uses `maximum-candidate-percentage`.
 If any case type and state exceeds its applicable percentage, the whole run is aborted before any cases are marked.
 
 ## Scheduling

--- a/docs/retain-and-dispose.md
+++ b/docs/retain-and-dispose.md
@@ -112,7 +112,13 @@ ccd:
 
 State IDs are matched case-insensitively and values must be between 0 and 100.
 A state without an override uses `maximum-candidate-percentage`.
+An override applies to every case type returned by the policy whose state ID matches the configured key.
 If any case type and state exceeds its applicable percentage, the whole run is aborted before any cases are marked.
+
+Simple state IDs can also be configured using a standard Spring Boot environment variable. For example, the `Delete`
+override above is `CCD_DECENTRALISEDRUNTIME_RETAINANDDISPOSE_MAXIMUMCANDIDATEPERCENTAGEBYSTATE_DELETE=100`.
+For state IDs containing underscores or other property-name separators, use YAML or `SPRING_APPLICATION_JSON` so the
+state ID is preserved as a map key.
 
 ## Scheduling
 

--- a/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/retention/RetainAndDisposeProperties.java
+++ b/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/retention/RetainAndDisposeProperties.java
@@ -1,7 +1,7 @@
 package uk.gov.hmcts.ccd.sdk.retention;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.TreeMap;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -18,7 +18,8 @@ public class RetainAndDisposeProperties {
   private String cron = "0 0 2 * * *";
   private String zone = "UTC";
   private int maximumCandidatePercentage = 5;
-  private final Map<String, Integer> maximumCandidatePercentageByState = new HashMap<>();
+  private final Map<String, Integer> maximumCandidatePercentageByState =
+      new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
   private int minimumCandidateCount = 10;
   private final SystemUser systemUser = new SystemUser();
 
@@ -49,11 +50,7 @@ public class RetainAndDisposeProperties {
   }
 
   int maximumCandidatePercentageFor(String state) {
-    return maximumCandidatePercentageByState.entrySet().stream()
-        .filter(entry -> entry.getKey().equalsIgnoreCase(state))
-        .map(Map.Entry::getValue)
-        .findFirst()
-        .orElse(maximumCandidatePercentage);
+    return maximumCandidatePercentageByState.getOrDefault(state, maximumCandidatePercentage);
   }
 
   public enum Mode {

--- a/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/retention/RetainAndDisposeProperties.java
+++ b/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/retention/RetainAndDisposeProperties.java
@@ -49,7 +49,11 @@ public class RetainAndDisposeProperties {
   }
 
   int maximumCandidatePercentageFor(String state) {
-    return maximumCandidatePercentageByState.getOrDefault(state, maximumCandidatePercentage);
+    return maximumCandidatePercentageByState.entrySet().stream()
+        .filter(entry -> entry.getKey().equalsIgnoreCase(state))
+        .map(Map.Entry::getValue)
+        .findFirst()
+        .orElse(maximumCandidatePercentage);
   }
 
   public enum Mode {

--- a/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/retention/RetainAndDisposeProperties.java
+++ b/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/retention/RetainAndDisposeProperties.java
@@ -1,5 +1,7 @@
 package uk.gov.hmcts.ccd.sdk.retention;
 
+import java.util.HashMap;
+import java.util.Map;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -16,6 +18,7 @@ public class RetainAndDisposeProperties {
   private String cron = "0 0 2 * * *";
   private String zone = "UTC";
   private int maximumCandidatePercentage = 5;
+  private final Map<String, Integer> maximumCandidatePercentageByState = new HashMap<>();
   private int minimumCandidateCount = 10;
   private final SystemUser systemUser = new SystemUser();
 
@@ -28,9 +31,25 @@ public class RetainAndDisposeProperties {
     if (maximumCandidatePercentage < 0 || maximumCandidatePercentage > 100) {
       throw new IllegalStateException(PREFIX + ".maximum-candidate-percentage must be between 0 and 100");
     }
+    maximumCandidatePercentageByState.forEach((state, percentage) -> {
+      if (!StringUtils.hasText(state)) {
+        throw new IllegalStateException(
+            PREFIX + ".maximum-candidate-percentage-by-state must not contain a blank state"
+        );
+      }
+      if (percentage == null || percentage < 0 || percentage > 100) {
+        throw new IllegalStateException(
+            PREFIX + ".maximum-candidate-percentage-by-state[" + state + "] must be between 0 and 100"
+        );
+      }
+    });
     if (minimumCandidateCount < 1) {
       throw new IllegalStateException(PREFIX + ".minimum-candidate-count must be at least 1");
     }
+  }
+
+  int maximumCandidatePercentageFor(String state) {
+    return maximumCandidatePercentageByState.getOrDefault(state, maximumCandidatePercentage);
   }
 
   public enum Mode {

--- a/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/retention/RetainAndDisposeTask.java
+++ b/sdk/decentralised-runtime/src/main/java/uk/gov/hmcts/ccd/sdk/retention/RetainAndDisposeTask.java
@@ -81,24 +81,25 @@ final class RetainAndDisposeTask implements Runnable {
   }
 
   private void checkCandidatePercentage(List<RetainAndDisposeCase> candidates) {
-    if (properties.getMaximumCandidatePercentage() == 100) {
-      return;
-    }
     List<Long> candidateReferences = candidates.stream()
         .map(RetainAndDisposeCase::reference)
         .toList();
     for (RetainAndDisposeRepository.CandidatePopulation population
         : repository.findCandidatePopulations(candidateReferences)) {
+      int maximumCandidatePercentage = properties.maximumCandidatePercentageFor(population.state());
+      if (maximumCandidatePercentage == 100) {
+        continue;
+      }
       if (population.candidateCount() < properties.getMinimumCandidateCount()) {
         continue;
       }
       if (population.candidateCount() * 100
-          > population.totalCount() * properties.getMaximumCandidatePercentage()) {
+          > population.totalCount() * maximumCandidatePercentage) {
         log.error(
             "Retain and dispose candidate circuit breaker tripped caseTypeId={} state={} candidateCount={} "
                 + "totalCount={} maximumCandidatePercentage={}. Aborting before marking any cases",
             population.caseTypeId(), population.state(), population.candidateCount(), population.totalCount(),
-            properties.getMaximumCandidatePercentage()
+            maximumCandidatePercentage
         );
         throw new IllegalStateException(
             "Retain and dispose candidates exceed the configured maximum percentage for case type "

--- a/sdk/decentralised-runtime/src/test/java/uk/gov/hmcts/ccd/sdk/retention/RetainAndDisposePropertiesTest.java
+++ b/sdk/decentralised-runtime/src/test/java/uk/gov/hmcts/ccd/sdk/retention/RetainAndDisposePropertiesTest.java
@@ -7,7 +7,10 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.context.properties.bind.Bindable;
 import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.boot.context.properties.source.ConfigurationPropertySources;
 import org.springframework.boot.context.properties.source.MapConfigurationPropertySource;
+import org.springframework.core.env.StandardEnvironment;
+import org.springframework.core.env.SystemEnvironmentPropertySource;
 
 class RetainAndDisposePropertiesTest {
 
@@ -25,6 +28,22 @@ class RetainAndDisposePropertiesTest {
     assertThat(properties.maximumCandidatePercentageFor("delete")).isEqualTo(100);
     assertThat(properties.maximumCandidatePercentageFor("DELETE")).isEqualTo(100);
     assertThat(properties.maximumCandidatePercentageFor("Draft")).isEqualTo(5);
+  }
+
+  @Test
+  void bindsMaximumCandidatePercentageByStateFromEnvironmentVariable() {
+    var environment = new StandardEnvironment();
+    environment.getPropertySources().addFirst(new SystemEnvironmentPropertySource(
+        "test-systemEnvironment",
+        Map.of("CCD_DECENTRALISEDRUNTIME_RETAINANDDISPOSE_MAXIMUMCANDIDATEPERCENTAGEBYSTATE_DELETE", "100")
+    ));
+    ConfigurationPropertySources.attach(environment);
+
+    RetainAndDisposeProperties properties = Binder.get(environment)
+        .bind(RetainAndDisposeProperties.PREFIX, Bindable.of(RetainAndDisposeProperties.class))
+        .orElseThrow(() -> new AssertionError("Retain and dispose properties were not bound"));
+
+    assertThat(properties.maximumCandidatePercentageFor("Delete")).isEqualTo(100);
   }
 
   @Test

--- a/sdk/decentralised-runtime/src/test/java/uk/gov/hmcts/ccd/sdk/retention/RetainAndDisposePropertiesTest.java
+++ b/sdk/decentralised-runtime/src/test/java/uk/gov/hmcts/ccd/sdk/retention/RetainAndDisposePropertiesTest.java
@@ -22,6 +22,8 @@ class RetainAndDisposePropertiesTest {
         .orElseThrow(() -> new AssertionError("Retain and dispose properties were not bound"));
 
     assertThat(properties.maximumCandidatePercentageFor("Delete")).isEqualTo(100);
+    assertThat(properties.maximumCandidatePercentageFor("delete")).isEqualTo(100);
+    assertThat(properties.maximumCandidatePercentageFor("DELETE")).isEqualTo(100);
     assertThat(properties.maximumCandidatePercentageFor("Draft")).isEqualTo(5);
   }
 

--- a/sdk/decentralised-runtime/src/test/java/uk/gov/hmcts/ccd/sdk/retention/RetainAndDisposePropertiesTest.java
+++ b/sdk/decentralised-runtime/src/test/java/uk/gov/hmcts/ccd/sdk/retention/RetainAndDisposePropertiesTest.java
@@ -1,0 +1,54 @@
+package uk.gov.hmcts.ccd.sdk.retention;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.boot.context.properties.source.MapConfigurationPropertySource;
+
+class RetainAndDisposePropertiesTest {
+
+  @Test
+  void bindsMaximumCandidatePercentageByState() {
+    var source = new MapConfigurationPropertySource(Map.of(
+        RetainAndDisposeProperties.PREFIX + ".maximum-candidate-percentage-by-state.Delete", 100
+    ));
+
+    RetainAndDisposeProperties properties = new Binder(source)
+        .bind(RetainAndDisposeProperties.PREFIX, Bindable.of(RetainAndDisposeProperties.class))
+        .orElseThrow(() -> new AssertionError("Retain and dispose properties were not bound"));
+
+    assertThat(properties.maximumCandidatePercentageFor("Delete")).isEqualTo(100);
+    assertThat(properties.maximumCandidatePercentageFor("Draft")).isEqualTo(5);
+  }
+
+  @Test
+  void rejectsMaximumCandidatePercentageByStateOutsideValidRange() {
+    RetainAndDisposeProperties properties = validProperties();
+    properties.getMaximumCandidatePercentageByState().put("Delete", 101);
+
+    assertThatThrownBy(properties::validate)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("maximum-candidate-percentage-by-state[Delete] must be between 0 and 100");
+  }
+
+  @Test
+  void rejectsBlankStateOverride() {
+    RetainAndDisposeProperties properties = validProperties();
+    properties.getMaximumCandidatePercentageByState().put(" ", 100);
+
+    assertThatThrownBy(properties::validate)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("maximum-candidate-percentage-by-state must not contain a blank state");
+  }
+
+  private static RetainAndDisposeProperties validProperties() {
+    RetainAndDisposeProperties properties = new RetainAndDisposeProperties();
+    properties.getSystemUser().setUsername("system-user@example.com");
+    properties.getSystemUser().setPassword("password");
+    return properties;
+  }
+}

--- a/sdk/decentralised-runtime/src/test/java/uk/gov/hmcts/ccd/sdk/retention/RetainAndDisposeTaskIntegrationTest.java
+++ b/sdk/decentralised-runtime/src/test/java/uk/gov/hmcts/ccd/sdk/retention/RetainAndDisposeTaskIntegrationTest.java
@@ -140,7 +140,7 @@ class RetainAndDisposeTaskIntegrationTest {
 
   @Test
   void appliesMaximumCandidatePercentageOverrideForState() {
-    properties.getMaximumCandidatePercentageByState().put("Delete", 100);
+    properties.getMaximumCandidatePercentageByState().put("delete", 100);
     RetainAndDisposeCase deleteCandidate = insertPopulation("CaseTypeA", "Delete", 10, 10);
     RetainAndDisposeCase draftCandidate = insertPopulation("CaseTypeA", "Draft", 20, 1);
 

--- a/sdk/decentralised-runtime/src/test/java/uk/gov/hmcts/ccd/sdk/retention/RetainAndDisposeTaskIntegrationTest.java
+++ b/sdk/decentralised-runtime/src/test/java/uk/gov/hmcts/ccd/sdk/retention/RetainAndDisposeTaskIntegrationTest.java
@@ -62,6 +62,7 @@ class RetainAndDisposeTaskIntegrationTest {
     policy.clear();
     properties.setMode(RetainAndDisposeProperties.Mode.LIVE);
     properties.setMaximumCandidatePercentage(5);
+    properties.getMaximumCandidatePercentageByState().clear();
     properties.setMinimumCandidateCount(1);
     nextReference = 1_000_000_000_000_000L;
 
@@ -135,6 +136,36 @@ class RetainAndDisposeTaskIntegrationTest {
     task.run();
 
     verify(ccdClient).markForDisposal(candidate);
+  }
+
+  @Test
+  void appliesMaximumCandidatePercentageOverrideForState() {
+    properties.getMaximumCandidatePercentageByState().put("Delete", 100);
+    RetainAndDisposeCase deleteCandidate = insertPopulation("CaseTypeA", "Delete", 10, 10);
+    RetainAndDisposeCase draftCandidate = insertPopulation("CaseTypeA", "Draft", 20, 1);
+
+    task.run();
+
+    verify(ccdClient).markForDisposal(deleteCandidate);
+    verify(ccdClient).markForDisposal(draftCandidate);
+  }
+
+  @Test
+  void stateOverrideDoesNotPreventAnotherStateFromAbortingRun() {
+    properties.getMaximumCandidatePercentageByState().put("Delete", 100);
+    insertPopulation("CaseTypeA", "Delete", 10, 10);
+    insertPopulation("CaseTypeA", "Draft", 20, 2);
+
+    assertCircuitBreakerTrips();
+  }
+
+  @Test
+  void stateOverrideCanEnableCircuitBreakerWhenGlobalPercentageIsOneHundred() {
+    properties.setMaximumCandidatePercentage(100);
+    properties.getMaximumCandidatePercentageByState().put("Draft", 5);
+    insertPopulation("CaseTypeA", "Draft", 20, 2);
+
+    assertCircuitBreakerTrips();
   }
 
   private void assertCircuitBreakerTrips() {


### PR DESCRIPTION
### Change description ###

Certain states may expect 100% of cases to be armed for deletion - eg. ET have a Delete state of which 100% of cases would be expected to be deleted. This makes it possible to override the default 5% circuit breaker on a state by state basis.


