### PR TITLE
Allow Elasticsearch client 9.x upgrades

### DIFF
--- a/sdk/ccd-gradle-plugin/src/main/groovy/uk/gov/hmcts/ccd/sdk/CcdSdkPlugin.java
+++ b/sdk/ccd-gradle-plugin/src/main/groovy/uk/gov/hmcts/ccd/sdk/CcdSdkPlugin.java
@@ -88,14 +88,6 @@ public class CcdSdkPlugin implements Plugin<Project> {
           project.getPluginManager().withPlugin("com.github.hmcts.rse-cft-lib", plugin ->
               project.getDependencies().add("cftlibImplementation", dependencyNotation));
         }
-        project.getConfigurations().configureEach(configuration ->
-            configuration.getResolutionStrategy().eachDependency(details -> {
-              if ("co.elastic.clients".equals(details.getRequested().getGroup())
-                  && ("elasticsearch-java".equals(details.getRequested().getName())
-                  || "elasticsearch-rest5-client".equals(details.getRequested().getName()))) {
-                details.useVersion("9.4.2");
-              }
-            }));
         // Surface that we are decentralised to the spring boot apps.
         // This is an env var since it needs to be read beyond the application's classpath
         // to shut off the default cftlib elasticsearch indexer when decentralised)

--- a/sdk/ccd-gradle-plugin/src/main/groovy/uk/gov/hmcts/ccd/sdk/CcdSdkPlugin.java
+++ b/sdk/ccd-gradle-plugin/src/main/groovy/uk/gov/hmcts/ccd/sdk/CcdSdkPlugin.java
@@ -17,6 +17,8 @@ import org.gradle.api.tasks.SourceSetContainer;
 
 public class CcdSdkPlugin implements Plugin<Project> {
 
+  private static final String DEFAULT_ELASTICSEARCH_CLIENT_VERSION = "9.4.5";
+
   public void apply(Project project) {
     project.getPlugins().apply(JavaPlugin.class);
 
@@ -84,9 +86,13 @@ public class CcdSdkPlugin implements Plugin<Project> {
         String dependencyNotation = "com.github.hmcts:ccd-runtime-indexing:" + version;
         if (config.runtimeIndexing) {
           project.getDependencies().add("implementation", dependencyNotation);
+          addElasticsearchClientDependencies(project, "implementation", config.elasticsearchClientVersion);
         } else {
-          project.getPluginManager().withPlugin("com.github.hmcts.rse-cft-lib", plugin ->
-              project.getDependencies().add("cftlibImplementation", dependencyNotation));
+          project.getPluginManager().withPlugin("com.github.hmcts.rse-cft-lib", plugin -> {
+            project.getDependencies().add("cftlibImplementation", dependencyNotation);
+            addElasticsearchClientDependencies(project, "cftlibImplementation",
+                config.elasticsearchClientVersion);
+          });
         }
         // Surface that we are decentralised to the spring boot apps.
         // This is an env var since it needs to be read beyond the application's classpath
@@ -110,6 +116,15 @@ public class CcdSdkPlugin implements Plugin<Project> {
     return implementationVersion != null ? implementationVersion : "DEV-SNAPSHOT";
   }
 
+  private void addElasticsearchClientDependencies(Project project, String configuration, String version) {
+    if (version == null || !version.matches("9\\..+")) {
+      throw new IllegalArgumentException("ccd.elasticsearchClientVersion must be a 9.x version");
+    }
+    // Explicit dependencies override versions managed by the Spring dependency-management plugin.
+    project.getDependencies().add(configuration, "co.elastic.clients:elasticsearch-java:" + version);
+    project.getDependencies().add(configuration, "co.elastic.clients:elasticsearch-rest5-client:" + version);
+  }
+
   @Data
   static class CCDConfig {
 
@@ -119,6 +134,7 @@ public class CcdSdkPlugin implements Plugin<Project> {
     private boolean decentralised = false;
     private boolean caseEventServiceBus = false;
     private boolean runtimeIndexing = false;
+    private String elasticsearchClientVersion = DEFAULT_ELASTICSEARCH_CLIENT_VERSION;
 
     public CCDConfig() {
     }

--- a/sdk/ccd-gradle-plugin/src/main/groovy/uk/gov/hmcts/ccd/sdk/CcdSdkPlugin.java
+++ b/sdk/ccd-gradle-plugin/src/main/groovy/uk/gov/hmcts/ccd/sdk/CcdSdkPlugin.java
@@ -18,9 +18,6 @@ import org.gradle.api.tasks.SourceSetContainer;
 
 public class CcdSdkPlugin implements Plugin<Project> {
 
-  private static final String ELASTICSEARCH_CLIENT_VERSION_RANGE = "[9, 10)";
-  private static final String PREFERRED_ELASTICSEARCH_CLIENT_VERSION = "9.4.5";
-
   public void apply(Project project) {
     project.getPlugins().apply(JavaPlugin.class);
 
@@ -119,8 +116,8 @@ public class CcdSdkPlugin implements Plugin<Project> {
     ExternalModuleDependency dependency = (ExternalModuleDependency) project.getDependencies()
         .create("co.elastic.clients:elasticsearch-java");
     dependency.version(version -> {
-      version.strictly(ELASTICSEARCH_CLIENT_VERSION_RANGE);
-      version.prefer(PREFERRED_ELASTICSEARCH_CLIENT_VERSION);
+      version.strictly("[9, 10)");
+      version.prefer("9.4.5");
     });
     project.getDependencies().add("implementation", dependency);
   }

--- a/sdk/ccd-gradle-plugin/src/main/groovy/uk/gov/hmcts/ccd/sdk/CcdSdkPlugin.java
+++ b/sdk/ccd-gradle-plugin/src/main/groovy/uk/gov/hmcts/ccd/sdk/CcdSdkPlugin.java
@@ -7,6 +7,7 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.ExternalModuleDependency;
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository;
 import org.gradle.api.artifacts.repositories.MavenRepositoryContentDescriptor;
 import org.gradle.api.file.DirectoryProperty;
@@ -17,7 +18,8 @@ import org.gradle.api.tasks.SourceSetContainer;
 
 public class CcdSdkPlugin implements Plugin<Project> {
 
-  private static final String DEFAULT_ELASTICSEARCH_CLIENT_VERSION = "9.4.5";
+  private static final String ELASTICSEARCH_CLIENT_VERSION_RANGE = "[9, 10)";
+  private static final String PREFERRED_ELASTICSEARCH_CLIENT_VERSION = "9.4.5";
 
   public void apply(Project project) {
     project.getPlugins().apply(JavaPlugin.class);
@@ -84,15 +86,12 @@ public class CcdSdkPlugin implements Plugin<Project> {
         project.getDependencies().add("implementation", "com.github.hmcts:decentralised-runtime:"
             + version);
         String dependencyNotation = "com.github.hmcts:ccd-runtime-indexing:" + version;
+        addElasticsearchClientDependency(project);
         if (config.runtimeIndexing) {
           project.getDependencies().add("implementation", dependencyNotation);
-          addElasticsearchClientDependencies(project, "implementation", config.elasticsearchClientVersion);
         } else {
-          project.getPluginManager().withPlugin("com.github.hmcts.rse-cft-lib", plugin -> {
-            project.getDependencies().add("cftlibImplementation", dependencyNotation);
-            addElasticsearchClientDependencies(project, "cftlibImplementation",
-                config.elasticsearchClientVersion);
-          });
+          project.getPluginManager().withPlugin("com.github.hmcts.rse-cft-lib", plugin ->
+              project.getDependencies().add("cftlibImplementation", dependencyNotation));
         }
         // Surface that we are decentralised to the spring boot apps.
         // This is an env var since it needs to be read beyond the application's classpath
@@ -116,13 +115,14 @@ public class CcdSdkPlugin implements Plugin<Project> {
     return implementationVersion != null ? implementationVersion : "DEV-SNAPSHOT";
   }
 
-  private void addElasticsearchClientDependencies(Project project, String configuration, String version) {
-    if (version == null || !version.matches("9\\..+")) {
-      throw new IllegalArgumentException("ccd.elasticsearchClientVersion must be a 9.x version");
-    }
-    // Explicit dependencies override versions managed by the Spring dependency-management plugin.
-    project.getDependencies().add(configuration, "co.elastic.clients:elasticsearch-java:" + version);
-    project.getDependencies().add(configuration, "co.elastic.clients:elasticsearch-rest5-client:" + version);
+  private void addElasticsearchClientDependency(Project project) {
+    ExternalModuleDependency dependency = (ExternalModuleDependency) project.getDependencies()
+        .create("co.elastic.clients:elasticsearch-java");
+    dependency.version(version -> {
+      version.strictly(ELASTICSEARCH_CLIENT_VERSION_RANGE);
+      version.prefer(PREFERRED_ELASTICSEARCH_CLIENT_VERSION);
+    });
+    project.getDependencies().add("implementation", dependency);
   }
 
   @Data
@@ -134,7 +134,6 @@ public class CcdSdkPlugin implements Plugin<Project> {
     private boolean decentralised = false;
     private boolean caseEventServiceBus = false;
     private boolean runtimeIndexing = false;
-    private String elasticsearchClientVersion = DEFAULT_ELASTICSEARCH_CLIENT_VERSION;
 
     public CCDConfig() {
     }

--- a/sdk/ccd-gradle-plugin/src/main/groovy/uk/gov/hmcts/ccd/sdk/CcdSdkPlugin.java
+++ b/sdk/ccd-gradle-plugin/src/main/groovy/uk/gov/hmcts/ccd/sdk/CcdSdkPlugin.java
@@ -115,10 +115,7 @@ public class CcdSdkPlugin implements Plugin<Project> {
   private void addElasticsearchClientDependency(Project project) {
     ExternalModuleDependency dependency = (ExternalModuleDependency) project.getDependencies()
         .create("co.elastic.clients:elasticsearch-java");
-    dependency.version(version -> {
-      version.strictly("[9, 10)");
-      version.prefer("9.4.5");
-    });
+    dependency.version(version -> version.strictly("[9, 10)"));
     project.getDependencies().add("implementation", dependency);
   }
 

--- a/sdk/ccd-runtime-indexing/build.gradle
+++ b/sdk/ccd-runtime-indexing/build.gradle
@@ -35,13 +35,6 @@ dependencies {
             prefer elasticsearchClientVersion
         }
     }
-    implementation('co.elastic.clients:elasticsearch-rest5-client') {
-        version {
-            strictly '[9, 10)'
-            prefer elasticsearchClientVersion
-        }
-    }
-
     implementation 'com.fasterxml.jackson.core:jackson-databind'
 
     compileOnly 'org.projectlombok:lombok:1.18.46'

--- a/sdk/ccd-runtime-indexing/build.gradle
+++ b/sdk/ccd-runtime-indexing/build.gradle
@@ -9,6 +9,8 @@ repositories {
     mavenCentral()
 }
 
+def elasticsearchClientVersion = '9.4.5'
+
 sourceSets {
     chaosTest {
         java.srcDir file('src/chaosTest/java')
@@ -29,12 +31,14 @@ dependencies {
 
     implementation('co.elastic.clients:elasticsearch-java') {
         version {
-            strictly '9.4.2'
+            strictly '[9, 10)'
+            prefer elasticsearchClientVersion
         }
     }
     implementation('co.elastic.clients:elasticsearch-rest5-client') {
         version {
-            strictly '9.4.2'
+            strictly '[9, 10)'
+            prefer elasticsearchClientVersion
         }
     }
 

--- a/sdk/ccd-runtime-indexing/src/chaosTest/java/uk/gov/hmcts/ccd/sdk/DecentralisedESIndexerChaosTest.java
+++ b/sdk/ccd-runtime-indexing/src/chaosTest/java/uk/gov/hmcts/ccd/sdk/DecentralisedESIndexerChaosTest.java
@@ -64,7 +64,7 @@ class DecentralisedESIndexerChaosTest {
 
   @Container
   private static final ElasticsearchContainer ELASTICSEARCH = new ElasticsearchContainer(
-      DockerImageName.parse("docker.elastic.co/elasticsearch/elasticsearch:9.4.5"))
+      DockerImageName.parse("docker.elastic.co/elasticsearch/elasticsearch:9.4.2"))
       .withNetwork(NETWORK)
       .withNetworkAliases("elasticsearch")
       .withEnv("xpack.security.enabled", "false");

--- a/sdk/ccd-runtime-indexing/src/chaosTest/java/uk/gov/hmcts/ccd/sdk/DecentralisedESIndexerChaosTest.java
+++ b/sdk/ccd-runtime-indexing/src/chaosTest/java/uk/gov/hmcts/ccd/sdk/DecentralisedESIndexerChaosTest.java
@@ -64,7 +64,7 @@ class DecentralisedESIndexerChaosTest {
 
   @Container
   private static final ElasticsearchContainer ELASTICSEARCH = new ElasticsearchContainer(
-      DockerImageName.parse("docker.elastic.co/elasticsearch/elasticsearch:9.4.2"))
+      DockerImageName.parse("docker.elastic.co/elasticsearch/elasticsearch:9.4.5"))
       .withNetwork(NETWORK)
       .withNetworkAliases("elasticsearch")
       .withEnv("xpack.security.enabled", "false");


### PR DESCRIPTION
The runtime indexing SDK requires Elasticsearch Java client 9.x, but Spring Boot 3 dependency management selects an incompatible 8.x release in consuming applications.

This declares `elasticsearch-java` with a strict `[9, 10)` range and a preferred version of 9.4.5 and the gradle plugin redeclares it on the consuming app's implementation configuration to ensure it overrides the spring boot bom

Consumers can select another compatible 9.x point release using normal Gradle dependency constraints.