### PR TITLE
Update Elasticsearch client to fix CVEs

### DIFF
--- a/sdk/ccd-runtime-indexing/build.gradle
+++ b/sdk/ccd-runtime-indexing/build.gradle
@@ -29,12 +29,12 @@ dependencies {
 
     implementation('co.elastic.clients:elasticsearch-java') {
         version {
-            strictly '9.4.2'
+            strictly '9.4.4'
         }
     }
     implementation('co.elastic.clients:elasticsearch-rest5-client') {
         version {
-            strictly '9.4.2'
+            strictly '9.4.4'
         }
     }
 


### PR DESCRIPTION
CVE-2026-63144, CVE-2026-63263

### Change description ###



